### PR TITLE
Server-side chart snapshots for trade ideas (matplotlib PNG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## Что обновлено в версии 3.8
 - Добавлен единый `CanonicalMarketService` и интерфейс `RealMarketDataProvider` для всех рыночных endpoint: `GET /price/{symbol}`, `GET /market`, `GET /chart/{symbol}/{tf}`, а также `GET /api/price/{symbol}`, `GET /api/market`, `GET /api/canonical/chart/{symbol}/{tf}`.
+- Trade idea графики переведены на server-side snapshot pipeline: при создании идеи backend получает реальные OHLC candles, строит PNG через `matplotlib`, сохраняет файл в `/static/charts/{symbol}_{timeframe}_{timestamp}.png` и возвращает путь как `chartImageUrl` (повторная генерация в modal больше не выполняется).
 - Основной live-провайдер теперь `TwelveDataProvider`; `YahooProvider` сохранён только как optional historical fallback для свечей (статус `delayed`) и больше не используется как live пользовательская цена.
 - Введён строгий контракт market-data ответа: `data_status` (`real | unavailable | delayed`), `source`, `source_symbol`, `last_updated_utc`, `is_live_market_data`.
 - Удалены тихие synthetic fallback цены для production-endpoint; при ошибках источника API возвращает `unavailable` и frontend показывает warning по live-ценам.

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -54,6 +54,7 @@ class ChartDataService:
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
                 message_ru="Неподдерживаемый таймфрейм для свечного графика.",
+                reason="fetch_error",
             )
 
         if not self.api_key:
@@ -62,6 +63,7 @@ class ChartDataService:
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
                 message_ru="Свечной API не настроен: отсутствует TWELVEDATA_API_KEY.",
+                reason="fetch_error",
             )
 
         params = {
@@ -82,6 +84,7 @@ class ChartDataService:
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
                 message_ru="Не удалось загрузить реальные свечные данные из Twelve Data.",
+                reason="fetch_error",
             )
         except ValueError:
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=invalid_json", normalized_symbol, normalized_tf)
@@ -89,6 +92,7 @@ class ChartDataService:
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
                 message_ru="Свечной API вернул некорректный ответ.",
+                reason="fetch_error",
             )
 
         if payload.get("status") == "error":
@@ -99,10 +103,12 @@ class ChartDataService:
                 payload.get("code"),
                 payload.get("message"),
             )
+            reason = "rate_limited" if str(payload.get("code")) == "429" else "fetch_error"
             return self.build_unavailable_payload(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
                 message_ru=f"Twelve Data недоступен: {payload.get('message') or 'неизвестная ошибка'}.",
+                reason=reason,
             )
 
         candles = self._normalize_candles(payload.get("values"))
@@ -112,6 +118,7 @@ class ChartDataService:
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
                 message_ru="Свечной API не вернул candles для выбранной идеи.",
+                reason="no_data",
             )
 
         logger.info("twelvedata_success symbol=%s tf=%s candles=%s", normalized_symbol, normalized_tf, len(candles))
@@ -197,7 +204,7 @@ class ChartDataService:
             return None
 
     @classmethod
-    def build_unavailable_payload(cls, *, symbol: str, timeframe: str, message_ru: str) -> dict[str, Any]:
+    def build_unavailable_payload(cls, *, symbol: str, timeframe: str, message_ru: str, reason: str) -> dict[str, Any]:
         return {
             "symbol": symbol,
             "timeframe": timeframe,
@@ -209,5 +216,6 @@ class ChartDataService:
                 "provider": "Twelve Data",
                 "interval": TIMEFRAME_MAPPING.get(timeframe),
                 "outputsize": 0,
+                "reason": reason,
             },
         }

--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+
+
+logger = logging.getLogger(__name__)
+
+
+class ChartSnapshotService:
+    def __init__(self, charts_dir: str = "app/static/charts") -> None:
+        self.charts_dir = Path(charts_dir)
+        self.charts_dir.mkdir(parents=True, exist_ok=True)
+
+    def build_snapshot(
+        self,
+        *,
+        symbol: str,
+        timeframe: str,
+        candles: list[dict[str, Any]],
+        levels: list[dict[str, Any]],
+        zones: list[dict[str, Any]],
+        entry: float | None,
+        stop_loss: float | None,
+        take_profit: float | None,
+    ) -> str | None:
+        if not candles:
+            return None
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        filename = f"{symbol}_{timeframe}_{timestamp}.png"
+        absolute_path = self.charts_dir / filename
+        relative_path = f"/static/charts/{filename}"
+
+        fig, ax = plt.subplots(figsize=(12, 6), dpi=120)
+        try:
+            x_values = list(range(len(candles)))
+            highs = [float(candle["high"]) for candle in candles]
+            lows = [float(candle["low"]) for candle in candles]
+            closes = [float(candle["close"]) for candle in candles]
+            opens = [float(candle["open"]) for candle in candles]
+
+            min_price = min(lows)
+            max_price = max(highs)
+            price_padding = (max_price - min_price) * 0.1 if max_price > min_price else max_price * 0.001
+
+            ax.set_facecolor("#0b1220")
+            fig.patch.set_facecolor("#0b1220")
+            ax.grid(True, color="#1f2937", linewidth=0.6, alpha=0.7)
+
+            candle_width = 0.6
+            for idx, (open_price, high_price, low_price, close_price) in enumerate(zip(opens, highs, lows, closes)):
+                color = "#22c55e" if close_price >= open_price else "#ef4444"
+                ax.vlines(idx, low_price, high_price, color="#cbd5e1", linewidth=0.8, alpha=0.9)
+                body_bottom = min(open_price, close_price)
+                body_height = max(0.000001, abs(close_price - open_price))
+                ax.add_patch(
+                    Rectangle(
+                        (idx - candle_width / 2, body_bottom),
+                        candle_width,
+                        body_height,
+                        facecolor=color,
+                        edgecolor=color,
+                        linewidth=1.0,
+                    )
+                )
+
+            for level in levels:
+                price = self._to_float(level.get("price"))
+                if price is None:
+                    continue
+                ax.axhline(price, color="#60a5fa", linewidth=1.0, linestyle="--", alpha=0.9)
+
+            for zone in zones:
+                price_from = self._to_float(zone.get("from") or zone.get("priceFrom"))
+                price_to = self._to_float(zone.get("to") or zone.get("priceTo"))
+                if price_from is None or price_to is None:
+                    continue
+                bottom = min(price_from, price_to)
+                height = abs(price_to - price_from)
+                ax.add_patch(
+                    Rectangle(
+                        (-0.5, bottom),
+                        len(candles),
+                        height if height > 0 else max_price * 0.0001,
+                        facecolor="#38bdf8",
+                        edgecolor="#38bdf8",
+                        alpha=0.12,
+                        linewidth=0.8,
+                    )
+                )
+
+            if entry is not None:
+                ax.scatter(len(candles) - 1, entry, color="#facc15", s=80, marker="o", zorder=5)
+            if stop_loss is not None:
+                ax.axhline(stop_loss, color="#ef4444", linewidth=1.3, linestyle="-", alpha=0.95)
+            if take_profit is not None:
+                ax.axhline(take_profit, color="#22c55e", linewidth=1.3, linestyle="-", alpha=0.95)
+
+            ax.set_title(f"{symbol} {timeframe}", color="#e5e7eb", fontsize=12, fontweight="bold")
+            ax.set_xlim(-1, len(candles))
+            ax.set_ylim(min_price - price_padding, max_price + price_padding)
+            ax.tick_params(colors="#9ca3af", labelsize=8)
+            for spine in ax.spines.values():
+                spine.set_color("#374151")
+            fig.tight_layout()
+            fig.savefig(absolute_path, facecolor=fig.get_facecolor())
+            logger.info("idea_snapshot_success symbol=%s timeframe=%s file=%s", symbol, timeframe, relative_path)
+            return relative_path
+        except Exception:
+            logger.exception("idea_snapshot_failed symbol=%s timeframe=%s", symbol, timeframe)
+            return None
+        finally:
+            plt.close(fig)
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -13,6 +13,7 @@ import requests
 
 from app.core.env import get_openrouter_api_key, get_openrouter_model
 from app.services.chart_data_service import ChartDataService
+from app.services.chart_snapshot_service import ChartSnapshotService
 from app.services.idea_narrative_llm import IdeaNarrativeLLMService
 from app.services.narrative_generator import generate_signal_preview_text, generate_signal_text
 from app.services.storage.json_storage import JsonStorage
@@ -64,6 +65,7 @@ class TradeIdeaService:
         self.signal_engine = signal_engine
         self.data_provider = DataProvider()
         self.chart_data_service = chart_data_service or ChartDataService()
+        self.chart_snapshot_service = ChartSnapshotService()
         self.refresh_interval_seconds = int(os.getenv("IDEAS_REFRESH_INTERVAL_SECONDS", "180"))
         self.idea_store = JsonStorage("signals_data/trade_ideas.json", {"updated_at_utc": None, "ideas": []})
         self.snapshot_store = JsonStorage("signals_data/trade_idea_snapshots.json", {"snapshots": []})
@@ -532,6 +534,15 @@ class TradeIdeaService:
             analysis=analysis_payload,
             trade_plan=trade_plan_payload,
         )
+        chart_snapshot = self._resolve_chart_snapshot(
+            signal=signal,
+            existing=existing,
+            symbol=symbol,
+            timeframe=timeframe,
+            entry=entry_value,
+            stop_loss=stop_loss,
+            take_profit=take_profit,
+        )
         is_terminal = status in TERMINAL_STATUSES
         closed_at = now.isoformat() if is_terminal else None
         final_status = status if is_terminal else existing.get("final_status") if existing else None
@@ -611,7 +622,10 @@ class TradeIdeaService:
             "trade_plan": trade_plan_payload,
             "detail_brief": detail_brief,
             "supported_sections": detail_brief.get("supported_sections", []),
-            "chart_image": None,
+            "chart_image": chart_snapshot["chartImageUrl"],
+            "chartImageUrl": chart_snapshot["chartImageUrl"],
+            "chart_snapshot_status": chart_snapshot["status"],
+            "chartSnapshotStatus": chart_snapshot["status"],
             "history": history,
             "updates": updates,
             "current_reasoning": decision_payload.get("explanation_ru"),
@@ -627,6 +641,72 @@ class TradeIdeaService:
             },
         }
         return self._attach_trade_result_metrics(payload)
+
+    def _resolve_chart_snapshot(
+        self,
+        *,
+        signal: dict[str, Any],
+        existing: dict[str, Any] | None,
+        symbol: str,
+        timeframe: str,
+        entry: float | None,
+        stop_loss: float | None,
+        take_profit: float | None,
+    ) -> dict[str, Any]:
+        if existing is not None:
+            existing_url = existing.get("chartImageUrl") or existing.get("chart_image")
+            existing_status = existing.get("chartSnapshotStatus") or existing.get("chart_snapshot_status") or "ok"
+            return {"chartImageUrl": existing_url, "status": existing_status}
+
+        chart_payload = self.chart_data_service.get_chart(symbol, timeframe)
+        fetch_status = str(chart_payload.get("status") or "").lower()
+        candles = chart_payload.get("candles") if isinstance(chart_payload.get("candles"), list) else []
+        logger.info(
+            "idea_snapshot_candle_fetch symbol=%s timeframe=%s fetch_status=%s candles=%s",
+            symbol,
+            timeframe,
+            fetch_status or "unknown",
+            len(candles),
+        )
+
+        if fetch_status != "ok":
+            failure_status = self._map_chart_fetch_status(chart_payload)
+            logger.warning("idea_snapshot_skipped symbol=%s timeframe=%s status=%s", symbol, timeframe, failure_status)
+            return {"chartImageUrl": None, "status": failure_status}
+        if not candles:
+            logger.warning("idea_snapshot_skipped symbol=%s timeframe=%s status=no_data", symbol, timeframe)
+            return {"chartImageUrl": None, "status": "no_data"}
+
+        chart_data = signal.get("chart_data") if isinstance(signal.get("chart_data"), dict) else {}
+        levels = chart_data.get("levels") if isinstance(chart_data.get("levels"), list) else []
+        zones = chart_data.get("zones") if isinstance(chart_data.get("zones"), list) else []
+        image_path = self.chart_snapshot_service.build_snapshot(
+            symbol=symbol,
+            timeframe=timeframe,
+            candles=candles,
+            levels=levels,
+            zones=zones,
+            entry=self._extract_numeric(entry),
+            stop_loss=self._extract_numeric(stop_loss),
+            take_profit=self._extract_numeric(take_profit),
+        )
+        if not image_path:
+            return {"chartImageUrl": None, "status": "fetch_error"}
+        logger.info("idea_snapshot_final_path symbol=%s timeframe=%s path=%s", symbol, timeframe, image_path)
+        return {"chartImageUrl": image_path, "status": "ok"}
+
+    @staticmethod
+    def _map_chart_fetch_status(chart_payload: dict[str, Any]) -> str:
+        meta = chart_payload.get("meta") if isinstance(chart_payload.get("meta"), dict) else {}
+        reason = str(meta.get("reason") or "").lower()
+        if reason in {"rate_limited", "no_data", "fetch_error"}:
+            return reason
+        message = str(chart_payload.get("message_ru") or "").lower()
+        if "limit" in message or "429" in message or "rate" in message:
+            return "rate_limited"
+        if "не вернул candles" in message or "пуст" in message or "no data" in message:
+            return "no_data"
+        return "fetch_error"
 
     def _append_snapshot(self, idea: dict[str, Any], previous: dict[str, Any] | None) -> None:
         snapshots = self.snapshot_store.read().get("snapshots", [])
@@ -2012,6 +2092,8 @@ class TradeIdeaService:
                 trade_plan=normalized_trade_plan,
             )
             chart_data = row.get("chartData") or row.get("chart_data")
+            chart_image_url = row.get("chartImageUrl") or row.get("chart_image")
+            chart_snapshot_status = row.get("chartSnapshotStatus") or row.get("chart_snapshot_status") or "ok"
             tags = row.get("tags")
             if not isinstance(tags, list) or not tags:
                 tags = [source, symbol, timeframe, direction]
@@ -2053,6 +2135,10 @@ class TradeIdeaService:
                         "stopLoss": stop_loss,
                         "takeProfit": take_profit,
                         "chartData": chart_data,
+                        "chartImageUrl": chart_image_url,
+                        "chart_image": chart_image_url,
+                        "chartSnapshotStatus": chart_snapshot_status,
+                        "chart_snapshot_status": chart_snapshot_status,
                         "ideaContext": str(idea_context),
                         "trigger": str(trigger),
                         "invalidation": str(invalidation),

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -34,6 +34,7 @@ function labelClass(label) {
 }
 
 function renderIdeaCard(idea) {
+  const chartImageUrl = idea.chartImageUrl || idea.chart_image || null;
   const analysis = idea.analysis || {};
   const tradePlan = idea.trade_plan || {};
   const updates = Array.isArray(idea.updates) ? idea.updates.slice(-5).reverse() : [];
@@ -54,11 +55,11 @@ function renderIdeaCard(idea) {
       <div class="idea-summary">${escapeHtml(idea.summary_ru || "")}</div>
 
       ${
-        idea.chart_image
+        chartImageUrl
           ? `<div class="idea-chart-wrap">
-               <img class="idea-chart-image" src="${escapeHtml(idea.chart_image)}?t=${Date.now()}" alt="${escapeHtml(idea.title || "chart")}" />
+               <img class="idea-chart-image" src="${escapeHtml(chartImageUrl)}?t=${Date.now()}" alt="${escapeHtml(idea.title || "chart")}" />
              </div>`
-          : `<div class="idea-chart-missing">Картинка сценария пока не сгенерирована.</div>`
+          : `<div class="idea-chart-missing">Снапшот графика недоступен (${escapeHtml(idea.chartSnapshotStatus || idea.chart_snapshot_status || "no_data")}).</div>`
       }
 
       <div class="idea-analysis-grid">

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -144,10 +144,12 @@
       position: relative;
     }
 
-    .preview-canvas {
+    .preview-canvas,
+    .preview-image {
       width: 100%;
       height: 100%;
       display: block;
+      object-fit: cover;
     }
 
     .tags {
@@ -230,10 +232,24 @@
       position: relative;
     }
 
-    .chart-canvas {
+    .chart-canvas,
+    .chart-image {
       width: 100%;
       height: 100%;
       display: block;
+      object-fit: contain;
+    }
+
+    .chart-fallback {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #9ca3af;
+      font-size: 14px;
+      padding: 12px;
+      text-align: center;
     }
 
     .legend {
@@ -306,7 +322,7 @@
     <div class="topbar">
       <div class="topbar-left">
         <h1>AI-идеи по рынку</h1>
-        <p>В короткой карточке показывается информативное превью, а по клику открывается полный график с зонами, уровнями, стрелками и подписями.</p>
+        <p>В карточке и модальном окне показывается готовый server-side PNG-снапшот, который сохраняется при создании идеи.</p>
       </div>
       <a class="home-link" href="/">На главную</a>
     </div>
@@ -325,7 +341,8 @@
       </div>
 
       <div class="chart-shell">
-        <canvas id="modal-chart" class="chart-canvas"></canvas>
+        <img id="modal-chart" class="chart-image" alt="Снапшот графика идеи" />
+        <div id="modal-chart-fallback" class="chart-fallback hidden">Снапшот графика недоступен.</div>
       </div>
 
       <div class="legend">
@@ -396,6 +413,7 @@
     const modalTitle = document.getElementById("modal-title");
     const modalSub = document.getElementById("modal-sub");
     const modalChart = document.getElementById("modal-chart");
+    const modalChartFallback = document.getElementById("modal-chart-fallback");
 
     const modalSummary = document.getElementById("modal-summary");
     const modalTechnical = document.getElementById("modal-technical");
@@ -441,6 +459,21 @@
       if (["bullish", "buy", "long"].includes(raw)) return "БЫЧИЙ";
       if (["bearish", "sell", "short"].includes(raw)) return "МЕДВЕЖИЙ";
       return "НЕЙТРАЛЬНЫЙ";
+    }
+
+    function getChartImageUrl(idea) {
+      const raw = idea?.chartImageUrl || idea?.chart_image || "";
+      if (!raw) return "";
+      const separator = raw.includes("?") ? "&" : "?";
+      return `${raw}${separator}t=${Date.now()}`;
+    }
+
+    function buildChartPreviewMarkup(idea, className = "preview-image") {
+      const chartUrl = getChartImageUrl(idea);
+      if (!chartUrl) {
+        return `<div class="empty">Снапшот графика недоступен (${escapeHtml(idea?.chartSnapshotStatus || idea?.chart_snapshot_status || "no_data")}).</div>`;
+      }
+      return `<img class="${className}" src="${escapeHtml(chartUrl)}" alt="Снапшот ${escapeHtml(idea?.symbol || "идеи")}" />`;
     }
 
     function setSection(textEl, value) {
@@ -790,22 +823,23 @@
       setSection(modalInvalidation, getText(idea.invalidation_ru, idea.invalidation, idea.trade_plan?.invalidation));
 
       modal.classList.add("open");
-      setTimeout(() => renderChart(modalChart, idea, false), 40);
+      const chartUrl = getChartImageUrl(idea);
+      if (chartUrl) {
+        modalChart.src = chartUrl;
+        modalChart.style.display = "block";
+        modalChartFallback.classList.add("hidden");
+      } else {
+        modalChart.removeAttribute("src");
+        modalChart.style.display = "none";
+        modalChartFallback.textContent = `Снапшот графика недоступен (${idea.chartSnapshotStatus || idea.chart_snapshot_status || "no_data"}).`;
+        modalChartFallback.classList.remove("hidden");
+      }
 
       if (resizeHandler) {
         window.removeEventListener("resize", resizeHandler);
       }
 
-      resizeHandler = () => {
-        if (activeIdea) renderChart(modalChart, activeIdea, false);
-        document.querySelectorAll(".preview-canvas").forEach((canvas) => {
-          const raw = canvas.getAttribute("data-idea");
-          if (!raw) return;
-          try {
-            renderChart(canvas, JSON.parse(raw), true);
-          } catch {}
-        });
-      };
+      resizeHandler = () => {};
 
       window.addEventListener("resize", resizeHandler);
     }
@@ -821,7 +855,7 @@
         return;
       }
 
-      ideasGrid.innerHTML = ideas.map((idea, idx) => {
+      ideasGrid.innerHTML = ideas.map((idea) => {
         const tags = Array.isArray(idea.tags) ? idea.tags : [];
         const summary = getText(idea.summary_ru, idea.summary);
         const symbol = idea.symbol || idea.instrument || idea.pair || "";
@@ -839,9 +873,7 @@
               <button class="watch-btn" type="button">Открыть</button>
             </div>
 
-            <div class="preview-shell">
-              <canvas class="preview-canvas" id="preview-${idx}" data-idea='${escapeHtml(JSON.stringify(idea))}'></canvas>
-            </div>
+            <div class="preview-shell">${buildChartPreviewMarkup(idea)}</div>
 
             <p class="summary">${escapeHtml(summary)}</p>
 
@@ -851,15 +883,6 @@
           </div>
         `;
       }).join("");
-
-      document.querySelectorAll(".preview-canvas").forEach((canvas) => {
-        try {
-          const idea = JSON.parse(canvas.getAttribute("data-idea"));
-          renderChart(canvas, idea, true);
-        } catch (e) {
-          console.error(e);
-        }
-      });
 
       document.querySelectorAll(".card").forEach((card) => {
         card.addEventListener("click", () => {


### PR DESCRIPTION
### Motivation
- Упростить и стабилизировать визуализацию идей: генерировать статичный PNG на сервере при создании идеи вместо runtime canvas/JS-рисунка в браузере. 
- Избежать браузерных рендереров/plotly и synthetic candles при ошибках провайдера, сделать поведение детерминированным и совместимым с деплоем на Render.

### Description
- Добавлен сервис `ChartSnapshotService` на `matplotlib` (Agg), который строит свечной PNG и сохраняет в `app/static/charts/{symbol}_{timeframe}_{timestamp}.png`, рисует свечи, горизонтальные уровни, зоны (rectangles), entry marker, SL и TP, логирует успех/ошибку и возвращает относительный путь ` /static/charts/...png`. (new: `app/services/chart_snapshot_service.py`).
- Интеграция в `TradeIdeaService`: при создании новой идеи выполняется `ChartDataService.get_chart(...)`; при успешном fetch — вызывается `ChartSnapshotService.build_snapshot(...)`, в payload идеи записываются поля `chartImageUrl`/`chart_image` и статус `chartSnapshotStatus`/`chart_snapshot_status`; при ошибке загрузки свечей `chartImageUrl = null` и `chartSnapshotStatus` устанавливается в `rate_limited | no_data | fetch_error`. Повторное обновление существующей идеи повторной генерации снимка не делает — используется сохранённый путь. (mod: `app/services/trade_idea_service.py`).
- `ChartDataService` теперь ставит код причины в `meta.reason` в `build_unavailable_payload` (`rate_limited | no_data | fetch_error`) чтобы корректно маппить статус snapshot без синтетики. (mod: `app/services/chart_data_service.py`).
- Frontend изменения: `/ideas` и главная страница используют `chartImageUrl` (или `chart_image`) и выводят `<img>` превью и модальное изображение; при отсутствии картинки показывается понятный fallback с указанным статусом; runtime canvas-рисование в modal/previes удалено. (mod: `app/static/ideas.js`, `app/static/index.html`).
- Документация: короткая заметка в `README.md` про новый server-side snapshot pipeline. (mod: `README.md`).
- Ключевые новые/изменённые файлы: `app/services/chart_snapshot_service.py` (new), `app/services/trade_idea_service.py` (mod), `app/services/chart_data_service.py` (mod), `app/static/ideas.js` (mod), `app/static/index.html` (mod), `README.md` (mod).

### Testing
- Запущена статическая проверка компиляции Python: `python -m compileall app/services/chart_snapshot_service.py app/services/trade_idea_service.py app/services/chart_data_service.py` — успешно (файлы скомпилированы без синтаксических ошибок).
- Локальный коммит создан: `Refactor trade ideas to server-side chart snapshots` (успешно).
- Автоматические unit/UI-тесты не запускались; интеграционные проверки UI-рендеринга в headless browser не выполнялись в этом окружении (Playwright отсутствует).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86a8c311c8331a9f337a95aa67be1)