### PR TITLE
Восстановление missing чартах и структурированных наративов; приоритет structured полей

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -133,8 +133,9 @@ class TradeIdeaService:
         ideas = payload.get("ideas", [])
         ideas, live_refresh_changed = self._refresh_active_ideas(ideas)
         ideas, snapshot_recovered = self._recover_missing_chart_snapshots(ideas)
+        ideas, description_recovered, _ = self._recover_missing_structured_descriptions(ideas)
         ideas, changed = self._ensure_statistics(ideas)
-        storage_changed = changed or snapshot_recovered or live_refresh_changed
+        storage_changed = changed or snapshot_recovered or live_refresh_changed or description_recovered
         if not ideas:
             payload = {
                 "updated_at_utc": datetime.now(timezone.utc).isoformat(),
@@ -345,14 +346,6 @@ class TradeIdeaService:
     def build_api_ideas(self) -> list[dict[str, Any]]:
         primary_payload = self.idea_store.read()
         primary_source = primary_payload.get("ideas", [])
-        primary_source, lazy_snapshot_changed = self._lazy_rebuild_missing_chart_snapshots(primary_source)
-        if lazy_snapshot_changed:
-            self.idea_store.write(
-                {
-                    "updated_at_utc": datetime.now(timezone.utc).isoformat(),
-                    "ideas": primary_source,
-                }
-            )
         primary = self._normalize_for_api(primary_source, source="trade_ideas_store")
         self._log_api_pipeline(primary, stage="primary")
         if primary:
@@ -1386,17 +1379,17 @@ class TradeIdeaService:
         market_structure_structured = (
             updated.get("market_structure_structured") if isinstance(updated.get("market_structure_structured"), dict) else {}
         )
-        updated["summary_structured"] = {**narrative_structured["summary_structured"], **summary_structured}
-        updated["trade_plan_structured"] = {**narrative_structured["trade_plan_structured"], **trade_plan_structured}
-        updated["market_structure_structured"] = {**narrative_structured["market_structure_structured"], **market_structure_structured}
+        updated["summary_structured"] = {**summary_structured, **narrative_structured["summary_structured"]}
+        updated["trade_plan_structured"] = {**trade_plan_structured, **narrative_structured["trade_plan_structured"]}
+        updated["market_structure_structured"] = {**market_structure_structured, **narrative_structured["market_structure_structured"]}
         updated["narrative_structured"] = {
             "summary_structured": updated["summary_structured"],
             "trade_plan_structured": updated["trade_plan_structured"],
             "market_structure_structured": updated["market_structure_structured"],
         }
-        if not str(updated.get("short_text") or "").strip():
+        if self._is_weak_narrative_text(updated.get("short_text")):
             updated["short_text"] = str(llm_result.data.get("short_text") or updated.get("summary") or "").strip()
-        if not str(updated.get("full_text") or "").strip():
+        if self._is_weak_narrative_text(updated.get("full_text")):
             updated["full_text"] = str(llm_result.data.get("full_text") or "").strip()
         updated["narrative_source"] = str(llm_result.source or updated.get("narrative_source") or "llm")
         detail_brief = updated.get("detail_brief") if isinstance(updated.get("detail_brief"), dict) else {}
@@ -1416,6 +1409,19 @@ class TradeIdeaService:
             updated.get("narrative_source"),
         )
         return updated
+
+    @staticmethod
+    def _is_weak_narrative_text(value: Any) -> bool:
+        text = str(value or "").strip().lower()
+        if not text:
+            return True
+        weak_tokens = (
+            "статус created",
+            "статус waiting",
+            "торговая идея обновлена",
+            "ждать подтверждение структуры",
+        )
+        return any(token in text for token in weak_tokens) or len(text) < 40
 
     @classmethod
     def _idea_row_to_signal_for_backfill(cls, idea: dict[str, Any]) -> dict[str, Any]:

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -131,7 +131,22 @@ function truncateText(value, limit = 92) {
   return `${text.slice(0, limit - 1).trimEnd()}…`;
 }
 
+function getStructuredNarrativeBlocks(idea) {
+  const summaryStructured = idea?.summary_structured || idea?.narrative_structured?.summary_structured || {};
+  const tradePlanStructured = idea?.trade_plan_structured || idea?.narrative_structured?.trade_plan_structured || {};
+  const marketStructureStructured = idea?.market_structure_structured || idea?.narrative_structured?.market_structure_structured || {};
+  return {
+    summaryStructured,
+    tradePlanStructured,
+    marketStructureStructured,
+  };
+}
+
 function buildShortText(idea) {
+  const { summaryStructured } = getStructuredNarrativeBlocks(idea);
+  const structuredShort = normalizeWhitespace(summaryStructured?.signal || summaryStructured?.action);
+  if (structuredShort) return truncateText(structuredShort, 140);
+
   const direct = normalizeWhitespace(idea?.short_text || idea?.shortText);
   if (direct) return direct;
 
@@ -152,6 +167,21 @@ function buildShortText(idea) {
 }
 
 function buildFullText(idea) {
+  const { summaryStructured, tradePlanStructured, marketStructureStructured } = getStructuredNarrativeBlocks(idea);
+  const structuredText = [
+    summaryStructured?.situation,
+    summaryStructured?.cause,
+    summaryStructured?.effect,
+    summaryStructured?.action,
+    summaryStructured?.risk_note,
+    marketStructureStructured?.structure,
+    tradePlanStructured?.entry_trigger,
+  ]
+    .map((value) => normalizeWhitespace(value))
+    .filter(Boolean)
+    .join(" ");
+  if (structuredText) return structuredText;
+
   const detailSummary = normalizeWhitespace(idea?.detail_brief?.summary_narrative);
   if (detailSummary) return detailSummary;
   const direct = normalizeWhitespace(
@@ -169,9 +199,7 @@ function buildFullText(idea) {
 function buildDetailBrief(idea) {
   const existing = idea?.detail_brief;
   if (existing && typeof existing === "object") return existing;
-  const summaryStructured = idea?.summary_structured || idea?.narrative_structured?.summary_structured || {};
-  const tradePlanStructured = idea?.trade_plan_structured || idea?.narrative_structured?.trade_plan_structured || {};
-  const marketStructureStructured = idea?.market_structure_structured || idea?.narrative_structured?.market_structure_structured || {};
+  const { summaryStructured, tradePlanStructured, marketStructureStructured } = getStructuredNarrativeBlocks(idea);
 
   const entry = formatLevel(idea?.entry);
   const stop = formatLevel(idea?.stopLoss);


### PR DESCRIPTION
### Motivation
- Устаревшие/частично заполненные идеи иногда показывают `chartImageUrl = null` и только слабый текст-фоллбек, потому что чарты и Grok-описания не были корректно восстановлены или перезаписаны в существующей записи.
- Нужно безопасно восстановить недостающие чарты и Grok-структурированные описания в тех же записях идеи без создания дублей и без изменения lifecycle логики.

### Description
- В `app/services/trade_idea_service.py` добавлена явная попытка восстановления структурированных описаний в `refresh_market_ideas()` и учёт этого при записи стора, чтобы backfill делался в backend-refresh-процессе; также убрана ленивое восстановление снапшотов из пути `build_api_ideas()` чтобы не запускать backfill при каждом чтении API.
- Исправлен порядок слияния structured-полей при бэке: теперь новые значения от LLM дополняют/перезаписывают слабые старые значения (merge в сторону новых данных).
- Добавлен детектор «слабого» legacy-текста `_is_weak_narrative_text()` и логика замены short/full текста результатами LLM при backfill, даже если поле не пусто, но явно слабое/фоллбек.
- В frontend `app/static/js/chart-page.js` добавлена логика чтения structured блоков и изменены `buildShortText`/`buildFullText`/`buildDetailBrief` так, чтобы рендер prioritizировал: 1) structured Grok-поля, 2) legacy long text, 3) крайний fallback; также вынесена helper-функция `getStructuredNarrativeBlocks()`.

Изменённые файлы:
- `app/services/trade_idea_service.py` — восстановление описаний при refresh, merge-порядок, детектор слабого текста, удаление lazy-snapshot в API-read.
- `app/static/js/chart-page.js` — приоритет рендера structured → legacy → fallback.

### Testing
- Проверка синтаксиса Python: `python -m py_compile app/services/trade_idea_service.py` — успешно.
- Проверка JS-синтаксиса: `node --check app/static/js/chart-page.js` — успешно.
- Логирование добавлено/существует для случаев обнаружения отсутствия чарта/описания и для успеха/неуспеха восстановления (идентификатор идеи, символ, timeframe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90201855883318074088f2ee22fb7)