### PR TITLE
Нарративы: переход на формат ПРИЧИНА → ЭФФЕКТ → ДЕЙСТВИЕ

### DIFF
--- a/app/services/idea_narrative_llm.py
+++ b/app/services/idea_narrative_llm.py
@@ -159,15 +159,20 @@ class IdeaNarrativeLLMService:
             "Сформируй объяснение торговой идеи только из переданных фактов.\n"
             "Запрещено придумывать новые уровни, направление, статус или причины вне фактов.\n"
             "Ты пишешь как SMC/ICT-трейдер: жёсткая причинно-следственная логика без общих формулировок.\n"
+            "Во всех объяснениях соблюдай порядок CAUSE → EFFECT → ACTION.\n"
+            "full_text верни строго в 3 блока с заголовками: CAUSE:, EFFECT:, ACTION:.\n"
+            "В каждом блоке максимум 1–2 коротких предложения, без повторов символа/таймфрейма и без воды.\n"
             f"Запрещённые фразы: {', '.join(banned)}.\n"
             "Если в фактах нет liquidity_sweep / structure_state / key_zone / location — явно напиши: "
             "\"структурных подтверждений недостаточно\".\n"
             "Если SMC-факты неполные, добавь: \"структурная база слабая, идея основана на вторичных факторах\".\n"
             "Нельзя использовать формулировку \"после коррекции\"; используй только: "
             "\"после снятия ликвидности\", \"после ложного пробоя\", \"после возврата в order block\".\n"
-            "full_text обязан идти в порядке: "
-            "[1] liquidity event, [2] structure state, [3] premium/discount location, [4] confirmation, "
-            "[5] trade logic entry/SL/TP, [6] risk/invalidation.\n"
+            "Логическая цепочка обязательна минимум одна: "
+            "например, liquidity sweep → sellers/buyers entered → continuation/reversal expected.\n"
+            "CAUSE должен описывать: liquidity sweep / реакцию от зоны / BOS-CHoCH / imbalance.\n"
+            "EFFECT должен описывать: continuation или reversal и статус структуры.\n"
+            "ACTION должен описывать: buy/sell/wait, условие входа, и когда no trade.\n"
             "Обязательно объясни уровни: почему вход в зоне OB/FVG/ликвидности, почему SL за снятой ликвидностью "
             "или по инвалидации структуры, почему TP на следующем пуле ликвидности/заполнении имбаланса.\n"
             "В full_text обязательно должен встретиться минимум один термин: liquidity/ликвидность/sweep/BOS/CHoCH/order block/FVG.\n"
@@ -199,22 +204,25 @@ class IdeaNarrativeLLMService:
         structural_warning = "структурных подтверждений недостаточно. " if smc_missing else ""
         weak_structure_warning = "структурная база слабая, идея основана на вторичных факторах. " if smc_missing else ""
         full = (
-            f"{symbol} {timeframe}: после снятия ликвидности ({liquidity}) цена показала {structure}. "
-            f"Локация {location}, рабочая зона {key_zone}. "
-            f"Подтверждение ищем по объёму и delta без конфликта со структурой. "
-            f"Вход у {entry} от {key_zone}; SL {sl} — {invalidation_logic}; TP {tp} — следующий пул ликвидности {target_liquidity}. "
-            f"{structural_warning}{weak_structure_warning}"
-            f"Событие: {event_type}. Изменения: {delta_text}."
+            "CAUSE:\n"
+            f"{symbol} {timeframe}: после снятия ликвидности ({liquidity}) цена дала {structure} в зоне {key_zone} ({location}). "
+            f"{structural_warning}{weak_structure_warning}\n\n"
+            "EFFECT:\n"
+            f"Снятие ликвидности → реакция участников → цель к следующему пулу {target_liquidity}. "
+            "Структура считается рабочей, пока нет инвалидации.\n\n"
+            "ACTION:\n"
+            f"Рабочий план: вход {entry}, SL {sl} ({invalidation_logic}), TP {tp}. "
+            f"Если структура ломается, no trade. Событие: {event_type}. Изменения: {delta_text}."
         )
         return {
             "headline": f"{symbol} {timeframe} — {direction}",
             "summary": short,
-            "cause": "После снятия ликвидности и реакции в ключевой SMC-зоне сценарий строится только по подтверждённым фактам.",
-            "confirmation": "Подтверждение фиксируется только при совпадении структуры, объёма и дельты с расчётным сценарием.",
+            "cause": "CAUSE: liquidity sweep и реакция в ключевой SMC-зоне подтверждают исходную причину идеи.",
+            "confirmation": "EFFECT: структура подтверждается только при совпадении BOS/CHoCH, объёма и дельты.",
             "risk": "Риск контролируется заранее рассчитанным стоп-уровнем.",
             "invalidation": f"Инвалидация: {invalidation_logic}.",
             "target_logic": f"Цель берётся из расчётного TP {tp} как следующий пул ликвидности ({target_liquidity}).",
-            "update_explanation": f"Обновление ({event_type}) сформировано по новым фактам: {delta_text}.",
+            "update_explanation": f"ACTION: обновление ({event_type}) основано на новых фактах: {delta_text}.",
             "short_text": short,
             "full_text": full,
         }

--- a/backend/narrative/narrative_generator.py
+++ b/backend/narrative/narrative_generator.py
@@ -5,7 +5,7 @@ from typing import Any
 
 
 def generate_signal_text(signal_data: dict[str, Any]) -> str:
-    """Генерирует единый профессиональный narrative (5–8 предложений в одном абзаце)."""
+    """Генерирует короткий narrative в формате CAUSE → EFFECT → ACTION."""
 
     language = _resolve_language(signal_data)
     if _market_data_unavailable(signal_data):
@@ -20,61 +20,44 @@ def generate_signal_text(signal_data: dict[str, Any]) -> str:
     take_profit = _fmt_level(signal_data.get("take_profit") or signal_data.get("takeProfit"))
     current_price = _fmt_level(signal_data.get("current_price") or signal_data.get("market_price"))
 
-    structure = _clean_text(signal_data.get("market_structure"))
     trend_phase = _structure_phase(signal_data, direction=direction)
+    structure = _clean_text(signal_data.get("market_structure")) or trend_phase
     liquidity = _liquidity_context(signal_data, direction=direction)
-    smart_money = _smart_money_action(signal_data, direction=direction)
-    zones = _zones_context(signal_data, direction=direction, entry=entry)
-    confirmations = _confirmations(signal_data)
+    confirmation = _confirmations(signal_data)
     expectation = _expected_path(signal_data, direction=direction, take_profit=take_profit)
     invalidation = _invalidation(signal_data, direction=direction, stop_loss=stop_loss)
+    action_hint = {"bullish": "buy", "bearish": "sell", "neutral": "wait"}[direction]
 
-    sentences: list[str] = []
     if language == "en":
-        price_ref = f" with spot near {current_price}" if current_price != "—" else ""
-        structure_part = structure or trend_phase
-        sentences.append(
-            f"{symbol} on {timeframe} is trading through {structure_part}{price_ref}, with price behavior consistent with a {trend_phase} regime rather than random noise."
+        price_ref = f" Spot is near {current_price}." if current_price != "—" else ""
+        cause = (
+            f"CAUSE:\n{symbol} {timeframe}: liquidity context is {liquidity}. "
+            f"Structure is {structure}.{price_ref}".strip()
         )
-        sentences.append(
-            f"Liquidity mapping shows {liquidity}, and that sweep/inducement sequence implies smart money likely {smart_money}."
+        effect = (
+            f"EFFECT:\nLiquidity sweep → smart money reaction → {expectation}. "
+            f"Confirmation comes from {confirmation}."
         )
-        sentences.append(
-            f"The active dealing zones are {zones}, where premium/discount positioning and supply-demand interaction define whether continuation stays valid."
-        )
-        sentences.append(
-            f"Bias confirmation comes from {confirmations}, so order flow and structure are aligned instead of conflicting."
-        )
-        sentences.append(
-            f"As long as price accepts around entry {entry} and avoids structural failure, the expected next leg is {expectation}, with TP reference at {take_profit}."
-        )
-        sentences.append(
-            f"The setup is invalidated if {invalidation}, which would shift the scenario from continuation to correction/distribution and nullify the current thesis."
+        action = (
+            f"ACTION:\n{action_hint.upper()} near entry {entry}, SL {stop_loss}, TP {take_profit}. "
+            f"No trade if {invalidation}."
         )
     else:
-        price_ref = f", при этом текущая цена около {current_price}" if current_price != "—" else ""
-        structure_part = structure or trend_phase
-        sentences.append(
-            f"{symbol} на {timeframe} торгуется через {structure_part}{price_ref}, и текущее поведение цены соответствует {trend_phase} фазе, а не случайной волатильности."
+        price_ref = f" Текущая цена около {current_price}." if current_price != "—" else ""
+        cause = (
+            f"ПРИЧИНА:\n{symbol} {timeframe}: ликвидность — {liquidity}. "
+            f"Структура — {structure}.{price_ref}".strip()
         )
-        sentences.append(
-            f"Карта ликвидности показывает {liquidity}, а последовательность sweep/inducement указывает, что smart money вероятно {smart_money}."
+        effect = (
+            f"ЭФФЕКТ:\nСнятие ликвидности → реакция крупных участников → {expectation}. "
+            f"Подтверждение: {confirmation}."
         )
-        sentences.append(
-            f"Рабочие зоны сфокусированы в {zones}, где позиция цены в premium/discount и взаимодействие supply/demand определяют валидность продолжения."
-        )
-        sentences.append(
-            f"Подтверждение bias формируется через {confirmations}, поэтому структура и order flow сейчас не конфликтуют между собой."
-        )
-        sentences.append(
-            f"Пока цена принимает зону входа {entry} и не ломает структуру, ожидается {expectation}, с целевым ориентиром TP {take_profit}."
-        )
-        sentences.append(
-            f"Сценарий теряет силу, если {invalidation}; в этом случае логика смещается из continuation в коррекцию/дистрибуцию и текущая идея отменяется."
+        action = (
+            f"ДЕЙСТВИЕ:\n{action_hint.upper()} от зоны входа {entry}, SL {stop_loss}, TP {take_profit}. "
+            f"Без сделки, если {invalidation}."
         )
 
-    paragraph = " ".join(_sentence(x) for x in sentences if _clean_text(x))
-    return re.sub(r"\s+", " ", paragraph).strip()
+    return f"{cause}\n\n{effect}\n\n{action}".strip()
 
 
 def generate_signal_preview_text(signal_data: dict[str, Any]) -> str:
@@ -106,12 +89,16 @@ def _build_unavailable_text(signal_data: dict[str, Any], *, language: str) -> st
     timeframe = str(signal_data.get("timeframe") or "H1").upper()
     if language == "en":
         return (
-            f"{symbol} on {timeframe} currently has no reliable market snapshot, so a structured trade narrative cannot be produced without fabricating levels or flow context. "
-            "Until live price, structure, and liquidity references are available, the scenario remains observational and no directional execution thesis is justified."
+            "CAUSE:\n"
+            f"{symbol} {timeframe}: no reliable market snapshot.\n\n"
+            "EFFECT:\nWithout live price, structure, and liquidity, direction cannot be confirmed.\n\n"
+            "ACTION:\nWait and do not open a trade until market data is restored."
         )
     return (
-        f"По {symbol} на {timeframe} сейчас нет надёжного рыночного снимка, поэтому структурный trade narrative нельзя формировать без подмены фактов по уровням и потоку ордеров. "
-        "До появления актуальной цены, структуры и карты ликвидности сценарий остаётся нейтральным наблюдением без обоснованной directional-идеи."
+        "ПРИЧИНА:\n"
+        f"{symbol} {timeframe}: нет надёжного рыночного снимка.\n\n"
+        "ЭФФЕКТ:\nБез актуальной цены, структуры и ликвидности направление не подтверждается.\n\n"
+        "ДЕЙСТВИЕ:\nЖдать и не открывать сделку до восстановления рыночных данных."
     )
 
 

--- a/tests/narrative/test_narrative_generator.py
+++ b/tests/narrative/test_narrative_generator.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import re
-
 from app.services.narrative_generator import generate_signal_preview_text, generate_signal_text
 
 
@@ -35,11 +33,11 @@ def test_generate_signal_text_contains_structured_causal_chain() -> None:
         }
     )
 
-    sentences = [x for x in re.split(r"(?<=[.!?])\s+", text) if x.strip()]
-    assert 5 <= len(sentences) <= 8
-    assert "smart money" in text.lower()
-    assert "liquidity" in text.lower()
-    assert "bias" in text.lower()
+    assert "ПРИЧИНА:" in text
+    assert "ЭФФЕКТ:" in text
+    assert "ДЕЙСТВИЕ:" in text
+    assert "снятие ликвидности" in text.lower()
+    assert "→" in text
     assert "TP 1.0876" in text
     assert "1.0828" in text
 
@@ -54,8 +52,10 @@ def test_generate_signal_text_returns_neutral_when_market_data_unavailable() -> 
         }
     )
 
+    assert "ПРИЧИНА:" in text
+    assert "ЭФФЕКТ:" in text
+    assert "ДЕЙСТВИЕ:" in text
     assert "нет надёжного рыночного снимка" in text
-    assert "нейтральным наблюдением" in text
 
 
 def test_generate_signal_preview_text_is_short_but_meaningful() -> None:


### PR DESCRIPTION
### Motivation
- Повысить ясность и скорость восприятия торговых идей, чтобы каждый тезис сразу объяснял причину, её следствие и конкретное действие.
- Упростить текстовую генерацию и унифицировать формат для LLM и fallback, не меняя архитектуру или источники данных.

### Description
- Переписан генератор текста в `backend/narrative/narrative_generator.py` — теперь `generate_signal_text` возвращает три блока: `ПРИЧИНА/ЭФФЕКТ/ДЕЙСТВИЕ` (и `CAUSE/EFFECT/ACTION` для EN) вместо длинного абзаца.
- Усилены микрологики: в тексте явно встроены причинно-следственные цепочки вида `liquidity sweep → reaction → expectation` и явный hint действия (`buy/sell/wait`) с условиями входа/SL/TP.
- Обновлён LLM-промпт в `app/services/idea_narrative_llm.py` с требованием строго возвращать `CAUSE → EFFECT → ACTION`, 1–2 коротких предложения на блок и минимальной логической цепочкой; также обновлён fallback `full_text` в том же сервисе.
- Обновлены тесты `tests/narrative/test_narrative_generator.py` и `tests/narrative/test_idea_narrative_llm.py` под новый формат, без изменений API полей (`entry`, `stop_loss`, `take_profit` и т.д.).

### Testing
- Запущена пара тестов: `pytest -q tests/narrative/test_narrative_generator.py tests/narrative/test_idea_narrative_llm.py`.
- Результат: `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8bafb6be883319f319bcfc1363b3a)