### PR TITLE
Нормализация свечей TwelveData в пайплайне идей (фикс Chart unavailable)

### DIFF
--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -95,9 +95,16 @@ class ChartDataService:
                 reason="fetch_error",
             )
 
-        payload = self._normalize_twelvedata_payload(payload)
-        candles = self._normalize_candles(payload.get("candles"))
+        payload, candles = self.normalize_provider_payload(payload)
         provider_status = str(payload.get("status") or "").lower()
+        logger.info(
+            "twelvedata_payload_normalized symbol=%s tf=%s provider_status=%s candle_count=%s keys=%s",
+            normalized_symbol,
+            normalized_tf,
+            provider_status or "unknown",
+            len(candles),
+            sorted(payload.keys()),
+        )
         if not candles:
             if provider_status == "error":
                 logger.warning(
@@ -118,7 +125,7 @@ class ChartDataService:
             return self.build_unavailable_payload(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
-                message_ru="Свечной API не вернул candles для выбранной идеи.",
+                message_ru="Свечной API не вернул candles/values для выбранной идеи.",
                 reason="no_data",
             )
 
@@ -165,15 +172,33 @@ class ChartDataService:
         return normalized
 
     @classmethod
+    def normalize_provider_payload(cls, payload: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        normalized_payload = cls._normalize_twelvedata_payload(payload)
+        raw_candles = normalized_payload.get("candles")
+        candles = cls._normalize_candles(raw_candles)
+        normalized_payload["candles"] = candles
+        if candles:
+            normalized_payload["status"] = "ok"
+        logger.info(
+            "twelvedata_payload_shape status=%s has_values=%s has_candles=%s raw_candles_count=%s normalized_candles_count=%s",
+            normalized_payload.get("status"),
+            isinstance(normalized_payload.get("values"), list),
+            isinstance(raw_candles, list),
+            len(raw_candles) if isinstance(raw_candles, list) else 0,
+            len(candles),
+        )
+        return normalized_payload, candles
+
+    @classmethod
     def _normalize_candles(cls, values: Any) -> list[dict[str, Any]]:
         if not isinstance(values, list):
             return []
 
         candles: list[dict[str, Any]] = []
-        for item in reversed(values):
+        for item in values:
             if not isinstance(item, dict):
                 continue
-            timestamp = cls._parse_timestamp(item.get("datetime"))
+            timestamp = cls._extract_timestamp(item)
             open_price = cls._to_float(item.get("open"))
             high_price = cls._to_float(item.get("high"))
             low_price = cls._to_float(item.get("low"))
@@ -190,7 +215,26 @@ class ChartDataService:
                     "close": close_price,
                 }
             )
+        candles.sort(key=lambda candle: int(candle["time"]))
         return candles
+
+    @classmethod
+    def _extract_timestamp(cls, item: dict[str, Any]) -> int | None:
+        for key in ("time", "timestamp"):
+            numeric_ts = cls._parse_numeric_timestamp(item.get(key))
+            if numeric_ts is not None:
+                return numeric_ts
+        return cls._parse_timestamp(item.get("datetime"))
+
+    @staticmethod
+    def _parse_numeric_timestamp(value: Any) -> int | None:
+        try:
+            parsed = int(float(value))
+        except (TypeError, ValueError):
+            return None
+        if parsed <= 0:
+            return None
+        return parsed
 
     @staticmethod
     def _parse_timestamp(value: Any) -> int | None:

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -695,9 +695,22 @@ class TradeIdeaService:
         chart_data = signal.get("chart_data") if isinstance(signal.get("chart_data"), dict) else {}
         if not chart_data and isinstance(signal.get("chartData"), dict):
             chart_data = signal.get("chartData")
-        candles = chart_data.get("candles") if isinstance(chart_data.get("candles"), list) else []
-        chart_payload: dict[str, Any] = {"status": "ok", "candles": candles}
+        normalized_chart_payload, candles = self.chart_data_service.normalize_provider_payload(chart_data)
+        chart_payload: dict[str, Any] = {
+            "status": normalized_chart_payload.get("status") or "ok",
+            "candles": candles,
+            "meta": normalized_chart_payload.get("meta") if isinstance(normalized_chart_payload.get("meta"), dict) else {},
+            "message_ru": normalized_chart_payload.get("message_ru"),
+        }
         fetch_status = str(chart_payload.get("status") or "ok").lower()
+        logger.info(
+            "idea_snapshot_signal_chart_payload symbol=%s timeframe=%s has_values=%s has_candles=%s normalized_candles=%s",
+            symbol,
+            timeframe,
+            isinstance(chart_data.get("values"), list),
+            isinstance(chart_data.get("candles"), list),
+            len(candles),
+        )
         if not candles:
             chart_payload = self.chart_data_service.get_chart(symbol, timeframe)
             fetch_status = str(chart_payload.get("status") or "").lower()
@@ -789,7 +802,7 @@ class TradeIdeaService:
         message = str(chart_payload.get("message_ru") or "").lower()
         if "limit" in message or "429" in message or "rate" in message:
             return "rate_limited"
-        if "не вернул candles" in message or "пуст" in message or "no data" in message:
+        if "не вернул candles" in message or "не вернул values" in message or "пуст" in message or "no data" in message:
             return "no_data"
         return "no_data"
 


### PR DESCRIPTION
### Motivation
- Исправить проблему, когда ответы TwelveData в поле `values` не доходили до пайплайна идей и снимков, из‑за чего UI показывал «Нет актуальных рыночных данных» / «Chart unavailable». 
- Сохранить текущую архитектуру и поведение идеи, не генерировать синтетические свечи и не менять lifecycle идей. 

### Description
- Добавлен единый метод `ChartDataService.normalize_provider_payload(...)`, который приводит `values -> candles`, нормализует O/H/L/C, поддерживает числовые `time`/`timestamp` и падает на `datetime`, а при наличии свечей помечает `status = "ok"`.
- `get_chart(...)` в `app/services/chart_data_service.py` и путь генерации snapshot в `_resolve_chart_snapshot(...)` в `app/services/trade_idea_service.py` теперь используют эту нормализацию, чтобы upstream payload с `values` корректно превращался в внутренний `payload["candles"]`.
- Нормализованные свечи сортируются по возрастанию по времени, добавлено логирование входной формы провайдера/количества свечей и расширена диагностика `no_data` (сообщение теперь упоминает `candles/values`).
- Изменения ограничены безопасными правками: файлы изменены `app/services/chart_data_service.py` и `app/services/trade_idea_service.py`, логика идей и lifecycle не менялись, снапшоты генерируются только при наличии реальных свечей.

### Testing
- Запущена компиляция проверка синтаксиса: `python -m compileall app/services/chart_data_service.py app/services/trade_idea_service.py` — успешно.
- Выполнена локальная smoke‑проверка `ChartDataService.normalize_provider_payload(...)` на payload с `values` и на payload с `candles` и numeric `time`, оба сценария успешно нормализовали свечи и вернули `status = "ok"` при наличии свечей.
- Поведение восстановления старых идей оставлено неизменным и старые записи будут обновляться через существующий путь `_recover_missing_chart_snapshots` или при следующем refresh; тесты наличия/отсутствия свечей в snapshot‑пути подтверждены логами и успешной генерацией относительных путей `/static/charts/...`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89b65eeb48331af4a66aa41cb8e52)