### PR TITLE
Support robust Grok SMC/ICT overlays with safe preservation and chart fallback rendering

### DIFF
--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -68,7 +68,7 @@ class ChartSnapshotService:
                     "patterns": len(overlay_patterns),
                 },
             )
-        zones = list(zones) + list(overlay_order_blocks) + list(overlay_fvg) + list(overlay_liquidity)
+        zones = list(zones) + list(overlay_order_blocks) + list(overlay_fvg)
         levels = list(levels) + list(overlay_structure) + list(overlay_liquidity)
         patterns = list(patterns) + list(overlay_patterns)
         take_profits = [value for value in (take_profits or []) if value is not None]
@@ -123,6 +123,7 @@ class ChartSnapshotService:
 
             self._draw_zones(ax=ax, zones=zones, candles_count=len(candles), max_price=max_price)
             self._draw_horizontal_levels(ax=ax, levels=levels, candles_count=len(candles))
+            self._draw_structure_markers(ax=ax, levels=levels, candles_count=len(candles))
             self._draw_trade_levels(
                 ax=ax,
                 candles_count=len(candles),
@@ -276,18 +277,18 @@ class ChartSnapshotService:
 
     def _draw_zones(self, *, ax: Any, zones: list[dict[str, Any]], candles_count: int, max_price: float) -> None:
         styles = {
-            "demand": {"face": "#22c55e", "label": "Demand"},
-            "supply": {"face": "#ef4444", "label": "Supply"},
-            "fvg": {"face": "#8b5cf6", "label": "FVG"},
-            "imbalance": {"face": "#a855f7", "label": "Imbalance"},
-            "order_block": {"face": "#f59e0b", "label": "OB"},
-            "ob": {"face": "#f59e0b", "label": "OB"},
-            "liquidity": {"face": "#06b6d4", "label": "Liquidity"},
-            "mitigation": {"face": "#14b8a6", "label": "Mitigation"},
+            "demand": {"face": "#22c55e", "edge": "#22c55e", "label": "Demand"},
+            "supply": {"face": "#ef4444", "edge": "#ef4444", "label": "Supply"},
+            "fvg": {"face": "#8b5cf6", "edge": "#8b5cf6", "label": "FVG"},
+            "imbalance": {"face": "#a855f7", "edge": "#a855f7", "label": "Imbalance"},
+            "order_block": {"face": "#f59e0b", "edge": "#f59e0b", "label": "OB"},
+            "ob": {"face": "#f59e0b", "edge": "#f59e0b", "label": "OB"},
+            "liquidity": {"face": "#06b6d4", "edge": "#06b6d4", "label": "Liquidity"},
+            "mitigation": {"face": "#14b8a6", "edge": "#14b8a6", "label": "Mitigation"},
         }
         for zone in zones[:10]:
             zone_type_raw = str(zone.get("type") or zone.get("kind") or zone.get("label") or "").lower().replace(" ", "_")
-            style = styles.get(zone_type_raw, {"face": "#38bdf8", "label": "Zone"})
+            style = styles.get(zone_type_raw, {"face": "#38bdf8", "edge": "#38bdf8", "label": "Zone"})
             price_from = self._to_float(zone.get("from") or zone.get("priceFrom") or zone.get("low"))
             price_to = self._to_float(zone.get("to") or zone.get("priceTo") or zone.get("high"))
             if price_from is None or price_to is None:
@@ -304,23 +305,23 @@ class ChartSnapshotService:
                     end_idx - start_idx,
                     height,
                     facecolor=style["face"],
-                    edgecolor=style["face"],
+                    edgecolor=style["edge"],
                     alpha=0.18,
-                    linewidth=1.2,
+                    linewidth=1.4,
                     zorder=1,
                 )
             )
             zone_label = str(zone.get("label") or style["label"])
             ax.text(
-                start_idx,
-                bottom + height / 2,
+                start_idx + 0.2,
+                bottom + height * 0.88,
                 self._shorten_text(zone_label, limit=14),
                 color="#e5e7eb",
                 fontsize=8,
                 alpha=0.9,
-                va="center",
+                va="top",
                 zorder=5,
-                bbox={"boxstyle": "round,pad=0.2", "facecolor": "#0f172a", "edgecolor": style["face"], "alpha": 0.55},
+                bbox={"boxstyle": "round,pad=0.2", "facecolor": "#0f172a", "edgecolor": style["edge"], "alpha": 0.55},
             )
 
     def _draw_horizontal_levels(self, *, ax: Any, levels: list[dict[str, Any]], candles_count: int) -> None:
@@ -330,19 +331,50 @@ class ChartSnapshotService:
                 continue
             level_type = str(level.get("label") or level.get("type") or "Level")
             lowered = level_type.lower()
-            style = ":" if "liq" in lowered or "session" in lowered else "--"
-            ax.axhline(price, color="#60a5fa", linewidth=0.9, linestyle=style, alpha=0.8)
+            is_liquidity = "liq" in lowered or "session" in lowered
+            is_structure = any(token in lowered for token in ("support", "resistance", "bos", "choch"))
+            style = ":" if is_liquidity else "--"
+            line_color = "#22d3ee" if is_liquidity else "#f59e0b" if is_structure else "#60a5fa"
+            label_color = "#67e8f9" if is_liquidity else "#fcd34d" if is_structure else "#93c5fd"
+            edge_color = "#0891b2" if is_liquidity else "#d97706" if is_structure else "#1d4ed8"
+            ax.axhline(price, color=line_color, linewidth=1.0, linestyle=style, alpha=0.88)
             ax.text(
                 candles_count + 0.55,
                 price,
                 level_type[:20],
-                color="#93c5fd",
+                color=label_color,
                 fontsize=8,
                 ha="right",
                 va="center",
                 alpha=0.95,
-                bbox={"boxstyle": "round,pad=0.16", "facecolor": "#0f172a", "edgecolor": "#1d4ed8", "alpha": 0.55},
+                bbox={"boxstyle": "round,pad=0.16", "facecolor": "#0f172a", "edgecolor": edge_color, "alpha": 0.55},
             )
+
+    def _draw_structure_markers(self, *, ax: Any, levels: list[dict[str, Any]], candles_count: int) -> None:
+        rendered = 0
+        for level in levels:
+            level_type = str(level.get("type") or "").lower()
+            if level_type not in {"bos", "choch"}:
+                continue
+            price = self._to_float(level.get("level") or level.get("price") or level.get("value"))
+            index = self._to_float(level.get("index"))
+            if price is None or index is None:
+                continue
+            x_pos = max(0, min(index, candles_count - 1))
+            color = "#38bdf8" if level_type == "bos" else "#f97316"
+            ax.scatter([x_pos], [price], color=color, s=26, zorder=7, edgecolors="#e2e8f0", linewidths=0.4)
+            ax.text(
+                x_pos + 0.25,
+                price,
+                level_type.upper(),
+                color="#e2e8f0",
+                fontsize=7,
+                zorder=8,
+                bbox={"boxstyle": "round,pad=0.14", "facecolor": "#0f172a", "edgecolor": color, "alpha": 0.66},
+            )
+            rendered += 1
+            if rendered >= 8:
+                break
 
     def _draw_trade_levels(
         self,

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -57,6 +57,13 @@ LEVEL_STOP_LOSS_OFFSET = 0.0020
 LEVEL_TAKE_PROFIT_OFFSET = 0.0040
 CANDLE_CONTEXT_COUNT = 40
 CHART_OVERLAY_KEYS = ("order_blocks", "liquidity", "fvg", "structure_levels", "patterns")
+CHART_OVERLAY_ALIASES = {
+    "order_blocks": ("order_blocks", "orderBlocks", "orderblock", "order_blocks_zones"),
+    "liquidity": ("liquidity", "liquidity_levels", "liquidityLevels"),
+    "fvg": ("fvg", "imbalances", "imbalance", "fair_value_gap"),
+    "structure_levels": ("structure_levels", "structure", "structureLevels"),
+    "patterns": ("patterns", "chart_patterns", "pattern_overlays"),
+}
 SNAPSHOT_RETRY_INTERVAL_SECONDS = int(os.getenv("IDEAS_SNAPSHOT_RETRY_INTERVAL_SECONDS", "1800"))
 NARRATIVE_REFRESH_COOLDOWN_SECONDS = int(os.getenv("IDEAS_NARRATIVE_REFRESH_COOLDOWN_SECONDS", "300"))
 logger = logging.getLogger(__name__)
@@ -848,7 +855,7 @@ class TradeIdeaService:
             idea_thesis=idea_thesis_text,
             unified_narrative=unified_narrative_text,
             chart_overlays=chart_overlays,
-        ):
+        ) and not self._has_material_trade_delta(existing=existing, signal=signal, status=status):
             logger.info(
                 "idea_refresh_skipped_empty_analysis idea_id=%s symbol=%s timeframe=%s",
                 existing.get("idea_id"),
@@ -875,7 +882,15 @@ class TradeIdeaService:
             else existing.get("close_explanation") if existing else None
         )
         if is_terminal and (unified_narrative_text or full_text):
-            close_explanation = unified_narrative_text or full_text
+            terminal_summary = self._build_close_explanation(
+                status=status,
+                symbol=symbol,
+                direction=bias,
+                target=self._format_price(take_profit),
+                invalidation=invalidation,
+            )
+            narrative_tail = unified_narrative_text or full_text
+            close_explanation = f"{terminal_summary} {narrative_tail}".strip()
         history = self._build_history(
             existing=existing,
             status=status,
@@ -1394,6 +1409,10 @@ class TradeIdeaService:
 
         levels, zones, markers, patterns, arrows = self._extract_snapshot_overlays(signal=signal, chart_data=chart_data)
         take_profits = self._extract_take_profits(signal=signal, fallback_take_profit=take_profit)
+        resolved_chart_overlays = self.merge_preserving_last_good_overlays(
+            existing.get("chart_overlays") if isinstance(existing, dict) else None,
+            self.normalize_chart_overlays(signal.get("chart_overlays")),
+        )
         logger.info(
             "snapshot_start symbol=%s timeframe=%s candles=%s has_existing=%s",
             symbol,
@@ -1416,7 +1435,7 @@ class TradeIdeaService:
             markers=markers,
             patterns=patterns,
             arrows=arrows,
-            chart_overlays=self.normalize_chart_overlays(signal.get("chart_overlays")),
+            chart_overlays=resolved_chart_overlays,
             setup_text=signal.get("short_scenario_ru") or signal.get("short_text") or signal.get("summary_ru"),
         )
         resolved_snapshot = self.chart_snapshot_service.resolve_snapshot_with_fallback(
@@ -1605,16 +1624,77 @@ class TradeIdeaService:
         if not isinstance(payload, dict):
             return normalized
         for key in CHART_OVERLAY_KEYS:
-            values = payload.get(key)
-            if isinstance(values, list):
-                normalized[key] = [item for item in values if isinstance(item, dict)]
+            values: list[Any] = []
+            for alias in CHART_OVERLAY_ALIASES.get(key, (key,)):
+                candidate = payload.get(alias)
+                if isinstance(candidate, list):
+                    values.extend(candidate)
+            normalized[key] = cls._normalize_overlay_items(key=key, items=values)
         return normalized
 
     @classmethod
     def is_meaningful_overlay_payload(cls, payload: dict[str, Any] | None) -> bool:
         if not isinstance(payload, dict):
             return False
-        return any(isinstance(payload.get(key), list) and payload.get(key) for key in CHART_OVERLAY_KEYS)
+        normalized = cls.normalize_chart_overlays(payload)
+        for key in CHART_OVERLAY_KEYS:
+            for item in normalized.get(key) or []:
+                if cls._overlay_item_has_coordinates(key=key, item=item):
+                    return True
+        return False
+
+    @classmethod
+    def _normalize_overlay_items(cls, *, key: str, items: list[Any]) -> list[dict[str, Any]]:
+        normalized_items: list[dict[str, Any]] = []
+        for raw_item in items:
+            if not isinstance(raw_item, dict):
+                continue
+            item = dict(raw_item)
+            if key in {"order_blocks", "fvg", "patterns"}:
+                low = cls._extract_numeric(item.get("low") if item.get("low") is not None else item.get("from"))
+                high = cls._extract_numeric(item.get("high") if item.get("high") is not None else item.get("to"))
+                if low is not None:
+                    item["low"] = low
+                if high is not None:
+                    item["high"] = high
+                start_index = cls._extract_numeric(item.get("start_index") if item.get("start_index") is not None else item.get("start"))
+                end_index = cls._extract_numeric(item.get("end_index") if item.get("end_index") is not None else item.get("end"))
+                if start_index is not None:
+                    item["start_index"] = int(start_index)
+                if end_index is not None:
+                    item["end_index"] = int(end_index)
+            elif key in {"liquidity", "structure_levels"}:
+                level = cls._extract_numeric(
+                    item.get("level")
+                    if item.get("level") is not None
+                    else item.get("price")
+                    if item.get("price") is not None
+                    else item.get("value")
+                )
+                if level is not None:
+                    item["level"] = level
+                    if item.get("price") is None:
+                        item["price"] = level
+                index = cls._extract_numeric(item.get("index"))
+                if index is not None:
+                    item["index"] = int(index)
+            normalized_items.append(item)
+        return normalized_items
+
+    @classmethod
+    def _overlay_item_has_coordinates(cls, *, key: str, item: dict[str, Any]) -> bool:
+        if key in {"order_blocks", "fvg", "patterns"}:
+            low = cls._extract_numeric(item.get("low") if item.get("low") is not None else item.get("from"))
+            high = cls._extract_numeric(item.get("high") if item.get("high") is not None else item.get("to"))
+            return low is not None and high is not None
+        level = cls._extract_numeric(
+            item.get("level")
+            if item.get("level") is not None
+            else item.get("price")
+            if item.get("price") is not None
+            else item.get("value")
+        )
+        return level is not None
 
     @classmethod
     def merge_preserving_last_good_overlays(
@@ -2220,6 +2300,10 @@ class TradeIdeaService:
         return not any(token in normalized for token in reasoning_tokens)
 
     @classmethod
+    def is_weak_narrative(cls, value: Any) -> bool:
+        return cls._is_weak_narrative_text(value)
+
+    @classmethod
     def isWeakNarrative(cls, value: Any) -> bool:
         return cls._is_weak_narrative_text(value)
 
@@ -2250,6 +2334,35 @@ class TradeIdeaService:
         has_idea_thesis = not cls.isWeakNarrative(idea_thesis)
         has_unified_narrative = not cls.isWeakNarrative(unified_narrative)
         return not any((has_analysis_blocks, has_meaningful_overlays, has_chart, has_idea_thesis, has_unified_narrative))
+
+    @classmethod
+    def _has_material_trade_delta(cls, *, existing: dict[str, Any], signal: dict[str, Any], status: str) -> bool:
+        signal_action = str(signal.get("action") or "").upper()
+        expected_signal = signal.get("signal")
+        if expected_signal is None:
+            expected_signal = "BUY" if signal_action == "BUY" else "SELL" if signal_action == "SELL" else "WAIT"
+        if str(existing.get("signal") or "").upper() != str(expected_signal or "").upper():
+            return True
+        for key, aliases in {
+            "entry": ("entry",),
+            "stop_loss": ("stop_loss", "stopLoss"),
+            "take_profit": ("take_profit", "takeProfit"),
+        }.items():
+            existing_value = cls._extract_numeric(existing.get(key))
+            incoming_value: float | None = None
+            for alias in aliases:
+                incoming_value = cls._extract_numeric(signal.get(alias))
+                if incoming_value is not None:
+                    break
+            if existing_value != incoming_value:
+                return True
+        existing_confidence = cls._extract_numeric(existing.get("confidence"))
+        incoming_confidence = cls._extract_numeric(signal.get("confidence_percent") or signal.get("probability_percent"))
+        if existing_confidence is not None and incoming_confidence is not None and abs(existing_confidence - incoming_confidence) >= cls.MEANINGFUL_CONFIDENCE_DELTA:
+            return True
+        if str(existing.get("status") or "").lower() != str(status or "").lower():
+            return True
+        return False
 
     @classmethod
     def _idea_row_to_signal_for_backfill(cls, idea: dict[str, Any]) -> dict[str, Any]:
@@ -2575,12 +2688,12 @@ class TradeIdeaService:
     def _build_close_explanation(*, status: str, symbol: str, direction: str, target: str, invalidation: str) -> str:
         if status == IDEA_STATUS_TP_HIT:
             return (
-                f"Идея по {symbol} отработала по take profit. Цена подтвердила {direction} сценарий и дошла до целевой ликвидности {target}. "
+                f"Идея по {symbol} отработала по take profit (tp_hit). Цена подтвердила {direction} сценарий и дошла до целевой ликвидности {target}. "
                 "Сценарий завершён и переведён в архив."
             )
         if status == IDEA_STATUS_SL_HIT:
             return (
-                f"Идея по {symbol} закрыта по stop loss. После теста зоны рынок не подтвердил сценарий и нарушил структуру. "
+                f"Идея по {symbol} закрыта по stop loss (sl_hit). После теста зоны рынок не подтвердил сценарий и нарушил структуру. "
                 "Идея переведена в архив."
             )
         return f"Сценарий по {symbol} отменён. {invalidation} Карточка переведена в архив."
@@ -4067,8 +4180,7 @@ class TradeIdeaService:
             if validated_row.get("_invalid_levels"):
                 continue
             normalized_overlays = self.normalize_chart_overlays(validated_row.get("chart_overlays"))
-            if self.is_meaningful_overlay_payload(normalized_overlays):
-                validated_row["chart_overlays"] = normalized_overlays
+            validated_row["chart_overlays"] = normalized_overlays
             logger.info(
                 "openrouter_overlay_parse symbol=%s timeframe=%s candles_present=%s model_overlays=%s categories=%s",
                 symbol,

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -660,8 +660,8 @@
           <canvas id="chart-overlay" class="overlay"></canvas>
         </div>
         <div id="chart-placeholder" class="chart-placeholder">
-          <strong>Chart unavailable</strong>
-          <span id="chart-placeholder-text">Chart unavailable</span>
+          <strong>График недоступен</strong>
+          <span id="chart-placeholder-text">График недоступен. Если свечи есть — будет показан live-чарт.</span>
         </div>
       </div>
 

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -806,7 +806,7 @@ function showChartPlaceholder(message) {
 
 function hideChartPlaceholder() {
   chartPlaceholder.classList.remove("open");
-  chartPlaceholderText.textContent = "Chart unavailable";
+  chartPlaceholderText.textContent = "График недоступен";
 }
 
 function normalizeChartImageUrl(url) {
@@ -826,8 +826,8 @@ function snapshotStatusRu(status) {
     fetch_error: "Снапшот не подготовлен: ошибка при получении данных.",
     unavailable: "Снапшот временно недоступен.",
   }[key];
-  if (reason) return `Chart unavailable — ${reason}`;
-  return "Chart unavailable";
+  if (reason) return `График недоступен — ${reason}`;
+  return "График недоступен";
 }
 
 function hasCandles(payload) {
@@ -874,7 +874,7 @@ function showLiveChart(payload) {
 
 function showUnavailableChart(message) {
   setChartMode("unavailable");
-  showChartPlaceholder(message || "Chart unavailable");
+  showChartPlaceholder(message || "График недоступен");
 }
 
 function updateDetailStatus(message) {
@@ -1008,13 +1008,14 @@ function normalizeSmcOverlays(payload) {
   const orderBlocks = Array.isArray(base?.order_blocks)
     ? base.order_blocks
       .map((item) => {
-        const from = toFiniteNumber(item?.from);
-        const to = toFiniteNumber(item?.to);
+        const from = toFiniteNumber(item?.from ?? item?.low);
+        const to = toFiniteNumber(item?.to ?? item?.high);
         if (from == null || to == null) return null;
         return {
           from: Math.min(from, to),
           to: Math.max(from, to),
           type: String(item?.type || "").toLowerCase(),
+          label: normalizeWhitespace(item?.label || ""),
         };
       })
       .filter(Boolean)
@@ -1023,12 +1024,13 @@ function normalizeSmcOverlays(payload) {
   const fvg = Array.isArray(base?.fvg)
     ? base.fvg
       .map((item) => {
-        const from = toFiniteNumber(item?.from);
-        const to = toFiniteNumber(item?.to);
+        const from = toFiniteNumber(item?.from ?? item?.low);
+        const to = toFiniteNumber(item?.to ?? item?.high);
         if (from == null || to == null) return null;
         return {
           from: Math.min(from, to),
           to: Math.max(from, to),
+          label: normalizeWhitespace(item?.label || "FVG"),
         };
       })
       .filter(Boolean)
@@ -1044,14 +1046,16 @@ function normalizeSmcOverlays(payload) {
       .filter(Boolean)
     : [];
 
-  const structure = Array.isArray(base?.structure)
-    ? base.structure
+  const structureSource = Array.isArray(base?.structure_levels) ? base.structure_levels : Array.isArray(base?.structure) ? base.structure : [];
+  const structure = Array.isArray(structureSource)
+    ? structureSource
       .map((item) => {
-        const level = toFiniteNumber(item?.level);
+        const level = toFiniteNumber(item?.level ?? item?.price);
         if (level == null) return null;
         return {
           level,
           type: normalizeWhitespace(item?.type || "structure"),
+          label: normalizeWhitespace(item?.label || item?.type || "Structure"),
         };
       })
       .filter(Boolean)
@@ -1140,7 +1144,7 @@ const overlayPlugin = {
       ctx.lineTo(rightX, y);
       ctx.stroke();
       ctx.restore();
-      drawLabel(ctx, Math.max(8, rightX - 180), y - 4, `Structure: ${item.type}`, "#fbbf24");
+      drawLabel(ctx, Math.max(8, rightX - 180), y - 4, item.label || `Structure: ${item.type}`, "#fbbf24");
     });
   },
 };


### PR DESCRIPTION
### Motivation
- Поддержать возвращаемую Grok структуру chart_overlays (order_blocks, liquidity, fvg, structure_levels, patterns) и не допускать потери уже накопленной полезной разметки при слабых или пустых refresh.
- Безопасно отрисовывать реальные SMC/ICT оверлеи на серверном snapshot-рендерере и при этом сохранить fallback на candle-rendering во фронтенде если снимок недоступен.
- Сохранить обратную совместимость с прежними/вариативными ключами и минимально вмешиваться в существующую архитектуру и контракты.

### Description
- Добавлена поддержка алиасов ключей `CHART_OVERLAY_ALIASES` и расширена `normalize_chart_overlays` чтобы всегда возвращать полную структуру с ключами `order_blocks`, `liquidity`, `fvg`, `structure_levels`, `patterns` и нормализовать поля (`low/high`, `from/to`, `level/price/value`, `start_index`/`end_index`).
- Введены `_normalize_overlay_items` и `_overlay_item_has_coordinates` и обновлён `is_meaningful_overlay_payload` так, чтобы частичные, но валидные объекты (хотя бы с координатами) считались meaningful и не сбрасывали существующие overlays; добавлена `merge_preserving_last_good_overlays` в путях snapshot-рендера.
- Защита от «агрессивного» пропуска обновления: добавлен `_has_material_trade_delta`, который позволяет не пропускать refresh если реально изменились trade-параметры (entry/SL/TP/signal/confidence/status); добавлен helper-алиас `is_weak_narrative`.
- Улучшен `chart_snapshot_service`: больше не смешиваем liquidity как зоны, добавлены отдельные стили для уровней/ликвидности/структуры, маркеры BOS/CHoCH при наличии `index`, аккуратные границы/метки для зон (OB/FVG) и сохранение last-good snapshot при ошибках.
- Фронтенд: `app/static/js/chart-page.js` теперь умеет читать `low/high` для зон, ключ `structure_levels` (с fallback на `structure`), переносит метки в отрисовку и показывает snapshot-first поведение с fallback на свечи; `ideas.html` и сообщения обновлены на русский текст для placeholder.

### Testing
- `python -m py_compile app/services/trade_idea_service.py app/services/chart_snapshot_service.py` — компиляция прошла успешно.
- `pytest -q tests/test_idea_update.py::test_trade_idea_updates_without_duplication tests/test_idea_update.py::test_trade_idea_archives_on_tp_and_keeps_history tests/test_idea_update.py::test_archive_explanation_generation_on_tp_sl tests/test_idea_update.py::test_no_trade_does_not_reopen_closed_lifecycle` — все четыре теста прошли успешно.
- `pytest -q tests/test_chart_api.py` — все тесты в этом модуле прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b044c5b48331a6ae70b2f769d645)