### PR TITLE
Enforce SMC/ICT-first narrative: prompt, validation and facts payload

### DIFF
--- a/app/services/idea_narrative_llm.py
+++ b/app/services/idea_narrative_llm.py
@@ -25,6 +25,15 @@ REQUIRED_FIELDS = (
     "short_text",
     "full_text",
 )
+SMC_REQUIRED_TOKENS = ("ликвидност", "sweep", "bos", "choch", "order block", "fvg")
+BANNED_PHRASES = (
+    "строится вокруг",
+    "в рамках",
+    "может привести",
+    "по текущей структуре",
+    "сценарий описан прямо",
+)
+WEAK_CAUSE_PHRASES = ("после коррекции",)
 
 
 @dataclass
@@ -133,17 +142,35 @@ class IdeaNarrativeLLMService:
             if not isinstance(value, str) or not value.strip():
                 return None
             result[field] = value.strip()
+        joined = " ".join(result.values()).casefold()
+        if any(phrase in joined for phrase in BANNED_PHRASES):
+            return None
+        if any(phrase in joined for phrase in WEAK_CAUSE_PHRASES):
+            return None
+        if not any(token in result["full_text"].casefold() for token in SMC_REQUIRED_TOKENS):
+            return None
         return result
 
     @staticmethod
     def _build_prompt(payload: dict[str, Any], *, strict: bool) -> str:
-        banned = ["строится вокруг", "в рамках сценария", "может привести"]
+        banned = list(BANNED_PHRASES)
         strict_line = "Ошибочный формат недопустим." if strict else "Формат обязателен."
         return (
             "Сформируй объяснение торговой идеи только из переданных фактов.\n"
             "Запрещено придумывать новые уровни, направление, статус или причины вне фактов.\n"
+            "Ты пишешь как SMC/ICT-трейдер: жёсткая причинно-следственная логика без общих формулировок.\n"
             f"Запрещённые фразы: {', '.join(banned)}.\n"
-            "Стиль: профессиональный трейдер, кратко, причинно-следственно, конкретно.\n"
+            "Если в фактах нет liquidity_sweep / structure_state / key_zone / location — явно напиши: "
+            "\"структурных подтверждений недостаточно\".\n"
+            "Если SMC-факты неполные, добавь: \"структурная база слабая, идея основана на вторичных факторах\".\n"
+            "Нельзя использовать формулировку \"после коррекции\"; используй только: "
+            "\"после снятия ликвидности\", \"после ложного пробоя\", \"после возврата в order block\".\n"
+            "full_text обязан идти в порядке: "
+            "[1] liquidity event, [2] structure state, [3] premium/discount location, [4] confirmation, "
+            "[5] trade logic entry/SL/TP, [6] risk/invalidation.\n"
+            "Обязательно объясни уровни: почему вход в зоне OB/FVG/ликвидности, почему SL за снятой ликвидностью "
+            "или по инвалидации структуры, почему TP на следующем пуле ликвидности/заполнении имбаланса.\n"
+            "В full_text обязательно должен встретиться минимум один термин: liquidity/ликвидность/sweep/BOS/CHoCH/order block/FVG.\n"
             "Верни только JSON с ключами: "
             + ", ".join(REQUIRED_FIELDS)
             + f". {strict_line}\n\n"
@@ -162,18 +189,31 @@ class IdeaNarrativeLLMService:
         rr = facts.get("rr")
         delta_text = json.dumps(delta or {}, ensure_ascii=False)
         short = f"{symbol} {timeframe}: {direction}, статус {status}."
+        liquidity = str(facts.get("liquidity_sweep") or "none")
+        structure = str(facts.get("structure_state") or "unknown")
+        key_zone = str(facts.get("key_zone") or "none")
+        location = str(facts.get("location") or "unknown")
+        target_liquidity = str(facts.get("target_liquidity") or tp or "не определён")
+        invalidation_logic = str(facts.get("invalidation_logic") or f"пробой уровня SL {sl}")
+        smc_missing = any(value in {"none", "unknown", ""} for value in (liquidity, structure, key_zone, location))
+        structural_warning = "структурных подтверждений недостаточно. " if smc_missing else ""
+        weak_structure_warning = "структурная база слабая, идея основана на вторичных факторах. " if smc_missing else ""
         full = (
-            f"{symbol} {timeframe}: направление {direction}, статус {status}, entry {entry}, SL {sl}, TP {tp}, RR {rr}. "
+            f"{symbol} {timeframe}: после снятия ликвидности ({liquidity}) цена показала {structure}. "
+            f"Локация {location}, рабочая зона {key_zone}. "
+            f"Подтверждение ищем по объёму и delta без конфликта со структурой. "
+            f"Вход у {entry} от {key_zone}; SL {sl} — {invalidation_logic}; TP {tp} — следующий пул ликвидности {target_liquidity}. "
+            f"{structural_warning}{weak_structure_warning}"
             f"Событие: {event_type}. Изменения: {delta_text}."
         )
         return {
             "headline": f"{symbol} {timeframe} — {direction}",
             "summary": short,
-            "cause": "Сценарий основан на подтверждённых фактах анализа без добавления новых уровней.",
+            "cause": "После снятия ликвидности и реакции в ключевой SMC-зоне сценарий строится только по подтверждённым фактам.",
             "confirmation": "Подтверждение фиксируется только при совпадении структуры, объёма и дельты с расчётным сценарием.",
             "risk": "Риск контролируется заранее рассчитанным стоп-уровнем.",
-            "invalidation": f"Инвалидация: статус меняется при нарушении уровня SL {sl}.",
-            "target_logic": f"Цель берётся из расчётного TP {tp}, без изменения со стороны текста.",
+            "invalidation": f"Инвалидация: {invalidation_logic}.",
+            "target_logic": f"Цель берётся из расчётного TP {tp} как следующий пул ликвидности ({target_liquidity}).",
             "update_explanation": f"Обновление ({event_type}) сформировано по новым фактам: {delta_text}.",
             "short_text": short,
             "full_text": full,

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -1064,6 +1064,59 @@ class TradeIdeaService:
         existing: dict[str, Any] | None,
     ) -> dict[str, Any]:
         market_context = signal.get("market_context") if isinstance(signal.get("market_context"), dict) else {}
+        liquidity_sweep_raw = signal.get("liquidity_sweep")
+        liquidity_sweep: str
+        if isinstance(liquidity_sweep_raw, str) and liquidity_sweep_raw.strip():
+            normalized = liquidity_sweep_raw.strip().casefold()
+            if "buy" in normalized:
+                liquidity_sweep = "buy_side"
+            elif "sell" in normalized:
+                liquidity_sweep = "sell_side"
+            elif normalized in {"none", "false", "0"}:
+                liquidity_sweep = "none"
+            else:
+                liquidity_sweep = "buy_side" if direction == "bearish" else "sell_side" if direction == "bullish" else "none"
+        elif bool(liquidity_sweep_raw):
+            liquidity_sweep = "buy_side" if direction == "bearish" else "sell_side" if direction == "bullish" else "none"
+        else:
+            liquidity_sweep = "none"
+
+        structure_raw = str(signal.get("structure_state") or "").strip().casefold()
+        if "choch" in structure_raw:
+            structure_state = "CHoCH"
+        elif "bos" in structure_raw:
+            structure_state = "BOS"
+        elif structure_raw in {"continuation", "trend", "analyzable"}:
+            structure_state = "continuation"
+        else:
+            structure_state = "continuation" if direction in {"bullish", "bearish"} else "CHoCH"
+
+        zone_source = " ".join(
+            str(part or "")
+            for part in (
+                signal.get("smc_ru"),
+                signal.get("ict_ru"),
+                signal.get("pattern_ru"),
+                market_context.get("summaryRu"),
+                market_context.get("patternSummaryRu"),
+            )
+        ).casefold()
+        if any(token in zone_source for token in ("order block", "ob", "supply", "demand")):
+            key_zone = "OB"
+        elif any(token in zone_source for token in ("fvg", "imbalance", "fair value gap", "имбаланс")):
+            key_zone = "FVG"
+        else:
+            key_zone = "none"
+
+        location = "discount" if direction == "bullish" else "premium" if direction == "bearish" else "premium"
+        target_liquidity = cls._format_price(cls._extract_numeric(signal.get("take_profit")))
+        if target_liquidity == "—":
+            target_liquidity = "next_liquidity_pool"
+        invalidation_logic = str(
+            signal.get("invalidation_reasoning")
+            or signal.get("invalidation_ru")
+            or "инвалидация при сломе структуры и возврате за зону снятой ликвидности"
+        )
         return {
             "symbol": symbol,
             "timeframe": timeframe,
@@ -1086,6 +1139,12 @@ class TradeIdeaService:
             "cumulative_delta_facts": signal.get("cumdelta_ru") or signal.get("cumulative_delta_ru"),
             "divergence_facts": signal.get("divergence_ru"),
             "fundamental_facts": signal.get("fundamental_ru"),
+            "liquidity_sweep": liquidity_sweep,
+            "structure_state": structure_state,
+            "key_zone": key_zone,
+            "location": location,
+            "target_liquidity": target_liquidity,
+            "invalidation_logic": invalidation_logic,
             "existing_idea_id": existing.get("idea_id") if existing else None,
         }
 

--- a/tests/narrative/test_idea_narrative_llm.py
+++ b/tests/narrative/test_idea_narrative_llm.py
@@ -18,9 +18,9 @@ class _Resp:
 
 def _ok_content() -> str:
     return (
-        '{"headline":"EURUSD H1 long","summary":"Кратко","cause":"Причина","confirmation":"Подтверждение",'
+        '{"headline":"EURUSD H1 long","summary":"Кратко","cause":"После снятия ликвидности причина ясна","confirmation":"Подтверждение",'
         '"risk":"Риск","invalidation":"Инвалидация","target_logic":"Логика цели",'
-        '"update_explanation":"Что изменилось","short_text":"Коротко","full_text":"Полный текст"}'
+        '"update_explanation":"Что изменилось","short_text":"Коротко","full_text":"После sweep ликвидности сформирован BOS и вход от order block."}'
     )
 
 
@@ -70,3 +70,26 @@ def test_fallback_after_invalid_retry(monkeypatch) -> None:
 
     assert result.source == "fallback"
     assert "EURUSD" in result.data["full_text"]
+
+
+def test_rejects_banned_phrase_and_retries(monkeypatch) -> None:
+    service = IdeaNarrativeLLMService()
+    service.api_key = "test"
+    calls = {"n": 0}
+
+    invalid = (
+        '{"headline":"EURUSD H1 long","summary":"Кратко","cause":"Причина","confirmation":"Подтверждение",'
+        '"risk":"Риск","invalidation":"Инвалидация","target_logic":"Логика цели",'
+        '"update_explanation":"Что изменилось","short_text":"Коротко","full_text":"Сценарий строится вокруг зоны входа."}'
+    )
+
+    def _post(*args, **kwargs):
+        calls["n"] += 1
+        content = invalid if calls["n"] == 1 else _ok_content()
+        return _Resp({"choices": [{"message": {"content": content}}]})
+
+    monkeypatch.setattr("requests.post", _post)
+    result = service.generate(event_type="idea_updated", facts={"symbol": "EURUSD"})
+
+    assert calls["n"] == 2
+    assert result.source == "llm"

--- a/tests/test_idea_update.py
+++ b/tests/test_idea_update.py
@@ -157,3 +157,31 @@ def test_archive_explanation_generation_on_tp_sl(tmp_path: Path) -> None:
     sl = service.upsert_trade_idea({**base, "latest_close": 1.256})
     assert sl["final_status"] == "sl_hit"
     assert "sl_hit" in (sl.get("close_explanation") or "")
+
+
+def test_build_narrative_facts_contains_smc_contract() -> None:
+    facts = TradeIdeaService._build_narrative_facts(
+        signal={
+            "entry": 1.1,
+            "stop_loss": 1.09,
+            "take_profit": 1.12,
+            "smc_ru": "Цена вернулась в order block после sweep sell-side ликвидности.",
+            "structure_state": "bos",
+            "liquidity_sweep": True,
+            "invalidation_reasoning": "Пробой локального HL отменяет BOS.",
+            "market_context": {"summaryRu": "Discount внутри dealing range."},
+        },
+        symbol="EURUSD",
+        timeframe="M15",
+        direction="bullish",
+        status="active",
+        rationale="SMC",
+        existing=None,
+    )
+
+    assert facts["liquidity_sweep"] == "sell_side"
+    assert facts["structure_state"] == "BOS"
+    assert facts["key_zone"] == "OB"
+    assert facts["location"] == "discount"
+    assert facts["target_liquidity"] == "1.12"
+    assert "HL" in facts["invalidation_logic"]


### PR DESCRIPTION
### Motivation
- Ужесточить генерацию narrative так, чтобы формат и язык всегда были SMC/ICT-first с явной причинно‑следственной логикой и без общих фраз.
- Избежать ситуаций, когда LLM возвращает расплывчатые формулировки или выдуманные уровни, и дать детерминированный fallback при нехватке SMC‑данных.
- Обеспечить стабильный, детерминированный контракт между сервисом и LLM (поля payload и порядок секций в `full_text`).

### Description
- Добавлена валидация LLM‑ответа с жёсткими запретами на набор фраз (`BANNED_PHRASES`) и запретом слабых причин (`после коррекции`), а также требование наличия SMC‑терминов в `full_text`; при нарушении формат отклоняется и делается retry. Это реализовано в `app/services/idea_narrative_llm.py`.
- Промпт LLM переписан на SMC/ICT‑порядок и усилия по формированию: требование начинать narrative с liquidity event → structure state → location → confirmation → trade logic → risk/invalidation и явные инструкции для случаев неполных SMC‑фактов (включая строки «структурных подтверждений недостаточно» и «структурная база слабая...»).
- Расширен и нормализован payload facts в `_build_narrative_facts` в `app/services/trade_idea_service.py` — теперь включает детерминированные поля `liquidity_sweep` (`buy_side`/`sell_side`/`none`), `structure_state` (`BOS`/`CHoCH`/`continuation`), `key_zone` (`OB`/`FVG`/`none`), `location` (`premium`/`discount`), `target_liquidity` и `invalidation_logic`.
- Обновлён fallback для LLM в `idea_narrative_llm.py` чтобы детерминированно возвращать SMC‑ориентированный текст и явно помечать слабую структуру; добавлены тесты, которые проверяют retry при banned phrasing и корректную нормализацию SMC‑полей (`tests/narrative/test_idea_narrative_llm.py`, `tests/test_idea_update.py`).

### Testing
- Запущены модульные тесты `pytest -q tests/narrative/test_idea_narrative_llm.py tests/test_idea_update.py`, все тесты прошли успешно (`9 passed`).
- Добавлены и прогнаны новые тесты: проверка retry на запрещённую фразу и проверка нормализации/заполнения SMC‑полей в `_build_narrative_facts`, оба утверждения подтверждены в тестах.
- Локальная предсборка и быстрая проверка формата JSON ответов выполнены через существующие unit tests и показали ожидаемое поведение системы.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58ed7a5a8833198f435ba23fd8544)