### PR TITLE
Упорядочить шапку модалки идеи: компактный премиум-стиль

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -232,30 +232,61 @@
     .modal-top {
       display: flex;
       justify-content: space-between;
-      gap: 16px;
-      align-items: flex-start;
-      margin-bottom: 14px;
+      gap: 12px;
+      align-items: center;
+      margin-bottom: 12px;
+      padding: 12px 14px;
+      border-radius: 16px;
+      border: 1px solid rgba(45, 67, 101, 0.85);
+      background: linear-gradient(180deg, rgba(14, 30, 56, 0.96) 0%, rgba(10, 22, 41, 0.96) 100%);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    }
+
+    .modal-headline {
+      min-width: 0;
     }
 
     .modal-top h2 {
-      margin: 0 0 6px;
-      font-size: 24px;
+      margin: 0 0 4px;
+      font-size: 22px;
+      line-height: 1.2;
+      font-weight: 800;
+      letter-spacing: 0.01em;
+      color: #f4f8ff;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .modal-sub {
       color: var(--muted);
-      font-size: 14px;
+      font-size: 12px;
+      line-height: 1.4;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .close-btn {
-      border: none;
-      background: #13233c;
-      color: #fff;
-      border-radius: 12px;
-      padding: 10px 14px;
-      font-size: 14px;
+      border: 1px solid #2a3f63;
+      background: linear-gradient(180deg, #132a49 0%, #10223c 100%);
+      color: #dbe7f7;
+      border-radius: 10px;
+      padding: 7px 11px;
+      font-size: 12px;
       font-weight: 700;
       cursor: pointer;
+      line-height: 1;
+      flex-shrink: 0;
+      transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+    }
+
+    .close-btn:hover {
+      border-color: #46699d;
+      background: linear-gradient(180deg, #183359 0%, #142c4c 100%);
+      color: #f4f8ff;
     }
 
     .chart-wrap {
@@ -526,6 +557,20 @@
         grid-template-columns: 1fr;
       }
 
+      .modal-top {
+        align-items: flex-start;
+        padding: 10px 12px;
+      }
+
+      .modal-top h2 {
+        font-size: 19px;
+        white-space: normal;
+      }
+
+      .modal-sub {
+        white-space: normal;
+      }
+
       .chart-wrap {
         height: 440px;
       }
@@ -564,7 +609,7 @@
   <div id="modal" class="modal">
     <div class="modal-card">
       <div class="modal-top">
-        <div>
+        <div class="modal-headline">
           <h2 id="modal-title">Идея</h2>
           <div id="modal-sub" class="modal-sub"></div>
         </div>

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -1264,7 +1264,15 @@ async function openIdea(idea) {
   const requestId = ++detailRequestId;
   modalTitle.textContent = `${idea.symbol} — ${getDirectionRu(idea.direction)}`;
   const supported = Array.isArray(idea?.detail_brief?.supported_sections) ? idea.detail_brief.supported_sections.length : 0;
-  modalSub.textContent = `${idea.timeframe} · Уверенность ${idea.confidence}% · аналитических секций: ${supported || "—"}`;
+  const compactMeta = [idea.timeframe];
+  const confidence = Number(idea?.confidence);
+  if (Number.isFinite(confidence) && confidence > 0) {
+    compactMeta.push(`Уверенность ${Math.round(confidence)}%`);
+  }
+  if (supported > 0) {
+    compactMeta.push(`Секций ${supported}`);
+  }
+  modalSub.textContent = compactMeta.join(" · ");
   modal.classList.add("open");
 
   renderDetailText(idea);


### PR DESCRIPTION
### Motivation
- Текущая шапка модального окна выглядела громоздкой и визуально не выделяла главное (инструмент + bias), а метаданные порой создавали шум и занимали слишком много места.
- Нужно сделать шапку более компактной, читаемой и «премиальной» в рамках существующей тёмной темы без изменения бекенда и контрактов.

### Description
- Обновлён CSS шапки в `app/static/ideas.html`: уменьшена высота, tightened spacing, добавлен аккуратный градиент/бордер/внутренний блик, усилена типографика заголовка и добавлены правила обрезки (`ellipsis`) для длинных строк; кнопка закрытия стилизована и интегрирована (размер, бордер, hover). (файл: `app/static/ideas.html`).
- Добавлен контейнер `.modal-headline` для корректного сжатия заголовка и выравнивания относительно кнопки закрытия. (файл: `app/static/ideas.html`).
- Логика вторичной строки метаданных в `openIdea` упрощена: теперь всегда показывается `timeframe`, `confidence` отображается только если валиден и >0, а количество секций — только при наличии, чтобы уменьшить визуальный шум (файл: `app/static/js/chart-page.js`).
- Добавлены мобильные правила, чтобы предотвратить некрасивые переносы на малых ширинах и сохранить читабельность. (файл: `app/static/ideas.html`).

### Testing
- Запущена проверка синтаксиса JS: `node --check app/static/js/chart-page.js` — успешно.
- Нет автоматизированных UI-тестов в репозитории; визуальная проверка в браузере не выполнялась в CI этой сессии.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a4ad46648331885bac20a70d3c92)