### PR TITLE
Исправление генерации PNG снапшотов графиков и статуса ошибки снапшота

### DIFF
--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -16,8 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 class ChartSnapshotService:
-    def __init__(self, charts_dir: str = "app/static/charts") -> None:
+    def __init__(self, charts_dir: str = "static/charts") -> None:
         self.charts_dir = Path(charts_dir)
+        os.makedirs("static/charts", exist_ok=True)
         self.charts_dir.mkdir(parents=True, exist_ok=True)
 
     def build_snapshot(
@@ -51,16 +53,16 @@ class ChartSnapshotService:
         absolute_path = self.charts_dir / filename
         relative_path = f"/static/charts/{filename}"
         logger.info(
-            "idea_snapshot_render_start symbol=%s timeframe=%s candles=%s output=%s",
+            "idea_snapshot_start symbol=%s timeframe=%s candles=%s output=%s absolute_path=%s",
             symbol,
             timeframe,
             len(candles),
             relative_path,
+            absolute_path,
         )
 
         fig, ax = plt.subplots(figsize=(12, 7), dpi=100)
         try:
-            x_values = list(range(len(candles)))
             highs = [float(candle["high"]) for candle in candles]
             lows = [float(candle["low"]) for candle in candles]
             closes = [float(candle["close"]) for candle in candles]
@@ -116,11 +118,38 @@ class ChartSnapshotService:
             for spine in ax.spines.values():
                 spine.set_color("#374151")
             fig.tight_layout(rect=[0, 0.035, 1, 0.98])
-            fig.savefig(absolute_path, facecolor=fig.get_facecolor())
-            logger.info("idea_snapshot_success symbol=%s timeframe=%s file=%s", symbol, timeframe, relative_path)
+
+            try:
+                plt.savefig(absolute_path, facecolor=fig.get_facecolor())
+            except Exception as exc:
+                logger.exception(
+                    "idea_snapshot_failed symbol=%s timeframe=%s candles=%s path=%s error=%s",
+                    symbol,
+                    timeframe,
+                    len(candles),
+                    absolute_path,
+                    exc,
+                )
+                return None
+
+            logger.info(
+                "idea_snapshot_success symbol=%s timeframe=%s candles=%s file=%s absolute_path=%s",
+                symbol,
+                timeframe,
+                len(candles),
+                relative_path,
+                absolute_path,
+            )
             return relative_path
-        except Exception:
-            logger.exception("idea_snapshot_failed symbol=%s timeframe=%s", symbol, timeframe)
+        except Exception as exc:
+            logger.exception(
+                "idea_snapshot_failed symbol=%s timeframe=%s candles=%s path=%s error=%s",
+                symbol,
+                timeframe,
+                len(candles),
+                absolute_path,
+                exc,
+            )
             return None
         finally:
             plt.close(fig)

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -744,7 +744,7 @@ class TradeIdeaService:
         )
         if not image_path:
             logger.warning(
-                "idea_snapshot_generation_failed symbol=%s timeframe=%s candles=%s",
+                "idea_snapshot_generation_failed symbol=%s timeframe=%s candles=%s status=snapshot_failed",
                 symbol,
                 timeframe,
                 len(candles),
@@ -758,7 +758,7 @@ class TradeIdeaService:
                     existing_status,
                 )
                 return {"chartImageUrl": existing_url, "status": existing_status}
-            return {"chartImageUrl": None, "status": "fetch_error"}
+            return {"chartImageUrl": None, "status": "snapshot_failed"}
         logger.info("idea_snapshot_final_path symbol=%s timeframe=%s path=%s", symbol, timeframe, image_path)
         return {"chartImageUrl": image_path, "status": "ok"}
 


### PR DESCRIPTION
### Motivation
- Снимки графиков не сохранялись и UI показывал «Chart unavailable», потому что этап сохранения PNG мог молча проваливаться и/или не существовала папка для файлов.
- Требовалось явное логирование ошибок, корректное создание директории и совместимость matplotlib с headless средой.

### Description
- Обновлён `ChartSnapshotService` для записи в `static/charts`, явного создания директории через `os.makedirs("static/charts", exist_ok=True)` и сохранения пути в формате `/static/charts/{symbol}_{timeframe}_{timestamp}.png`.
- Добавлен защитный `try/except` вокруг `plt.savefig(...)`, подробные логи начала/успеха/ошибки с указанием абсолютного пути и текста исключения, и гарантированное закрытие matplotlib через `plt.close(fig)`.
- В `TradeIdeaService` при неуспехе генерации снапшота возвращается статус `snapshot_failed` вместо ранее использовавшегося `fetch_error`, и лог генерации теперь помечает `status=snapshot_failed` при ошибке.
- Файлы изменённые: `app/services/chart_snapshot_service.py` и `app/services/trade_idea_service.py`.

### Testing
- Сборка файлов проверена через `python -m py_compile app/services/chart_snapshot_service.py app/services/trade_idea_service.py` и компиляция прошла успешно.
- Автоматизированный запуск тестового сценария создания снапшота (`ChartSnapshotService.build_snapshot(...)` с синтетическими свечами) подтвердил выдачу URL и создание файла `static/charts/EURUSD_H1_20260422095959.png` (файл существует).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89be4ebe08331a26323736164b245)