### PR TITLE
Мягкая подсветка новых и значимо обновлённых карточек идей на /ideas

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -125,6 +125,14 @@
       transition: transform 0.15s ease, border-color 0.15s ease;
     }
 
+    .card.is-new-idea {
+      animation: newIdeaPulse 2.4s ease-out;
+    }
+
+    .card.is-updated-idea {
+      animation: updatedIdeaPulse 2.4s ease-out;
+    }
+
     .card:hover {
       transform: translateY(-2px);
       border-color: #35527f;
@@ -212,6 +220,55 @@
       border: 1px solid var(--border);
       border-radius: 22px;
       padding: 20px;
+    }
+
+    .modal-card.is-updated-idea-modal {
+      animation: modalUpdatedPulse 2.4s ease-out;
+    }
+
+    @keyframes newIdeaPulse {
+      0% {
+        border-color: #3a4f73;
+        box-shadow: 0 0 0 rgba(56, 189, 248, 0);
+      }
+      30% {
+        border-color: #5bc4ff;
+        box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35), 0 0 20px rgba(56, 189, 248, 0.18);
+      }
+      100% {
+        border-color: var(--border);
+        box-shadow: 0 0 0 rgba(56, 189, 248, 0);
+      }
+    }
+
+    @keyframes updatedIdeaPulse {
+      0% {
+        border-color: #3a4f73;
+        box-shadow: 0 0 0 rgba(20, 184, 166, 0);
+      }
+      30% {
+        border-color: #5ac8bc;
+        box-shadow: 0 0 0 1px rgba(20, 184, 166, 0.32), 0 0 16px rgba(234, 179, 8, 0.16);
+      }
+      100% {
+        border-color: var(--border);
+        box-shadow: 0 0 0 rgba(20, 184, 166, 0);
+      }
+    }
+
+    @keyframes modalUpdatedPulse {
+      0% {
+        border-color: var(--border);
+        box-shadow: 0 0 0 rgba(20, 184, 166, 0);
+      }
+      35% {
+        border-color: #4fc8bb;
+        box-shadow: 0 0 0 1px rgba(20, 184, 166, 0.28), 0 0 18px rgba(20, 184, 166, 0.14);
+      }
+      100% {
+        border-color: var(--border);
+        box-shadow: 0 0 0 rgba(20, 184, 166, 0);
+      }
     }
 
     .modal-top {

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -44,6 +44,8 @@ const previousIdeaSignatures = new Map();
 const pendingCardHighlights = new Map();
 const cardHighlightTimers = new Map();
 let modalHighlightTimerId = null;
+let loadInFlight = null;
+let ideasRefreshTimerId = null;
 const CHART_REQUEST_TIMEOUT_MS = 5000;
 const IDEAS_REFRESH_INTERVAL_MS = 60000;
 const CARD_HIGHLIGHT_DURATION_MS = 2400;
@@ -1142,42 +1144,67 @@ function highlightUpdatedModalIfNeeded(ideaId, events) {
 }
 
 async function load() {
+  if (loadInFlight) return loadInFlight;
+
+  const request = (async () => {
+    try {
+      const res = await fetch("/ideas/market", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const normalizedIdeas = normalizeIdeas(data);
+      if (!normalizedIdeas.length && ENABLE_MOCK_IDEAS_ON_EMPTY) {
+        console.warn("Используем временный mock идей: активирован ideas_mock=1.");
+        allIdeas = normalizeIdeas({ ideas: TEMP_MOCK_IDEAS });
+      } else {
+        allIdeas = normalizedIdeas;
+      }
+      const highlightEvents = syncIdeaDiffState(allIdeas);
+      if (initialIdeasLoaded) {
+        highlightEvents.forEach((event) => {
+          pendingCardHighlights.set(event.id, event.kind);
+        });
+      }
+
+      populateFilters(allIdeas);
+      applyFilters();
+      renderStats(allIdeas, data?.statistics);
+
+      const nextActiveIdea = activeIdea ? allIdeas.find((idea) => ideaIdentity(idea) === ideaIdentity(activeIdea)) : null;
+      if (nextActiveIdea && nextActiveIdea !== activeIdea) {
+        activeIdea = nextActiveIdea;
+        renderDetailText(nextActiveIdea);
+        highlightUpdatedModalIfNeeded(ideaIdentity(nextActiveIdea), highlightEvents);
+      }
+      initialIdeasLoaded = true;
+    } catch (error) {
+      console.warn("Не удалось загрузить /ideas/market, synthetic fallback отключён.", error);
+      allIdeas = [];
+      populateFilters(allIdeas);
+      renderIdeas(allIdeas, "Источник идей временно недоступен. Нет актуальных рыночных данных.");
+      renderStats(allIdeas, null);
+    }
+  })();
+
+  loadInFlight = request;
   try {
-    const res = await fetch("/ideas/market", { cache: "no-store" });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    const normalizedIdeas = normalizeIdeas(data);
-    if (!normalizedIdeas.length && ENABLE_MOCK_IDEAS_ON_EMPTY) {
-      console.warn("Используем временный mock идей: активирован ideas_mock=1.");
-      allIdeas = normalizeIdeas({ ideas: TEMP_MOCK_IDEAS });
-    } else {
-      allIdeas = normalizedIdeas;
+    await request;
+  } finally {
+    if (loadInFlight === request) {
+      loadInFlight = null;
     }
-    const highlightEvents = syncIdeaDiffState(allIdeas);
-    if (initialIdeasLoaded) {
-      highlightEvents.forEach((event) => {
-        pendingCardHighlights.set(event.id, event.kind);
-      });
-    }
-
-    populateFilters(allIdeas);
-    applyFilters();
-    renderStats(allIdeas, data?.statistics);
-
-    const nextActiveIdea = activeIdea ? allIdeas.find((idea) => ideaIdentity(idea) === ideaIdentity(activeIdea)) : null;
-    if (nextActiveIdea && nextActiveIdea !== activeIdea) {
-      activeIdea = nextActiveIdea;
-      renderDetailText(nextActiveIdea);
-      highlightUpdatedModalIfNeeded(ideaIdentity(nextActiveIdea), highlightEvents);
-    }
-    initialIdeasLoaded = true;
-  } catch (error) {
-    console.warn("Не удалось загрузить /ideas/market, synthetic fallback отключён.", error);
-    allIdeas = [];
-    populateFilters(allIdeas);
-    renderIdeas(allIdeas, "Источник идей временно недоступен. Нет актуальных рыночных данных.");
-    renderStats(allIdeas, null);
   }
+  return request;
+}
+
+function scheduleIdeasRefresh() {
+  if (ideasRefreshTimerId) window.clearTimeout(ideasRefreshTimerId);
+  ideasRefreshTimerId = window.setTimeout(async () => {
+    try {
+      await load();
+    } finally {
+      scheduleIdeasRefresh();
+    }
+  }, IDEAS_REFRESH_INTERVAL_MS);
 }
 
 symbolFilter.addEventListener("change", applyFilters);
@@ -1196,5 +1223,4 @@ window.addEventListener("resize", () => {
   resizeChart();
 });
 
-load();
-window.setInterval(load, IDEAS_REFRESH_INTERVAL_MS);
+load().finally(scheduleIdeasRefresh);

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -19,6 +19,7 @@ const chartHost = document.getElementById("chart-host");
 const overlayCanvas = document.getElementById("chart-overlay");
 const chartPlaceholder = document.getElementById("chart-placeholder");
 const chartPlaceholderText = document.getElementById("chart-placeholder-text");
+const modalCard = modal?.querySelector(".modal-card");
 
 const ideaSummary = document.getElementById("idea-summary");
 const levelEntry = document.getElementById("level-entry");
@@ -33,12 +34,19 @@ const scenarioInvalidation = document.getElementById("scenario-invalidation");
 
 let allIdeas = [];
 let activeIdea = null;
+let initialIdeasLoaded = false;
 let chart = null;
 let candleSeries = null;
 let currentChartPayload = null;
 let detailRequestId = 0;
 let chartDisplayMode = "unavailable";
+const previousIdeaSignatures = new Map();
+const pendingCardHighlights = new Map();
+const cardHighlightTimers = new Map();
+let modalHighlightTimerId = null;
 const CHART_REQUEST_TIMEOUT_MS = 5000;
+const IDEAS_REFRESH_INTERVAL_MS = 60000;
+const CARD_HIGHLIGHT_DURATION_MS = 2400;
 const DEFAULT_PAIR_OPTIONS = ["EURUSD", "GBPUSD", "USDJPY"];
 const DEFAULT_TIMEFRAME_OPTIONS = ["M15", "H1", "H4"];
 const ENABLE_MOCK_IDEAS_ON_EMPTY = new URLSearchParams(window.location.search).get("ideas_mock") === "1";
@@ -90,6 +98,30 @@ function getDirectionLabel(value) {
 
 function normalizeWhitespace(value) {
   return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function ideaIdentity(idea) {
+  return String(idea?.id || `${idea?.symbol || ""}-${idea?.timeframe || ""}`).trim();
+}
+
+function buildMeaningfulSignature(idea) {
+  return JSON.stringify({
+    status: normalizeWhitespace(idea?.status),
+    updated_at: normalizeWhitespace(idea?.updated_at),
+    chartImageUrl: normalizeWhitespace(idea?.chartImageUrl || idea?.chart_image),
+    unified_narrative: normalizeWhitespace(idea?.unified_narrative),
+    idea_thesis: normalizeWhitespace(idea?.idea_thesis || idea?.ideaThesis),
+    signal: normalizeWhitespace(idea?.signal || idea?.direction || idea?.bias),
+    confidence: Number(idea?.confidence ?? ""),
+    entry: formatLevel(idea?.entry),
+    sl: formatLevel(idea?.stopLoss),
+    tp: formatLevel(idea?.takeProfit),
+  });
+}
+
+function escapeSelectorValue(value) {
+  if (window.CSS?.escape) return window.CSS.escape(value);
+  return String(value).replace(/["\\]/g, "\\$&");
 }
 
 function formatDateTime(value) {
@@ -430,7 +462,7 @@ function renderIdeas(ideas, notice = "") {
       : "";
 
     return `
-      <div class="card" data-index="${idx}">
+      <div class="card" data-index="${idx}" data-idea-id="${escapeHtml(ideaIdentity(idea))}">
         <div class="card-head">
           <div>
             <div class="symbol">${escapeHtml(symbol)}</div>
@@ -453,6 +485,32 @@ function renderIdeas(ideas, notice = "") {
   document.querySelectorAll(".card").forEach((card, idx) => {
     card.addEventListener("click", () => openIdea(ideas[idx]));
   });
+  applyPendingCardHighlights();
+}
+
+function applyHighlightClassTemporary(node, className) {
+  if (!node) return;
+  const existingTimer = cardHighlightTimers.get(node);
+  if (existingTimer) window.clearTimeout(existingTimer);
+  node.classList.remove("is-new-idea", "is-updated-idea");
+  // Force reflow so repeated meaningful updates can retrigger the subtle animation.
+  void node.offsetWidth;
+  node.classList.add(className);
+  const timeoutId = window.setTimeout(() => {
+    node.classList.remove(className);
+    cardHighlightTimers.delete(node);
+  }, CARD_HIGHLIGHT_DURATION_MS);
+  cardHighlightTimers.set(node, timeoutId);
+}
+
+function applyPendingCardHighlights() {
+  if (!pendingCardHighlights.size) return;
+  pendingCardHighlights.forEach((kind, ideaId) => {
+    const card = ideasRoot.querySelector(`.card[data-idea-id="${escapeSelectorValue(ideaId)}"]`);
+    if (!card) return;
+    applyHighlightClassTemporary(card, kind === "new" ? "is-new-idea" : "is-updated-idea");
+  });
+  pendingCardHighlights.clear();
 }
 
 function applyFilters() {
@@ -1032,9 +1090,55 @@ async function openIdea(idea) {
 
 function closeModal() {
   modal.classList.remove("open");
+  modalCard?.classList.remove("is-updated-idea-modal");
+  if (modalHighlightTimerId) {
+    window.clearTimeout(modalHighlightTimerId);
+    modalHighlightTimerId = null;
+  }
   activeIdea = null;
   detailRequestId += 1;
   showUnavailableChart("Chart unavailable (data temporarily missing)");
+}
+
+function syncIdeaDiffState(nextIdeas) {
+  const nextSignatures = new Map();
+  const highlightEvents = [];
+
+  nextIdeas.forEach((idea) => {
+    const ideaId = ideaIdentity(idea);
+    if (!ideaId) return;
+    const signature = buildMeaningfulSignature(idea);
+    nextSignatures.set(ideaId, signature);
+
+    if (!initialIdeasLoaded) return;
+    if (!previousIdeaSignatures.has(ideaId)) {
+      highlightEvents.push({ id: ideaId, kind: "new" });
+      return;
+    }
+    if (previousIdeaSignatures.get(ideaId) !== signature) {
+      highlightEvents.push({ id: ideaId, kind: "updated" });
+    }
+  });
+
+  previousIdeaSignatures.clear();
+  nextSignatures.forEach((value, key) => previousIdeaSignatures.set(key, value));
+  return highlightEvents;
+}
+
+function highlightUpdatedModalIfNeeded(ideaId, events) {
+  if (!activeIdea || !modal.classList.contains("open")) return;
+  const activeIdeaId = ideaIdentity(activeIdea);
+  if (!activeIdeaId || activeIdeaId !== ideaId) return;
+  const wasUpdated = events.some((event) => event.id === ideaId && event.kind === "updated");
+  if (!wasUpdated) return;
+  modalCard?.classList.remove("is-updated-idea-modal");
+  void modalCard?.offsetWidth;
+  modalCard?.classList.add("is-updated-idea-modal");
+  if (modalHighlightTimerId) window.clearTimeout(modalHighlightTimerId);
+  modalHighlightTimerId = window.setTimeout(() => {
+    modalCard?.classList.remove("is-updated-idea-modal");
+    modalHighlightTimerId = null;
+  }, CARD_HIGHLIGHT_DURATION_MS);
 }
 
 async function load() {
@@ -1049,9 +1153,24 @@ async function load() {
     } else {
       allIdeas = normalizedIdeas;
     }
+    const highlightEvents = syncIdeaDiffState(allIdeas);
+    if (initialIdeasLoaded) {
+      highlightEvents.forEach((event) => {
+        pendingCardHighlights.set(event.id, event.kind);
+      });
+    }
+
     populateFilters(allIdeas);
     applyFilters();
     renderStats(allIdeas, data?.statistics);
+
+    const nextActiveIdea = activeIdea ? allIdeas.find((idea) => ideaIdentity(idea) === ideaIdentity(activeIdea)) : null;
+    if (nextActiveIdea && nextActiveIdea !== activeIdea) {
+      activeIdea = nextActiveIdea;
+      renderDetailText(nextActiveIdea);
+      highlightUpdatedModalIfNeeded(ideaIdentity(nextActiveIdea), highlightEvents);
+    }
+    initialIdeasLoaded = true;
   } catch (error) {
     console.warn("Не удалось загрузить /ideas/market, synthetic fallback отключён.", error);
     allIdeas = [];
@@ -1078,3 +1197,4 @@ window.addEventListener("resize", () => {
 });
 
 load();
+window.setInterval(load, IDEAS_REFRESH_INTERVAL_MS);


### PR DESCRIPTION
### Motivation
- Пользователь не видел визуально, какая карточка появилась или действительно обновилась при автообновлении данных, хотя звук уже срабатывал. Требуется незаметная, но явная акцентировка изменений без пересборки страницы или дерганий верстки.
- Подсветка должна срабатывать только после initial sync и только для «значимых» изменений (чтобы не спамить при несущественных обновлениях), и при этом не ломать текущую тёмную тему и поведение модалки.

### Description
- Добавлен «значимый» diff: функция `buildMeaningfulSignature(idea)` сравнивает поля `status`, `updated_at`, `chartImageUrl`, `unified_narrative`/`idea_thesis`, `signal`/`direction`/`bias`, `confidence`, `entry`/`sl`/`tp`; сравнение выполняется через `syncIdeaDiffState(nextIdeas)` и используется map `previousIdeaSignatures` для детекции `new` / `updated` событий.
- Карточкам добавлен идентификатор `data-idea-id` (через `ideaIdentity(idea)`) и реализована очередь `pendingCardHighlights`, которая применяет временные классы без дублирования карточек; применение класса делает `applyHighlightClassTemporary(node, className)` и автоматически снимает класс через таймер `CARD_HIGHLIGHT_DURATION_MS = 2400`.
- Мягкая подсветка модалки: если открытая идея получила значимое обновление, модальному контейнеру добавляется класс `is-updated-idea-modal` без закрытия/переоткрытия, содержимое обновляется in-place (через текущую `renderDetailText` / `renderDetail*` поведение).
- Авто-рефреш данных: добавлен периодический вызов `setInterval(load, IDEAS_REFRESH_INTERVAL_MS)` (по умолчанию 60000 мс) для корректной работы подсветок при серверных обновлениях без перезагрузки страницы.
- CSS: добавлены классы и анимации в текущей тёмной палитре — `is-new-idea` (мягкий cyan/blue pulse), `is-updated-idea` (teal/gold pulse) и `is-updated-idea-modal` для модалки; анимации ограничены `border`/`box-shadow` и длительностью ~2.4s, без трансформаций, чтобы избежать прыжков макета.
- Файлы: изменения в `app/static/js/chart-page.js` и `app/static/ideas.html` (CSS-анимации). Ключевые символы/таймеры: `IDEAS_REFRESH_INTERVAL_MS = 60000`, `CARD_HIGHLIGHT_DURATION_MS = 2400`, классы `is-new-idea`, `is-updated-idea`, `is-updated-idea-modal`.

### Testing
- `node --check app/static/js/chart-page.js` — успешно (проверка синтаксиса JS прошла).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99782045483318752b4ca04d467a3)