### PR TITLE
Backend SMC-движок и интеграция оверлеев в snapshot-рендер

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,3 +355,10 @@ TWELVEDATA_OUTPUTSIZE=50
 - При сломе сценария идея помечается как `invalidated`, а при новом lifecycle создаётся новая запись.
 - Это поведение реализовано без радикального изменения текущего UI: список на `/ideas` оставлен компактным, а depth анализа перенесён в modal full card.
 - Sentiment внутри trade idea используется только как дополнительный контекст и не даёт гарантий результата.
+
+## Backend SMC overlays (server-side only)
+- Добавлен backend-движок `app/services/smc_engine.py`, который считает SMC-структуры по реальным свечам (`candles`) и формирует готовый overlay payload.
+- Детекция выполняется только на сервере: Swing High/Low, BOS, CHoCH, EQH/EQL, liquidity pools, FVG/imbalance и bullish/bearish order blocks.
+- `TradeIdeaService` теперь запускает SMC engine после получения свечей, прикрепляет `smc_overlays` к payload идеи и передаёт эти данные в snapshot renderer.
+- `ChartSnapshotService` рисует уже готовые backend overlays (zones/levels/labels/arrows/patterns) без frontend-вычислений.
+- Frontend по-прежнему только потребляет `chartImageUrl` и metadata, без JS-детекции SMC.

--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -36,6 +36,7 @@ class ChartSnapshotService:
         confidence: int | None = None,
         status: str | None = None,
         markers: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
         patterns: list[dict[str, Any]] | None = None,
         arrows: list[dict[str, Any]] | None = None,
         setup_text: str | None = None,
@@ -46,6 +47,7 @@ class ChartSnapshotService:
         levels = levels or []
         zones = zones or []
         markers = markers or []
+        labels = labels or []
         patterns = patterns or []
         arrows = arrows or []
         take_profits = [value for value in (take_profits or []) if value is not None]
@@ -107,7 +109,8 @@ class ChartSnapshotService:
                 stop_loss=stop_loss,
                 take_profits=take_profits,
             )
-            rendered = self._draw_smc_markers(ax=ax, markers=markers, candles_count=len(candles))
+            merged_markers = labels + markers
+            rendered = self._draw_smc_markers(ax=ax, markers=merged_markers, candles_count=len(candles))
             rendered += self._draw_arrows(ax=ax, arrows=arrows, candles_count=len(candles), highs=highs, lows=lows)
             rendered += self._draw_patterns(ax=ax, patterns=patterns, candles_count=len(candles))
             if rendered < 5:
@@ -134,7 +137,7 @@ class ChartSnapshotService:
                 padding=price_padding,
                 levels=levels,
                 zones=zones,
-                markers=markers,
+                markers=merged_markers,
                 entry=entry,
                 stop_loss=stop_loss,
                 take_profits=take_profits,

--- a/app/services/smc_engine.py
+++ b/app/services/smc_engine.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class SwingPoint:
+    index: int
+    price: float
+    kind: str  # high | low
+
+
+class SmcEngine:
+    """Детерминированный backend-движок для SMC-overlays."""
+
+    def analyze(
+        self,
+        *,
+        candles: list[dict[str, Any]],
+        symbol: str,
+        timeframe: str,
+        bias: str | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        normalized = self._normalize_candles(candles)
+        if len(normalized) < 7:
+            return self._empty_payload(symbol=symbol, timeframe=timeframe, bias=bias)
+
+        swings = self._find_swings(normalized)
+        swing_highs = [point for point in swings if point.kind == "high"]
+        swing_lows = [point for point in swings if point.kind == "low"]
+
+        labels: list[dict[str, Any]] = []
+        levels: list[dict[str, Any]] = []
+        zones: list[dict[str, Any]] = []
+        arrows: list[dict[str, Any]] = []
+        patterns: list[dict[str, Any]] = []
+
+        eq_highs = self._find_equal_swings(swing_highs, price_key="high")
+        eq_lows = self._find_equal_swings(swing_lows, price_key="low")
+        labels.extend(eq_highs + eq_lows)
+
+        for marker in eq_highs:
+            levels.append(
+                {
+                    "type": "liquidity",
+                    "label": "Buy-side liquidity",
+                    "price": marker["price"],
+                    "start_index": marker["index"],
+                }
+            )
+        for marker in eq_lows:
+            levels.append(
+                {
+                    "type": "liquidity",
+                    "label": "Sell-side liquidity",
+                    "price": marker["price"],
+                    "start_index": marker["index"],
+                }
+            )
+
+        fvg_zones = self._find_fvg(normalized)
+        zones.extend(fvg_zones)
+
+        structure_labels, structure_arrows, ob_zones = self._find_structure_and_ob(
+            candles=normalized,
+            swing_highs=swing_highs,
+            swing_lows=swing_lows,
+        )
+        labels.extend(structure_labels)
+        arrows.extend(structure_arrows)
+        zones.extend(ob_zones)
+
+        liquidity_zones = self._find_liquidity_pools(eq_highs=eq_highs, eq_lows=eq_lows, candles=normalized)
+        zones.extend(liquidity_zones)
+
+        range_pattern = self._find_range_pattern(eq_highs=eq_highs, eq_lows=eq_lows)
+        if range_pattern:
+            patterns.append(range_pattern)
+
+        return {
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "bias": bias,
+            "source": "backend_smc_engine",
+            "zones": zones[:16],
+            "levels": levels[:16],
+            "labels": labels[:24],
+            "arrows": arrows[:12],
+            "patterns": patterns[:8],
+            "meta": {
+                "candles": len(normalized),
+                "swings": len(swings),
+                "swing_highs": len(swing_highs),
+                "swing_lows": len(swing_lows),
+            },
+        }
+
+    @staticmethod
+    def _empty_payload(*, symbol: str, timeframe: str, bias: str | None) -> dict[str, Any]:
+        return {
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "bias": bias,
+            "source": "backend_smc_engine",
+            "zones": [],
+            "levels": [],
+            "labels": [],
+            "arrows": [],
+            "patterns": [],
+            "meta": {"candles": 0, "swings": 0, "swing_highs": 0, "swing_lows": 0},
+        }
+
+    @staticmethod
+    def _normalize_candles(candles: list[dict[str, Any]]) -> list[dict[str, float]]:
+        normalized: list[dict[str, float]] = []
+        for candle in candles:
+            try:
+                normalized.append(
+                    {
+                        "open": float(candle["open"]),
+                        "high": float(candle["high"]),
+                        "low": float(candle["low"]),
+                        "close": float(candle["close"]),
+                    }
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+        return normalized
+
+    def _find_swings(self, candles: list[dict[str, float]], window: int = 2) -> list[SwingPoint]:
+        swings: list[SwingPoint] = []
+        for idx in range(window, len(candles) - window):
+            high = candles[idx]["high"]
+            low = candles[idx]["low"]
+            left = candles[idx - window : idx]
+            right = candles[idx + 1 : idx + 1 + window]
+            if all(high > bar["high"] for bar in left + right):
+                swings.append(SwingPoint(index=idx, price=high, kind="high"))
+            if all(low < bar["low"] for bar in left + right):
+                swings.append(SwingPoint(index=idx, price=low, kind="low"))
+        swings.sort(key=lambda item: item.index)
+        return swings
+
+    def _find_equal_swings(self, swings: list[SwingPoint], *, price_key: str) -> list[dict[str, Any]]:
+        markers: list[dict[str, Any]] = []
+        if len(swings) < 2:
+            return markers
+        label = "EQH" if price_key == "high" else "EQL"
+        for prev, current in zip(swings, swings[1:]):
+            tolerance = max(abs(prev.price), 1.0) * 0.00035
+            if abs(current.price - prev.price) <= tolerance:
+                markers.append(
+                    {
+                        "type": "eqh" if price_key == "high" else "eql",
+                        "text": label,
+                        "label": label,
+                        "index": current.index,
+                        "price": current.price,
+                        "start_index": prev.index,
+                    }
+                )
+        return markers
+
+    def _find_fvg(self, candles: list[dict[str, float]]) -> list[dict[str, Any]]:
+        zones: list[dict[str, Any]] = []
+        for idx in range(2, len(candles)):
+            left = candles[idx - 2]
+            current = candles[idx]
+            if current["low"] > left["high"]:
+                zones.append(
+                    {
+                        "type": "fvg",
+                        "label": "Bullish FVG",
+                        "direction": "bullish",
+                        "start_index": idx - 2,
+                        "end_index": idx,
+                        "low": left["high"],
+                        "high": current["low"],
+                    }
+                )
+            elif left["low"] > current["high"]:
+                zones.append(
+                    {
+                        "type": "fvg",
+                        "label": "Bearish FVG",
+                        "direction": "bearish",
+                        "start_index": idx - 2,
+                        "end_index": idx,
+                        "low": current["high"],
+                        "high": left["low"],
+                    }
+                )
+        return zones
+
+    def _find_structure_and_ob(
+        self,
+        *,
+        candles: list[dict[str, float]],
+        swing_highs: list[SwingPoint],
+        swing_lows: list[SwingPoint],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+        labels: list[dict[str, Any]] = []
+        arrows: list[dict[str, Any]] = []
+        zones: list[dict[str, Any]] = []
+
+        highs_by_index = {point.index: point for point in swing_highs}
+        lows_by_index = {point.index: point for point in swing_lows}
+        last_swing_high: SwingPoint | None = None
+        last_swing_low: SwingPoint | None = None
+        trend: str | None = None
+
+        for idx, candle in enumerate(candles):
+            if idx in highs_by_index:
+                last_swing_high = highs_by_index[idx]
+            if idx in lows_by_index:
+                last_swing_low = lows_by_index[idx]
+
+            close_price = candle["close"]
+            if last_swing_high and idx > last_swing_high.index and close_price > last_swing_high.price:
+                event = "bos" if trend in {None, "bullish"} else "choch"
+                trend = "bullish"
+                labels.append({"type": event, "text": event.upper(), "index": idx, "price": last_swing_high.price})
+                arrows.append(
+                    {
+                        "type": "structure",
+                        "label": event.upper(),
+                        "from_index": max(last_swing_high.index, idx - 4),
+                        "to_index": idx,
+                        "from_price": last_swing_high.price,
+                        "to_price": close_price,
+                        "direction": "up",
+                    }
+                )
+                ob = self._last_opposite_candle_zone(candles=candles, break_index=idx, bullish=True)
+                if ob:
+                    zones.append(ob)
+                last_swing_high = None
+
+            if last_swing_low and idx > last_swing_low.index and close_price < last_swing_low.price:
+                event = "bos" if trend in {None, "bearish"} else "choch"
+                trend = "bearish"
+                labels.append({"type": event, "text": event.upper(), "index": idx, "price": last_swing_low.price})
+                arrows.append(
+                    {
+                        "type": "structure",
+                        "label": event.upper(),
+                        "from_index": max(last_swing_low.index, idx - 4),
+                        "to_index": idx,
+                        "from_price": last_swing_low.price,
+                        "to_price": close_price,
+                        "direction": "down",
+                    }
+                )
+                ob = self._last_opposite_candle_zone(candles=candles, break_index=idx, bullish=False)
+                if ob:
+                    zones.append(ob)
+                last_swing_low = None
+
+        return labels, arrows, zones
+
+    def _last_opposite_candle_zone(self, *, candles: list[dict[str, float]], break_index: int, bullish: bool) -> dict[str, Any] | None:
+        start = max(0, break_index - 12)
+        selected_index: int | None = None
+        for idx in range(break_index - 1, start - 1, -1):
+            bar = candles[idx]
+            is_bearish = bar["close"] < bar["open"]
+            is_bullish = bar["close"] > bar["open"]
+            if bullish and is_bearish:
+                selected_index = idx
+                break
+            if (not bullish) and is_bullish:
+                selected_index = idx
+                break
+        if selected_index is None:
+            return None
+
+        selected = candles[selected_index]
+        ob_type = "bullish_order_block" if bullish else "bearish_order_block"
+        return {
+            "type": "order_block",
+            "subtype": ob_type,
+            "label": "Bullish OB" if bullish else "Bearish OB",
+            "start_index": selected_index,
+            "end_index": min(selected_index + 8, len(candles) - 1),
+            "low": selected["low"],
+            "high": selected["high"],
+            "direction": "bullish" if bullish else "bearish",
+        }
+
+    @staticmethod
+    def _find_liquidity_pools(
+        *,
+        eq_highs: list[dict[str, Any]],
+        eq_lows: list[dict[str, Any]],
+        candles: list[dict[str, float]],
+    ) -> list[dict[str, Any]]:
+        zones: list[dict[str, Any]] = []
+        for marker in eq_highs[:3]:
+            zones.append(
+                {
+                    "type": "liquidity",
+                    "label": "Buy-side liquidity",
+                    "start_index": max(0, int(marker.get("start_index") or marker.get("index", 0)) - 1),
+                    "end_index": min(len(candles) - 1, int(marker.get("index", 0)) + 6),
+                    "low": float(marker["price"]) * 0.9997,
+                    "high": float(marker["price"]) * 1.0003,
+                }
+            )
+        for marker in eq_lows[:3]:
+            zones.append(
+                {
+                    "type": "liquidity",
+                    "label": "Sell-side liquidity",
+                    "start_index": max(0, int(marker.get("start_index") or marker.get("index", 0)) - 1),
+                    "end_index": min(len(candles) - 1, int(marker.get("index", 0)) + 6),
+                    "low": float(marker["price"]) * 0.9997,
+                    "high": float(marker["price"]) * 1.0003,
+                }
+            )
+        return zones
+
+    @staticmethod
+    def _find_range_pattern(*, eq_highs: list[dict[str, Any]], eq_lows: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if not eq_highs or not eq_lows:
+            return None
+        last_high = eq_highs[-1]
+        last_low = eq_lows[-1]
+        start_idx = min(int(last_high.get("index", 0)), int(last_low.get("index", 0)))
+        end_idx = max(int(last_high.get("index", 0)), int(last_low.get("index", 0)))
+        if end_idx - start_idx < 2:
+            return None
+        low = min(float(last_high["price"]), float(last_low["price"]))
+        high = max(float(last_high["price"]), float(last_low["price"]))
+        return {
+            "type": "range",
+            "label": "Accumulation" if end_idx - start_idx > 8 else "Compression",
+            "start_index": start_idx,
+            "end_index": end_idx,
+            "low": low,
+            "high": high,
+            "price": high,
+            "index": end_idx,
+        }

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -14,6 +14,7 @@ import requests
 from app.core.env import get_openrouter_api_key, get_openrouter_model
 from app.services.chart_data_service import ChartDataService
 from app.services.chart_snapshot_service import ChartSnapshotService
+from app.services.smc_engine import SmcEngine
 from app.services.idea_narrative_llm import IdeaNarrativeLLMService
 from app.services.narrative_generator import generate_signal_preview_text, generate_signal_text
 from app.services.storage.json_storage import JsonStorage
@@ -66,6 +67,7 @@ class TradeIdeaService:
         self.data_provider = DataProvider()
         self.chart_data_service = chart_data_service or ChartDataService()
         self.chart_snapshot_service = ChartSnapshotService()
+        self.smc_engine = SmcEngine()
         self.refresh_interval_seconds = int(os.getenv("IDEAS_REFRESH_INTERVAL_SECONDS", "180"))
         self.idea_store = JsonStorage("signals_data/trade_ideas.json", {"updated_at_utc": None, "ideas": []})
         self.snapshot_store = JsonStorage("signals_data/trade_idea_snapshots.json", {"snapshots": []})
@@ -660,6 +662,12 @@ class TradeIdeaService:
             "chartImageUrl": chart_snapshot["chartImageUrl"],
             "chart_snapshot_status": chart_snapshot["status"],
             "chartSnapshotStatus": chart_snapshot["status"],
+            "smc_overlays": chart_snapshot.get("smc_overlays") or {},
+            "zones": (chart_snapshot.get("smc_overlays") or {}).get("zones", []),
+            "levels": (chart_snapshot.get("smc_overlays") or {}).get("levels", []),
+            "labels": (chart_snapshot.get("smc_overlays") or {}).get("labels", []),
+            "arrows": (chart_snapshot.get("smc_overlays") or {}).get("arrows", []),
+            "patterns": (chart_snapshot.get("smc_overlays") or {}).get("patterns", []),
             "history": history,
             "updates": updates,
             "current_reasoning": decision_payload.get("explanation_ru"),
@@ -735,7 +743,11 @@ class TradeIdeaService:
                 timeframe,
                 failure_status,
             )
-            return {"chartImageUrl": None, "status": failure_status}
+            return {
+                "chartImageUrl": None,
+                "status": failure_status,
+                "smc_overlays": self.smc_engine.analyze(candles=[], symbol=symbol, timeframe=timeframe, bias=bias),
+            }
         if fetch_status != "ok":
             logger.info(
                 "idea_snapshot_candle_override symbol=%s timeframe=%s payload_status=%s effective_status=ok candles=%s",
@@ -745,7 +757,18 @@ class TradeIdeaService:
                 len(candles),
             )
 
-        levels, zones, markers, patterns, arrows = self._extract_snapshot_overlays(signal=signal, chart_data=chart_data)
+        smc_overlays = self.smc_engine.analyze(
+            candles=candles,
+            symbol=symbol,
+            timeframe=timeframe,
+            bias=bias,
+            context={"status": status},
+        )
+        levels, zones, markers, patterns, arrows = self._extract_snapshot_overlays(
+            signal=signal,
+            chart_data=chart_data,
+            smc_overlays=smc_overlays,
+        )
         take_profits = self._extract_take_profits(signal=signal, fallback_take_profit=take_profit)
         logger.info(
             "snapshot_start symbol=%s timeframe=%s candles=%s has_existing=%s",
@@ -767,6 +790,7 @@ class TradeIdeaService:
             confidence=confidence,
             status=status,
             markers=markers,
+            labels=smc_overlays.get("labels"),
             patterns=patterns,
             arrows=arrows,
             setup_text=signal.get("short_scenario_ru") or signal.get("short_text") or signal.get("summary_ru"),
@@ -786,8 +810,8 @@ class TradeIdeaService:
                     existing_url,
                     existing_status,
                 )
-                return {"chartImageUrl": existing_url, "status": "snapshot_failed"}
-            return {"chartImageUrl": None, "status": "snapshot_failed"}
+                return {"chartImageUrl": existing_url, "status": "snapshot_failed", "smc_overlays": smc_overlays}
+            return {"chartImageUrl": None, "status": "snapshot_failed", "smc_overlays": smc_overlays}
         logger.info(
             "snapshot_success symbol=%s timeframe=%s candles=%s path=%s",
             symbol,
@@ -795,7 +819,7 @@ class TradeIdeaService:
             len(candles),
             image_path,
         )
-        return {"chartImageUrl": image_path, "status": "ok"}
+        return {"chartImageUrl": image_path, "status": "ok", "smc_overlays": smc_overlays}
 
     def _extract_take_profits(self, *, signal: dict[str, Any], fallback_take_profit: float | None) -> list[float]:
         candidates = signal.get("take_profits")
@@ -820,7 +844,9 @@ class TradeIdeaService:
         *,
         signal: dict[str, Any],
         chart_data: dict[str, Any],
+        smc_overlays: dict[str, Any] | None = None,
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+        smc_overlays = smc_overlays if isinstance(smc_overlays, dict) else {}
         levels = self._pick_dict_list(signal, chart_data, "levels", "horizontal_levels", "key_levels", "liquidity_levels", "session_levels")
         zones = self._pick_dict_list(
             signal,
@@ -846,6 +872,11 @@ class TradeIdeaService:
         )
         arrows = self._pick_dict_list(signal, chart_data, "arrows", "directional_arrows", "narrative_arrows")
         patterns = self._pick_dict_list(signal, chart_data, "patterns", "chart_patterns", "harmonic_patterns")
+        levels = [item for item in (smc_overlays.get("levels") or []) if isinstance(item, dict)] + levels
+        zones = [item for item in (smc_overlays.get("zones") or []) if isinstance(item, dict)] + zones
+        markers = [item for item in (smc_overlays.get("labels") or []) if isinstance(item, dict)] + markers
+        arrows = [item for item in (smc_overlays.get("arrows") or []) if isinstance(item, dict)] + arrows
+        patterns = [item for item in (smc_overlays.get("patterns") or []) if isinstance(item, dict)] + patterns
 
         normalized_zones = [self._normalize_zone_overlay(item) for item in zones]
         normalized_markers = [self._normalize_marker_overlay(item) for item in markers]

--- a/tests/analysis/test_smc_engine.py
+++ b/tests/analysis/test_smc_engine.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from app.services.smc_engine import SmcEngine
+
+
+def _candles() -> list[dict[str, float]]:
+    return [
+        {"open": 1.1000, "high": 1.1010, "low": 1.0990, "close": 1.1008},
+        {"open": 1.1008, "high": 1.1015, "low": 1.1001, "close": 1.1012},
+        {"open": 1.1012, "high": 1.1020, "low": 1.1005, "close": 1.1007},
+        {"open": 1.1007, "high": 1.1011, "low": 1.0998, "close": 1.1002},
+        {"open": 1.1002, "high": 1.1006, "low": 1.0992, "close": 1.0995},
+        {"open": 1.0995, "high": 1.1003, "low": 1.0990, "close": 1.1001},
+        {"open": 1.1001, "high": 1.1018, "low": 1.0999, "close": 1.1016},
+        {"open": 1.1016, "high": 1.1024, "low": 1.1012, "close": 1.1022},
+        {"open": 1.1022, "high": 1.1026, "low": 1.1015, "close": 1.1017},
+        {"open": 1.1017, "high": 1.1020, "low": 1.1007, "close": 1.1009},
+        {"open": 1.1009, "high": 1.1012, "low": 1.1001, "close": 1.1004},
+        {"open": 1.1004, "high": 1.1010, "low": 1.0996, "close": 1.0998},
+        {"open": 1.0998, "high": 1.1000, "low": 1.0989, "close": 1.0991},
+        {"open": 1.0991, "high": 1.0998, "low": 1.0988, "close": 1.0996},
+        {"open": 1.0996, "high": 1.1005, "low": 1.0992, "close": 1.1003},
+    ]
+
+
+def test_smc_engine_builds_backend_overlays() -> None:
+    engine = SmcEngine()
+
+    payload = engine.analyze(candles=_candles(), symbol="EURUSD", timeframe="M15", bias="bullish")
+
+    assert payload["source"] == "backend_smc_engine"
+    assert payload["symbol"] == "EURUSD"
+    assert payload["timeframe"] == "M15"
+    assert isinstance(payload["zones"], list)
+    assert isinstance(payload["levels"], list)
+    assert isinstance(payload["labels"], list)
+    assert isinstance(payload["arrows"], list)
+    assert isinstance(payload["patterns"], list)
+
+    label_types = {row.get("type") for row in payload["labels"]}
+    assert label_types & {"bos", "choch", "eqh", "eql"}
+
+    zone_types = {row.get("type") for row in payload["zones"]}
+    assert zone_types & {"fvg", "order_block", "liquidity"}


### PR DESCRIPTION
### Motivation
- Перенести всю логику SMC (order blocks, FVG, liquidity, BOS/CHoCH и т.д.) на сервер, чтобы фронтенд только отображал уже готовые оверлеи и снимки графиков. 
- Сохранить текущий snapshot-based рендеринг и не выполнять вычисления SMC в браузере. 
- Сделать детерминированную, простую и безопасную серверную реализацию без глобальной перестройки архитектуры.

### Description
- Добавлен новый backend-модуль `app/services/smc_engine.py`, реализующий `SmcEngine.analyze(...)` и возвращающий chart-friendly payload с `zones`, `levels`, `labels`, `arrows`, `patterns` и `meta` по реальным свечам. 
- В `TradeIdeaService` инициализирован `SmcEngine` и интегрирован вызов движка в `_resolve_chart_snapshot(...)`, результат прикрепляется к идее как `smc_overlays` и дополнительно пробрасывается в верхнеуровневые поля `zones/levels/labels/arrows/patterns`. 
- `ChartSnapshotService` расширен для приёма `labels` и объединяет backend `labels` с `markers` при рендере, чтобы отобразить backend-оверлеи на генерируемом PNG без браузерных расчётов. 
- Добавлен тест `tests/analysis/test_smc_engine.py` и обновлён `README.md` с описанием server-side SMC flow.

### Testing
- Запущены автоматические тесты: `pytest -q tests/analysis/test_smc_engine.py tests/test_chart_api.py tests/api/test_ideas_api.py`, все тесты успешно прошли (`24 passed`, с предупреждениями). 
- Новый тест `tests/analysis/test_smc_engine.py` проверяет форму payload и наличие ключевых типов оверлеев (`fvg`, `order_block`, `liquidity`, `bos`/`choch`/`eqh`/`eql`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ae8aec708331b8850a8270f32daf)