### PR TITLE
Не затирать chartImageUrl при неудачной регенерации снапшота

### DIFF
--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -195,6 +195,18 @@ class ChartSnapshotService:
         finally:
             plt.close(fig)
 
+    def is_valid_snapshot_path(self, image_path: str | None) -> bool:
+        if not image_path:
+            return False
+        normalized = str(image_path).strip()
+        if not normalized:
+            return False
+        if normalized.startswith(("http://", "https://")):
+            return True
+        if normalized.startswith("/static/charts/"):
+            return True
+        return False
+
     def _draw_zones(self, *, ax: Any, zones: list[dict[str, Any]], candles_count: int, max_price: float) -> None:
         styles = {
             "demand": {"face": "#22c55e", "label": "Demand"},

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -1093,6 +1093,8 @@ class TradeIdeaService:
         status: str,
     ) -> dict[str, Any]:
         existing_url = (existing or {}).get("chartImageUrl") or (existing or {}).get("chart_image")
+        if not self.chart_snapshot_service.is_valid_snapshot_path(existing_url):
+            existing_url = None
         existing_status = (existing or {}).get("chartSnapshotStatus") or (existing or {}).get("chart_snapshot_status") or "ok"
         chart_data = signal.get("chart_data") if isinstance(signal.get("chart_data"), dict) else {}
         if not chart_data and isinstance(signal.get("chartData"), dict):
@@ -1135,6 +1137,15 @@ class TradeIdeaService:
                 symbol,
                 timeframe,
             )
+            if existing_url:
+                logger.info(
+                    "idea_snapshot_no_data_reused_existing symbol=%s timeframe=%s path=%s previous_status=%s",
+                    symbol,
+                    timeframe,
+                    existing_url,
+                    existing_status,
+                )
+                return {"chartImageUrl": existing_url, "status": "no_data", "candles": []}
             return {"chartImageUrl": None, "status": "no_data", "candles": []}
         if fetch_status != "ok":
             logger.info(
@@ -1171,7 +1182,7 @@ class TradeIdeaService:
             arrows=arrows,
             setup_text=signal.get("short_scenario_ru") or signal.get("short_text") or signal.get("summary_ru"),
         )
-        if not image_path:
+        if not self.chart_snapshot_service.is_valid_snapshot_path(image_path):
             logger.warning(
                 "snapshot_failed symbol=%s timeframe=%s candles=%s status=snapshot_failed",
                 symbol,


### PR DESCRIPTION
### Motivation
- В процессе обновления идея могла терять ранее рабочий снимок графика, потому что `_resolve_chart_snapshot()` возвращал `chartImageUrl: None` при ошибках генерации или отсутствии свечей, и это значение затирало старый URL в записи идеи.

### Description
- Добавлена проверка пути снапшота `is_valid_snapshot_path` в `app/services/chart_snapshot_service.py` для надёжной валидации существующих и новых путей к изображению.
- В `app/services/trade_idea_service.py::_resolve_chart_snapshot` существующий `chartImageUrl` теперь учитывается только если проходит валидацию и не затирается при `no_data` или `snapshot_failed` ситуациях, вместо того чтобы записывать `None` в запись идеи.
- При отсутствии свечей (`no_data`) или при неудаче генерации снапшота (`snapshot_failed`) функция возвращает предыдущий валидный URL если он есть, а новый URL применяется только когда `build_snapshot` вернул корректный путь.
- Изменения минимальны и локализованы к логике разрешения/замены снапшота, сохраняют совместимость API и не изменяют модель жизненного цикла идеи.

### Testing
- Выполнена компиляция файлов с помощью `python -m compileall app/services/trade_idea_service.py app/services/chart_snapshot_service.py`, которая прошла успешно.
- Внесённые правки статически проверены на отсутствие синтаксических ошибок и не меняют публичные контрактные поля идей.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9989b26288331bba9bc63d0b460ea)