### PR TITLE
Запрет обновления закрытых идей и уточнённый matching в `upsert_trade_idea`

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -286,6 +286,7 @@ class TradeIdeaService:
         symbol = str(signal.get("symbol", "")).upper()
         timeframe = str(signal.get("timeframe", "H1")).upper()
         setup_type = self._setup_type(signal)
+        action = str(signal.get("action", "NO_TRADE")).upper()
         now = datetime.now(timezone.utc)
         active_index = next(
             (
@@ -293,10 +294,20 @@ class TradeIdeaService:
                 for index, idea in enumerate(ideas)
                 if idea.get("symbol") == symbol
                 and idea.get("timeframe") == timeframe
+                and idea.get("setup_type") == setup_type
                 and idea.get("status") in ACTIVE_STATUSES
             ),
             None,
         )
+
+        if active_index is None and action == "NO_TRADE":
+            latest_matching_idea = self._latest_matching_idea(
+                ideas=ideas,
+                symbol=symbol,
+                timeframe=timeframe,
+            )
+            if latest_matching_idea is not None:
+                return latest_matching_idea
 
         if active_index is not None:
             current = ideas[active_index]
@@ -311,6 +322,24 @@ class TradeIdeaService:
         store = {"updated_at_utc": now.isoformat(), "ideas": ideas}
         self.idea_store.write(store)
         return updated
+
+    @staticmethod
+    def _latest_matching_idea(
+        *,
+        ideas: list[dict[str, Any]],
+        symbol: str,
+        timeframe: str,
+    ) -> dict[str, Any] | None:
+        matched = [
+            idea
+            for idea in ideas
+            if idea.get("symbol") == symbol
+            and idea.get("timeframe") == timeframe
+        ]
+        if not matched:
+            return None
+        matched.sort(key=lambda item: str(item.get("updated_at") or item.get("created_at") or ""), reverse=True)
+        return matched[0]
 
     def _apply_updates(self, generated: list[dict]) -> dict[str, Any]:
         symbols_with_candles: set[tuple[str, str]] = set()

--- a/tests/test_idea_update.py
+++ b/tests/test_idea_update.py
@@ -159,6 +159,39 @@ def test_archive_explanation_generation_on_tp_sl(tmp_path: Path) -> None:
     assert "sl_hit" in (sl.get("close_explanation") or "")
 
 
+def test_no_trade_does_not_reopen_closed_lifecycle(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    base_signal = {
+        "symbol": "EURUSD",
+        "timeframe": "H1",
+        "action": "BUY",
+        "entry": 1.0820,
+        "stop_loss": 1.0790,
+        "take_profit": 1.0880,
+        "latest_close": 1.0823,
+        "confidence_percent": 74,
+        "description_ru": "Первичный long-сценарий.",
+        "reason_ru": "Структура подтверждает long.",
+        "market_context": {"patternBias": "bullish"},
+    }
+
+    service.upsert_trade_idea(base_signal)
+    closed = service.upsert_trade_idea({**base_signal, "latest_close": 1.0890})
+    unchanged = service.upsert_trade_idea({
+        "symbol": "EURUSD",
+        "timeframe": "H1",
+        "action": "NO_TRADE",
+        "market_context": {"patternBias": "bullish"},
+        "reason_ru": "Нового подтверждения нет.",
+    })
+
+    ideas = service.idea_store.read()["ideas"]
+    assert len(ideas) == 1
+    assert unchanged["idea_id"] == closed["idea_id"]
+    assert unchanged["status"] == "archived"
+    assert unchanged["final_status"] == "tp_hit"
+
+
 def test_build_narrative_facts_contains_smc_contract() -> None:
     facts = TradeIdeaService._build_narrative_facts(
         signal={


### PR DESCRIPTION
### Motivation
- Исправить поведение lifecycle: одна живая идея должна обновляться в том же `idea_id`, а при достижении TP/SL запись должна оставаться окончательно закрытой.
- Предотвратить создание новой карточки из `NO_TRADE` сразу после закрытия идеи, чтобы не реанимировать терминальные записи.

### Description
- В `upsert_trade_idea` добавлен учёт `setup_type` при поиске активной идеи, чтобы обновления применялись только к тому же setup (обновлена логика matching).
- Добавлено извлечение `action` из сигнала и guard: если `action == "NO_TRADE"` и нет живой идеи для текущего `setup_type`, метод возвращает последнюю подходящую идею по `symbol`/`timeframe` вместо создания новой записи.
- Добавлен вспомогательный метод ` _latest_matching_idea` для безопасного выбора последней идеи по `symbol`/`timeframe`.
- Обновлён тестовый набор: добавлен регрессионный тест `test_no_trade_does_not_reopen_closed_lifecycle` для контроля, что `NO_TRADE` не переоткрывает закрытую (TP/SL) идею.
- Файлы изменённые: `app/services/trade_idea_service.py`, `tests/test_idea_update.py`.

### Testing
- Запущена группа тестов: `pytest -q tests/test_idea_update.py` — все тесты прошли успешно (`6 passed`).
- Автоматические проверки подтверждают, что поведение обновления/закрытия идей соответствует требуемым бизнес-правилам.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e889501a808331b3d947ada318c12e)