### PR TITLE
Добавить серверную генерацию PNG-снэпшотов графиков (matplotlib)

### DIFF
--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -26,21 +26,32 @@ class ChartSnapshotService:
         symbol: str,
         timeframe: str,
         candles: list[dict[str, Any]],
-        levels: list[dict[str, Any]],
-        zones: list[dict[str, Any]],
+        levels: list[dict[str, Any]] | None = None,
+        zones: list[dict[str, Any]] | None = None,
         entry: float | None,
         stop_loss: float | None,
-        take_profit: float | None,
+        take_profits: list[float] | None = None,
+        bias: str | None = None,
+        confidence: int | None = None,
+        status: str | None = None,
+        markers: list[dict[str, Any]] | None = None,
+        patterns: list[dict[str, Any]] | None = None,
     ) -> str | None:
         if not candles:
+            logger.info("idea_snapshot_skipped reason=no_candles symbol=%s timeframe=%s", symbol, timeframe)
             return None
+        levels = levels or []
+        zones = zones or []
+        markers = markers or []
+        patterns = patterns or []
+        take_profits = [value for value in (take_profits or []) if value is not None]
 
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
         filename = f"{symbol}_{timeframe}_{timestamp}.png"
         absolute_path = self.charts_dir / filename
         relative_path = f"/static/charts/{filename}"
 
-        fig, ax = plt.subplots(figsize=(12, 6), dpi=120)
+        fig, ax = plt.subplots(figsize=(12, 7), dpi=100)
         try:
             x_values = list(range(len(candles)))
             highs = [float(candle["high"]) for candle in candles]
@@ -73,45 +84,31 @@ class ChartSnapshotService:
                     )
                 )
 
-            for level in levels:
-                price = self._to_float(level.get("price"))
-                if price is None:
-                    continue
-                ax.axhline(price, color="#60a5fa", linewidth=1.0, linestyle="--", alpha=0.9)
+            self._draw_zones(ax=ax, zones=zones, candles_count=len(candles), max_price=max_price)
+            self._draw_horizontal_levels(ax=ax, levels=levels, candles_count=len(candles))
+            self._draw_trade_levels(
+                ax=ax,
+                candles_count=len(candles),
+                entry=entry,
+                stop_loss=stop_loss,
+                take_profits=take_profits,
+            )
+            rendered = self._draw_smc_markers(ax=ax, markers=markers, candles_count=len(candles))
+            rendered += self._draw_patterns(ax=ax, patterns=patterns, candles_count=len(candles))
+            if rendered < 5:
+                self._draw_direction_hint(ax=ax, candles_count=len(candles), entry=entry, take_profits=take_profits, bias=bias)
 
-            for zone in zones:
-                price_from = self._to_float(zone.get("from") or zone.get("priceFrom"))
-                price_to = self._to_float(zone.get("to") or zone.get("priceTo"))
-                if price_from is None or price_to is None:
-                    continue
-                bottom = min(price_from, price_to)
-                height = abs(price_to - price_from)
-                ax.add_patch(
-                    Rectangle(
-                        (-0.5, bottom),
-                        len(candles),
-                        height if height > 0 else max_price * 0.0001,
-                        facecolor="#38bdf8",
-                        edgecolor="#38bdf8",
-                        alpha=0.12,
-                        linewidth=0.8,
-                    )
-                )
-
-            if entry is not None:
-                ax.scatter(len(candles) - 1, entry, color="#facc15", s=80, marker="o", zorder=5)
-            if stop_loss is not None:
-                ax.axhline(stop_loss, color="#ef4444", linewidth=1.3, linestyle="-", alpha=0.95)
-            if take_profit is not None:
-                ax.axhline(take_profit, color="#22c55e", linewidth=1.3, linestyle="-", alpha=0.95)
-
-            ax.set_title(f"{symbol} {timeframe}", color="#e5e7eb", fontsize=12, fontweight="bold")
+            header = self._build_header(symbol=symbol, timeframe=timeframe, bias=bias, confidence=confidence, status=status)
+            ax.set_title(header, color="#e5e7eb", fontsize=12, fontweight="bold", pad=14)
+            self._draw_compact_legend(fig)
             ax.set_xlim(-1, len(candles))
             ax.set_ylim(min_price - price_padding, max_price + price_padding)
             ax.tick_params(colors="#9ca3af", labelsize=8)
+            ax.set_xlabel("Индекс свечи", color="#9ca3af", fontsize=8)
+            ax.set_ylabel("Цена", color="#9ca3af", fontsize=8)
             for spine in ax.spines.values():
                 spine.set_color("#374151")
-            fig.tight_layout()
+            fig.tight_layout(rect=[0, 0.035, 1, 0.98])
             fig.savefig(absolute_path, facecolor=fig.get_facecolor())
             logger.info("idea_snapshot_success symbol=%s timeframe=%s file=%s", symbol, timeframe, relative_path)
             return relative_path
@@ -120,6 +117,159 @@ class ChartSnapshotService:
             return None
         finally:
             plt.close(fig)
+
+    def _draw_zones(self, *, ax: Any, zones: list[dict[str, Any]], candles_count: int, max_price: float) -> None:
+        styles = {
+            "demand": {"face": "#22c55e", "label": "Demand"},
+            "supply": {"face": "#ef4444", "label": "Supply"},
+            "fvg": {"face": "#8b5cf6", "label": "FVG"},
+            "order_block": {"face": "#f59e0b", "label": "OB"},
+            "ob": {"face": "#f59e0b", "label": "OB"},
+        }
+        for zone in zones[:5]:
+            zone_type_raw = str(zone.get("type") or zone.get("kind") or zone.get("label") or "").lower().replace(" ", "_")
+            style = styles.get(zone_type_raw, {"face": "#38bdf8", "label": "Zone"})
+            price_from = self._to_float(zone.get("from") or zone.get("priceFrom") or zone.get("low"))
+            price_to = self._to_float(zone.get("to") or zone.get("priceTo") or zone.get("high"))
+            if price_from is None or price_to is None:
+                continue
+            start_idx = int(zone.get("startIndex") or zone.get("start") or max(candles_count - 25, 0))
+            end_idx = int(zone.get("endIndex") or zone.get("end") or candles_count - 1)
+            start_idx = max(-1, min(start_idx, candles_count - 1))
+            end_idx = max(start_idx + 1, min(end_idx, candles_count))
+            bottom = min(price_from, price_to)
+            height = abs(price_to - price_from) or max_price * 0.00008
+            ax.add_patch(
+                Rectangle(
+                    (start_idx - 0.5, bottom),
+                    end_idx - start_idx,
+                    height,
+                    facecolor=style["face"],
+                    edgecolor=style["face"],
+                    alpha=0.16,
+                    linewidth=0.8,
+                )
+            )
+            ax.text(start_idx, bottom + height / 2, style["label"], color="#e5e7eb", fontsize=7, alpha=0.85)
+
+    def _draw_horizontal_levels(self, *, ax: Any, levels: list[dict[str, Any]], candles_count: int) -> None:
+        for level in levels[:6]:
+            price = self._to_float(level.get("price") or level.get("value") or level.get("level"))
+            if price is None:
+                continue
+            level_type = str(level.get("type") or level.get("label") or "Level")
+            lowered = level_type.lower()
+            style = ":" if "liq" in lowered or "session" in lowered else "--"
+            ax.axhline(price, color="#60a5fa", linewidth=0.9, linestyle=style, alpha=0.8)
+            ax.text(candles_count - 0.1, price, level_type[:14], color="#93c5fd", fontsize=7, ha="right", va="bottom", alpha=0.9)
+
+    def _draw_trade_levels(
+        self,
+        *,
+        ax: Any,
+        candles_count: int,
+        entry: float | None,
+        stop_loss: float | None,
+        take_profits: list[float],
+    ) -> None:
+        if entry is not None:
+            ax.axhline(entry, color="#facc15", linewidth=1.2, linestyle="-", alpha=0.95)
+            ax.text(candles_count - 0.1, entry, "Entry", color="#fde68a", fontsize=8, ha="right", va="bottom")
+        if stop_loss is not None:
+            ax.axhline(stop_loss, color="#ef4444", linewidth=1.2, linestyle="--", alpha=0.95)
+            ax.text(candles_count - 0.1, stop_loss, "SL", color="#fca5a5", fontsize=8, ha="right", va="bottom")
+        for index, tp in enumerate(take_profits[:3], start=1):
+            ax.axhline(tp, color="#22c55e", linewidth=1.1, linestyle="--", alpha=0.92)
+            ax.text(candles_count - 0.1, tp, f"TP{index}", color="#86efac", fontsize=8, ha="right", va="bottom")
+
+    def _draw_smc_markers(self, *, ax: Any, markers: list[dict[str, Any]], candles_count: int) -> int:
+        allowed = {"bos", "choch", "sweep", "eqh", "eql"}
+        rendered = 0
+        for marker in markers:
+            marker_type = str(marker.get("type") or marker.get("label") or "").lower()
+            if marker_type not in allowed:
+                continue
+            price = self._to_float(marker.get("price") or marker.get("value"))
+            index = int(marker.get("index") or marker.get("candleIndex") or candles_count - 1)
+            if price is None:
+                continue
+            index = max(0, min(index, candles_count - 1))
+            ax.text(index, price, marker_type.upper(), color="#c4b5fd", fontsize=7, alpha=0.85)
+            rendered += 1
+            if rendered >= 4:
+                break
+        return rendered
+
+    def _draw_patterns(self, *, ax: Any, patterns: list[dict[str, Any]], candles_count: int) -> int:
+        rendered = 0
+        for pattern in patterns[:2]:
+            name = str(pattern.get("type") or pattern.get("name") or pattern.get("pattern") or "").strip()
+            if not name:
+                continue
+            points = pattern.get("points") if isinstance(pattern.get("points"), list) else []
+            if len(points) >= 2:
+                xs: list[float] = []
+                ys: list[float] = []
+                for point in points[:4]:
+                    if not isinstance(point, dict):
+                        continue
+                    x_val = self._to_float(point.get("index") or point.get("x"))
+                    y_val = self._to_float(point.get("price") or point.get("y"))
+                    if x_val is None or y_val is None:
+                        continue
+                    xs.append(max(0, min(x_val, candles_count - 1)))
+                    ys.append(y_val)
+                if len(xs) >= 2:
+                    ax.plot(xs, ys, color="#f9a8d4", linewidth=0.9, alpha=0.7)
+            label_price = self._to_float(pattern.get("price") or pattern.get("y"))
+            label_index = int(pattern.get("index") or pattern.get("x") or candles_count - 3)
+            if label_price is not None:
+                ax.text(max(0, min(label_index, candles_count - 1)), label_price, name[:12], color="#fbcfe8", fontsize=7, alpha=0.85)
+            rendered += 1
+        return rendered
+
+    def _draw_direction_hint(
+        self,
+        *,
+        ax: Any,
+        candles_count: int,
+        entry: float | None,
+        take_profits: list[float],
+        bias: str | None,
+    ) -> None:
+        if entry is None or not take_profits:
+            return
+        direction = str(bias or "").lower()
+        target = take_profits[0]
+        if direction not in {"bullish", "bearish"}:
+            direction = "bullish" if target >= entry else "bearish"
+        start_x = max(candles_count - 12, 1)
+        end_x = candles_count - 2
+        color = "#22c55e" if direction == "bullish" else "#ef4444"
+        ax.annotate("", xy=(end_x, target), xytext=(start_x, entry), arrowprops={"arrowstyle": "->", "color": color, "lw": 1.3, "alpha": 0.7})
+
+    @staticmethod
+    def _build_header(symbol: str, timeframe: str, bias: str | None, confidence: int | None, status: str | None) -> str:
+        parts = [symbol.upper(), timeframe.upper()]
+        if bias:
+            parts.append(str(bias).upper())
+        if confidence is not None:
+            parts.append(f"{int(confidence)}%")
+        if status:
+            parts.append(str(status).upper())
+        return " • ".join(parts)
+
+    @staticmethod
+    def _draw_compact_legend(fig: Any) -> None:
+        fig.text(
+            0.5,
+            0.008,
+            "Demand | Supply | FVG | OB | BOS | CHoCH | Liquidity",
+            ha="center",
+            color="#94a3b8",
+            fontsize=7,
+            alpha=0.75,
+        )
 
     @staticmethod
     def _to_float(value: Any) -> float | None:

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -571,6 +571,9 @@ class TradeIdeaService:
             entry=entry_value,
             stop_loss=stop_loss,
             take_profit=take_profit,
+            bias=bias,
+            confidence=int(signal.get("confidence_percent") or signal.get("probability_percent") or 0),
+            status=status,
         )
         is_terminal = status in TERMINAL_STATUSES
         closed_at = now.isoformat() if is_terminal else None
@@ -681,15 +684,25 @@ class TradeIdeaService:
         entry: float | None,
         stop_loss: float | None,
         take_profit: float | None,
+        bias: str,
+        confidence: int,
+        status: str,
     ) -> dict[str, Any]:
         if existing is not None:
             existing_url = existing.get("chartImageUrl") or existing.get("chart_image")
             existing_status = existing.get("chartSnapshotStatus") or existing.get("chart_snapshot_status") or "ok"
             return {"chartImageUrl": existing_url, "status": existing_status}
 
-        chart_payload = self.chart_data_service.get_chart(symbol, timeframe)
-        fetch_status = str(chart_payload.get("status") or "").lower()
-        candles = chart_payload.get("candles") if isinstance(chart_payload.get("candles"), list) else []
+        chart_data = signal.get("chart_data") if isinstance(signal.get("chart_data"), dict) else {}
+        if not chart_data and isinstance(signal.get("chartData"), dict):
+            chart_data = signal.get("chartData")
+        candles = chart_data.get("candles") if isinstance(chart_data.get("candles"), list) else []
+        chart_payload: dict[str, Any] = {"status": "ok", "candles": candles}
+        fetch_status = "ok"
+        if not candles:
+            chart_payload = self.chart_data_service.get_chart(symbol, timeframe)
+            fetch_status = str(chart_payload.get("status") or "").lower()
+            candles = chart_payload.get("candles") if isinstance(chart_payload.get("candles"), list) else []
         logger.info(
             "idea_snapshot_candle_fetch symbol=%s timeframe=%s fetch_status=%s candles=%s",
             symbol,
@@ -706,9 +719,11 @@ class TradeIdeaService:
             logger.warning("idea_snapshot_skipped symbol=%s timeframe=%s status=no_data", symbol, timeframe)
             return {"chartImageUrl": None, "status": "no_data"}
 
-        chart_data = signal.get("chart_data") if isinstance(signal.get("chart_data"), dict) else {}
         levels = chart_data.get("levels") if isinstance(chart_data.get("levels"), list) else []
         zones = chart_data.get("zones") if isinstance(chart_data.get("zones"), list) else []
+        markers = chart_data.get("markers") if isinstance(chart_data.get("markers"), list) else []
+        patterns = signal.get("chart_patterns") if isinstance(signal.get("chart_patterns"), list) else []
+        take_profits = self._extract_take_profits(signal=signal, fallback_take_profit=take_profit)
         image_path = self.chart_snapshot_service.build_snapshot(
             symbol=symbol,
             timeframe=timeframe,
@@ -717,12 +732,35 @@ class TradeIdeaService:
             zones=zones,
             entry=self._extract_numeric(entry),
             stop_loss=self._extract_numeric(stop_loss),
-            take_profit=self._extract_numeric(take_profit),
+            take_profits=take_profits,
+            bias=bias,
+            confidence=confidence,
+            status=status,
+            markers=markers,
+            patterns=patterns,
         )
         if not image_path:
             return {"chartImageUrl": None, "status": "fetch_error"}
         logger.info("idea_snapshot_final_path symbol=%s timeframe=%s path=%s", symbol, timeframe, image_path)
         return {"chartImageUrl": image_path, "status": "ok"}
+
+    def _extract_take_profits(self, *, signal: dict[str, Any], fallback_take_profit: float | None) -> list[float]:
+        candidates = signal.get("take_profits")
+        if not isinstance(candidates, list):
+            candidates = signal.get("take_profit_levels")
+        take_profits: list[float] = []
+        if isinstance(candidates, list):
+            for item in candidates:
+                if isinstance(item, dict):
+                    value = self._extract_numeric(item.get("price") or item.get("value"))
+                else:
+                    value = self._extract_numeric(item)
+                if value is not None:
+                    take_profits.append(value)
+        fallback_value = self._extract_numeric(fallback_take_profit)
+        if fallback_value is not None and not take_profits:
+            take_profits.append(fallback_value)
+        return take_profits
 
     @staticmethod
     def _map_chart_fetch_status(chart_payload: dict[str, Any]) -> str:


### PR DESCRIPTION
### Motivation
- Нужно генерировать читаемые PNG-снэпшоты графиков для каждой идеи сделки на стороне сервера без браузерного рендеринга и тяжёлых зависимостей.  
- Сохранить существующую бизнес-логику и выдавать null, если нет реальных свечных данных (не фейковые данные).  

### Description
- Реализован `ChartSnapshotService.build_snapshot(...)` на `matplotlib` с тёмной темой и детерминированным рендером свечей, заголовком, зонами, горизонтальными уровнями, уровнями сделки (Entry/SL/TP1..), лёгкими SMC-маркерами, минимальной отрисовкой паттернов, стрелкой направления и компактной легендой; код в `app/services/chart_snapshot_service.py`.  
- Интеграция в `TradeIdeaService`: при создании новой идеи сервис использует `signal.chart_data` (если есть) с fallback на `ChartDataService`, передаёт `bias/confidence/status/markers/patterns/take_profits` в `ChartSnapshotService`, и при отсутствии свечей возвращает `chartImageUrl: null`; изменения в `app/services/trade_idea_service.py`.  
- Добавлены анти-clutter ограничения: лимиты на число зон/уровней/аннотаций, короткие подписи и ограничение числа отрисованных меток, чтобы изображение оставалось читаемым.  
- Файловый вывод: PNG сохраняется по шаблону `/static/charts/{symbol}_{timeframe}_{timestamp}.png`, логируются количество свечей, успех/ошибка и итоговый путь.  

### Testing
- Прогонены тесты `tests/test_idea_update.py::test_trade_idea_updates_without_duplication` и `tests/test_idea_update.py::test_trade_idea_archives_on_tp_and_keeps_history`, оба прошли успешно.  
- Локальная проверка генерации изображения вызовом `ChartSnapshotService.build_snapshot(...)` создала файл вида `/static/charts/EURUSD_H1_20260422090701.png` и вернула относительный путь, проверка прошла успешно.  
- В коде оставлено логирование для контроля количества свечей, статуса генерации и итогового пути файла; при отсутствии свечей snapshot не создаётся и возвращается `null` URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88f0e87ac83319b6a33c73561797f)