### PR TITLE
Улучшение рендеринга графиков до TradingView-подобного вида с SMC-оверлеями

### DIFF
--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -36,6 +36,10 @@ class ChartSnapshotService:
         status: str | None = None,
         markers: list[dict[str, Any]] | None = None,
         patterns: list[dict[str, Any]] | None = None,
+        order_blocks: list[dict[str, Any]] | None = None,
+        liquidity_levels: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        arrows: list[dict[str, Any]] | None = None,
     ) -> str | None:
         if not candles:
             logger.info("idea_snapshot_skipped reason=no_candles symbol=%s timeframe=%s", symbol, timeframe)
@@ -44,6 +48,10 @@ class ChartSnapshotService:
         zones = zones or []
         markers = markers or []
         patterns = patterns or []
+        order_blocks = order_blocks or []
+        liquidity_levels = liquidity_levels or []
+        labels = labels or []
+        arrows = arrows or []
         take_profits = [value for value in (take_profits or []) if value is not None]
 
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
@@ -60,7 +68,7 @@ class ChartSnapshotService:
             absolute_path,
         )
 
-        fig, ax = plt.subplots(figsize=(12, 7), dpi=100)
+        fig, ax = plt.subplots(figsize=(16, 9), dpi=120)
         try:
             highs = [float(candle["high"]) for candle in candles]
             lows = [float(candle["low"]) for candle in candles]
@@ -69,16 +77,28 @@ class ChartSnapshotService:
 
             min_price = min(lows)
             max_price = max(highs)
-            price_padding = (max_price - min_price) * 0.1 if max_price > min_price else max_price * 0.001
+            zone_prices = self._collect_zone_prices(zones + order_blocks)
+            level_prices = self._collect_level_prices(levels + liquidity_levels)
+            trade_prices = [value for value in [entry, stop_loss, *take_profits] if value is not None]
+            all_prices = [*highs, *lows, *zone_prices, *level_prices, *trade_prices]
+            min_price = min(all_prices)
+            max_price = max(all_prices)
+            price_padding = (max_price - min_price) * 0.02 if max_price > min_price else max_price * 0.001
+            y_min = min_price - price_padding
+            y_max = max_price + price_padding
 
-            ax.set_facecolor("#0b1220")
-            fig.patch.set_facecolor("#0b1220")
-            ax.grid(True, color="#1f2937", linewidth=0.6, alpha=0.7)
+            ax.set_facecolor("#08111f")
+            fig.patch.set_facecolor("#08111f")
+            ax.grid(True, color="#334155", linewidth=0.55, alpha=0.35)
 
-            candle_width = 0.6
+            self._draw_zones(ax=ax, zones=zones, candles_count=len(candles), max_price=max_price)
+            self._draw_zones(ax=ax, zones=order_blocks, candles_count=len(candles), max_price=max_price)
+
+            candle_width = 0.82
             for idx, (open_price, high_price, low_price, close_price) in enumerate(zip(opens, highs, lows, closes)):
                 color = "#22c55e" if close_price >= open_price else "#ef4444"
-                ax.vlines(idx, low_price, high_price, color="#cbd5e1", linewidth=0.8, alpha=0.9)
+                wick_color = "#e2e8f0" if close_price >= open_price else "#fca5a5"
+                ax.vlines(idx, low_price, high_price, color=wick_color, linewidth=1.2, alpha=0.95, zorder=3)
                 body_bottom = min(open_price, close_price)
                 body_height = max(0.000001, abs(close_price - open_price))
                 ax.add_patch(
@@ -88,12 +108,13 @@ class ChartSnapshotService:
                         body_height,
                         facecolor=color,
                         edgecolor=color,
-                        linewidth=1.0,
+                        linewidth=1.1,
+                        zorder=4,
                     )
                 )
 
-            self._draw_zones(ax=ax, zones=zones, candles_count=len(candles), max_price=max_price)
             self._draw_horizontal_levels(ax=ax, levels=levels, candles_count=len(candles))
+            self._draw_horizontal_levels(ax=ax, levels=liquidity_levels, candles_count=len(candles))
             self._draw_trade_levels(
                 ax=ax,
                 candles_count=len(candles),
@@ -103,6 +124,8 @@ class ChartSnapshotService:
             )
             rendered = self._draw_smc_markers(ax=ax, markers=markers, candles_count=len(candles))
             rendered += self._draw_patterns(ax=ax, patterns=patterns, candles_count=len(candles))
+            rendered += self._draw_labels(ax=ax, labels=labels, candles_count=len(candles))
+            rendered += self._draw_arrows(ax=ax, arrows=arrows, candles_count=len(candles))
             if rendered < 5:
                 self._draw_direction_hint(ax=ax, candles_count=len(candles), entry=entry, take_profits=take_profits, bias=bias)
 
@@ -110,13 +133,13 @@ class ChartSnapshotService:
             ax.set_title(header, color="#e5e7eb", fontsize=12, fontweight="bold", pad=14)
             self._draw_compact_legend(fig)
             ax.set_xlim(-1, len(candles))
-            ax.set_ylim(min_price - price_padding, max_price + price_padding)
+            ax.set_ylim(y_min, y_max)
             ax.tick_params(colors="#9ca3af", labelsize=8)
-            ax.set_xlabel("Индекс свечи", color="#9ca3af", fontsize=8)
+            ax.set_xlabel("Свечи", color="#9ca3af", fontsize=8)
             ax.set_ylabel("Цена", color="#9ca3af", fontsize=8)
             for spine in ax.spines.values():
                 spine.set_color("#374151")
-            fig.tight_layout(rect=[0, 0.035, 1, 0.98])
+            fig.tight_layout(rect=[0.01, 0.02, 1, 0.98])
 
             success = False
             try:
@@ -173,7 +196,7 @@ class ChartSnapshotService:
             "order_block": {"face": "#f59e0b", "label": "OB"},
             "ob": {"face": "#f59e0b", "label": "OB"},
         }
-        for zone in zones[:5]:
+        for zone in zones[:10]:
             zone_type_raw = str(zone.get("type") or zone.get("kind") or zone.get("label") or "").lower().replace(" ", "_")
             style = styles.get(zone_type_raw, {"face": "#38bdf8", "label": "Zone"})
             price_from = self._to_float(zone.get("from") or zone.get("priceFrom") or zone.get("low"))
@@ -193,22 +216,33 @@ class ChartSnapshotService:
                     height,
                     facecolor=style["face"],
                     edgecolor=style["face"],
-                    alpha=0.16,
-                    linewidth=0.8,
+                    alpha=0.19,
+                    linewidth=1.0,
+                    zorder=1,
                 )
             )
-            ax.text(start_idx, bottom + height / 2, style["label"], color="#e5e7eb", fontsize=7, alpha=0.85)
+            ax.text(
+                start_idx,
+                bottom + height / 2,
+                style["label"],
+                color="#e5e7eb",
+                fontsize=7,
+                alpha=0.9,
+                bbox={"facecolor": "#0f172a", "edgecolor": style["face"], "alpha": 0.55, "boxstyle": "round,pad=0.18"},
+                zorder=6,
+            )
 
     def _draw_horizontal_levels(self, *, ax: Any, levels: list[dict[str, Any]], candles_count: int) -> None:
-        for level in levels[:6]:
+        for level in levels[:12]:
             price = self._to_float(level.get("price") or level.get("value") or level.get("level"))
             if price is None:
                 continue
             level_type = str(level.get("type") or level.get("label") or "Level")
             lowered = level_type.lower()
             style = ":" if "liq" in lowered or "session" in lowered else "--"
-            ax.axhline(price, color="#60a5fa", linewidth=0.9, linestyle=style, alpha=0.8)
-            ax.text(candles_count - 0.1, price, level_type[:14], color="#93c5fd", fontsize=7, ha="right", va="bottom", alpha=0.9)
+            color = "#67e8f9" if "liq" in lowered else "#60a5fa"
+            ax.axhline(price, color=color, linewidth=1.0, linestyle=style, alpha=0.85, zorder=2)
+            ax.text(candles_count - 0.1, price, level_type[:18], color="#bae6fd", fontsize=7, ha="right", va="bottom", alpha=0.95, zorder=7)
 
     def _draw_trade_levels(
         self,
@@ -220,14 +254,14 @@ class ChartSnapshotService:
         take_profits: list[float],
     ) -> None:
         if entry is not None:
-            ax.axhline(entry, color="#facc15", linewidth=1.2, linestyle="-", alpha=0.95)
-            ax.text(candles_count - 0.1, entry, "Entry", color="#fde68a", fontsize=8, ha="right", va="bottom")
+            ax.axhline(entry, color="#facc15", linewidth=1.3, linestyle="-", alpha=0.95, zorder=5)
+            ax.text(candles_count - 0.1, entry, "Entry", color="#fde68a", fontsize=8, ha="right", va="bottom", zorder=8)
         if stop_loss is not None:
-            ax.axhline(stop_loss, color="#ef4444", linewidth=1.2, linestyle="--", alpha=0.95)
-            ax.text(candles_count - 0.1, stop_loss, "SL", color="#fca5a5", fontsize=8, ha="right", va="bottom")
+            ax.axhline(stop_loss, color="#ef4444", linewidth=1.3, linestyle="--", alpha=0.95, zorder=5)
+            ax.text(candles_count - 0.1, stop_loss, "SL", color="#fca5a5", fontsize=8, ha="right", va="bottom", zorder=8)
         for index, tp in enumerate(take_profits[:3], start=1):
-            ax.axhline(tp, color="#22c55e", linewidth=1.1, linestyle="--", alpha=0.92)
-            ax.text(candles_count - 0.1, tp, f"TP{index}", color="#86efac", fontsize=8, ha="right", va="bottom")
+            ax.axhline(tp, color="#22c55e", linewidth=1.2, linestyle="--", alpha=0.92, zorder=5)
+            ax.text(candles_count - 0.1, tp, f"TP{index}", color="#86efac", fontsize=8, ha="right", va="bottom", zorder=8)
 
     def _draw_smc_markers(self, *, ax: Any, markers: list[dict[str, Any]], candles_count: int) -> int:
         allowed = {"bos", "choch", "sweep", "eqh", "eql"}
@@ -241,7 +275,7 @@ class ChartSnapshotService:
             if price is None:
                 continue
             index = max(0, min(index, candles_count - 1))
-            ax.text(index, price, marker_type.upper(), color="#c4b5fd", fontsize=7, alpha=0.85)
+            ax.text(index, price, marker_type.upper(), color="#c4b5fd", fontsize=7, alpha=0.9, zorder=8)
             rendered += 1
             if rendered >= 4:
                 break
@@ -267,11 +301,55 @@ class ChartSnapshotService:
                     xs.append(max(0, min(x_val, candles_count - 1)))
                     ys.append(y_val)
                 if len(xs) >= 2:
-                    ax.plot(xs, ys, color="#f9a8d4", linewidth=0.9, alpha=0.7)
+                    ax.plot(xs, ys, color="#f9a8d4", linewidth=1.0, alpha=0.75, zorder=6)
             label_price = self._to_float(pattern.get("price") or pattern.get("y"))
             label_index = int(pattern.get("index") or pattern.get("x") or candles_count - 3)
             if label_price is not None:
-                ax.text(max(0, min(label_index, candles_count - 1)), label_price, name[:12], color="#fbcfe8", fontsize=7, alpha=0.85)
+                ax.text(max(0, min(label_index, candles_count - 1)), label_price, name[:12], color="#fbcfe8", fontsize=7, alpha=0.9, zorder=8)
+            rendered += 1
+        return rendered
+
+    def _draw_labels(self, *, ax: Any, labels: list[dict[str, Any]], candles_count: int) -> int:
+        rendered = 0
+        for label in labels[:16]:
+            name = str(label.get("text") or label.get("label") or label.get("type") or "").strip()
+            if not name:
+                continue
+            price = self._to_float(label.get("price") or label.get("y") or label.get("value"))
+            index = int(label.get("index") or label.get("x") or label.get("candleIndex") or candles_count - 2)
+            if price is None:
+                continue
+            index = max(0, min(index, candles_count - 1))
+            ax.text(
+                index,
+                price,
+                name[:18],
+                color="#f8fafc",
+                fontsize=7,
+                bbox={"facecolor": "#1e293b", "edgecolor": "#64748b", "alpha": 0.6, "boxstyle": "round,pad=0.16"},
+                zorder=9,
+            )
+            rendered += 1
+        return rendered
+
+    def _draw_arrows(self, *, ax: Any, arrows: list[dict[str, Any]], candles_count: int) -> int:
+        rendered = 0
+        for arrow in arrows[:10]:
+            from_index = int(arrow.get("from_index") or arrow.get("x1") or max(candles_count - 12, 0))
+            to_index = int(arrow.get("to_index") or arrow.get("x2") or candles_count - 2)
+            from_price = self._to_float(arrow.get("from_price") or arrow.get("y1") or arrow.get("start_price"))
+            to_price = self._to_float(arrow.get("to_price") or arrow.get("y2") or arrow.get("end_price"))
+            if from_price is None or to_price is None:
+                continue
+            lowered = str(arrow.get("type") or arrow.get("label") or "").lower()
+            color = "#facc15" if "entry" in lowered else "#a78bfa"
+            ax.annotate(
+                "",
+                xy=(max(0, min(to_index, candles_count - 1)), to_price),
+                xytext=(max(0, min(from_index, candles_count - 1)), from_price),
+                arrowprops={"arrowstyle": "-|>", "color": color, "lw": 1.45, "alpha": 0.9},
+                zorder=10,
+            )
             rendered += 1
         return rendered
 
@@ -317,6 +395,25 @@ class ChartSnapshotService:
             fontsize=7,
             alpha=0.75,
         )
+
+    def _collect_zone_prices(self, zones: list[dict[str, Any]]) -> list[float]:
+        prices: list[float] = []
+        for zone in zones:
+            low = self._to_float(zone.get("from") or zone.get("priceFrom") or zone.get("low"))
+            high = self._to_float(zone.get("to") or zone.get("priceTo") or zone.get("high"))
+            if low is not None:
+                prices.append(low)
+            if high is not None:
+                prices.append(high)
+        return prices
+
+    def _collect_level_prices(self, levels: list[dict[str, Any]]) -> list[float]:
+        prices: list[float] = []
+        for level in levels:
+            price = self._to_float(level.get("price") or level.get("value") or level.get("level"))
+            if price is not None:
+                prices.append(price)
+        return prices
 
     @staticmethod
     def _to_float(value: Any) -> float | None:

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -749,6 +749,19 @@ class TradeIdeaService:
         zones = chart_data.get("zones") if isinstance(chart_data.get("zones"), list) else []
         markers = chart_data.get("markers") if isinstance(chart_data.get("markers"), list) else []
         patterns = signal.get("chart_patterns") if isinstance(signal.get("chart_patterns"), list) else []
+        order_blocks = self._extract_overlay_items(signal=signal, chart_data=chart_data, keys=("order_blocks", "orderBlocks", "ob"))
+        liquidity_levels = self._extract_overlay_items(
+            signal=signal,
+            chart_data=chart_data,
+            keys=("liquidity", "liquidity_levels", "liquidityLevels", "liquidity_areas", "liquidityAreas"),
+        )
+        pattern_items = self._extract_overlay_items(signal=signal, chart_data=chart_data, keys=("patterns",))
+        labels = self._extract_overlay_items(signal=signal, chart_data=chart_data, keys=("labels", "smc_labels", "smcLabels"))
+        arrows = self._extract_overlay_items(signal=signal, chart_data=chart_data, keys=("arrows", "entry_arrows", "structure_arrows"))
+        zones = [*zones, *order_blocks, *self._extract_fvg_zones(pattern_items)]
+        levels = [*levels, *self._liquidity_to_levels(liquidity_levels)]
+        labels = [*labels, *self._patterns_to_labels(pattern_items)]
+        arrows = [*arrows, *self._build_default_trade_arrows(entry=entry, take_profit=take_profit, bias=bias, candles_count=len(candles))]
         take_profits = self._extract_take_profits(signal=signal, fallback_take_profit=take_profit)
         logger.info(
             "snapshot_start symbol=%s timeframe=%s candles=%s has_existing=%s",
@@ -771,6 +784,10 @@ class TradeIdeaService:
             status=status,
             markers=markers,
             patterns=patterns,
+            order_blocks=order_blocks,
+            liquidity_levels=liquidity_levels,
+            labels=labels,
+            arrows=arrows,
         )
         if not image_path:
             logger.warning(
@@ -815,6 +832,96 @@ class TradeIdeaService:
         if fallback_value is not None and not take_profits:
             take_profits.append(fallback_value)
         return take_profits
+
+    @staticmethod
+    def _extract_overlay_items(
+        *,
+        signal: dict[str, Any],
+        chart_data: dict[str, Any],
+        keys: tuple[str, ...],
+    ) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        for key in keys:
+            values = signal.get(key)
+            if isinstance(values, list):
+                items.extend(item for item in values if isinstance(item, dict))
+            chart_values = chart_data.get(key)
+            if isinstance(chart_values, list):
+                items.extend(item for item in chart_values if isinstance(item, dict))
+        return items
+
+    @classmethod
+    def _extract_fvg_zones(cls, patterns: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        zones: list[dict[str, Any]] = []
+        for pattern in patterns:
+            pattern_name = str(pattern.get("type") or pattern.get("name") or "").lower()
+            if "fvg" not in pattern_name and "imbalance" not in pattern_name:
+                continue
+            low = cls._extract_numeric(pattern.get("low") or pattern.get("price_from"))
+            high = cls._extract_numeric(pattern.get("high") or pattern.get("price_to"))
+            if low is None or high is None:
+                continue
+            zones.append(
+                {
+                    "type": "fvg",
+                    "from": low,
+                    "to": high,
+                    "startIndex": pattern.get("startIndex") or pattern.get("start") or 0,
+                    "endIndex": pattern.get("endIndex") or pattern.get("end") or 9999,
+                }
+            )
+        return zones
+
+    @classmethod
+    def _liquidity_to_levels(cls, liquidity: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        levels: list[dict[str, Any]] = []
+        for item in liquidity:
+            price = cls._extract_numeric(item.get("price") or item.get("value") or item.get("level"))
+            if price is None:
+                continue
+            level_label = str(item.get("label") or item.get("type") or "Liquidity")
+            levels.append({"price": price, "type": level_label})
+        return levels
+
+    @staticmethod
+    def _patterns_to_labels(patterns: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        labels: list[dict[str, Any]] = []
+        allowed = ("bos", "choch", "liquidity", "sweep", "ob", "fvg")
+        for item in patterns:
+            name = str(item.get("type") or item.get("name") or "").strip()
+            if not name or not any(token in name.lower() for token in allowed):
+                continue
+            price = item.get("price") or item.get("y") or item.get("value")
+            idx = item.get("index") or item.get("x") or item.get("candleIndex")
+            labels.append({"text": name.upper(), "price": price, "index": idx})
+        return labels
+
+    @classmethod
+    def _build_default_trade_arrows(
+        cls,
+        *,
+        entry: float | None,
+        take_profit: float | None,
+        bias: str,
+        candles_count: int,
+    ) -> list[dict[str, Any]]:
+        entry_price = cls._extract_numeric(entry)
+        target_price = cls._extract_numeric(take_profit)
+        if entry_price is None or target_price is None:
+            return []
+        start = max(candles_count - 14, 1)
+        end = candles_count - 2
+        direction = str(bias or "").lower()
+        arrow_type = "entry" if direction in {"bullish", "bearish"} else "structure"
+        return [
+            {
+                "type": arrow_type,
+                "from_index": start,
+                "to_index": end,
+                "from_price": entry_price,
+                "to_price": target_price,
+            }
+        ]
 
     @staticmethod
     def _map_chart_fetch_status(chart_payload: dict[str, Any]) -> str:


### PR DESCRIPTION
### Motivation
- Снипшоты графиков были слишком узкими и без SMC-данных; цель — получить полноформатные, читаемые снимки в тёмной теме, похожие на TradingView.
- Нужно отрисовывать все SMC-элементы (зоны, order blocks, FVG, уровни, метки, стрелки, trade lines) и уплотнить Y-оси вокруг всех оверлеев. 
- Исправить pipeline: извлекать оверлеи из JSON идеи/signal и передавать их в `chart_snapshot_service` для корректного рендера.

### Description
- Обновлён `app/services/chart_snapshot_service.py`: увеличен холст до `16x9` и DPI, сменена тёмная тема на `#08111f`, улучшены тела свечей/фитили, уменьшены пустые отступы и добавлена плотная авто‑масштабировка Y с учётом оверлеев. 
- В `ChartSnapshotService.build_snapshot(...)` добавлены новые параметры `order_blocks`, `liquidity_levels`, `labels`, `arrows` и реализованы новые отрисовщики `_draw_labels`, `_draw_arrows`, `_collect_zone_prices`, `_collect_level_prices`; порядок рендера приведён к: зоны → свечи → уровни → trade lines → метки → стрелки. 
- Обновлён `app/services/trade_idea_service.py`: добавлен сбор и нормализация overlay-данных из `signal`/`chart_data` через `_extract_overlay_items`, `_extract_fvg_zones`, `_liquidity_to_levels`, `_patterns_to_labels` и построение fallback-стрелок `_build_default_trade_arrows`, после чего новые структуры передаются в `build_snapshot`. 
- Файлы изменены: `app/services/chart_snapshot_service.py` и `app/services/trade_idea_service.py` (см. изменения для точных патчей и маппинга). 
- Mapping (idea data → chart overlays): `zones`/`chart_data.zones` → zone overlays; `order_blocks`/`orderBlocks`/`ob` → OB-зоны; `patterns` с `fvg`/`imbalance` → FVG-зоны; `liquidity*` → горизонтальные уровни; `patterns` (BOS/CHoCH/Liquidity/Sweep/OB/FVG) → labels; `arrows`/fallback `entry→take_profit` → стрелки.

### Testing
- Запущены автоматические тесты `pytest -q tests/test_chart_api.py tests/test_idea_update.py` и завершились успешно (всего `14 passed`).
- Все изменения сохраняют существующие контракты маршрутов и не ломают тесты интеграции чарта.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ad227ae48331b50457e87115e2ab)