### PR TITLE
Добавить fallback на Yahoo Finance для свечных данных и endpoint /api/debug/market-health

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -188,6 +188,30 @@ async def twelvedata_health_debug() -> dict:
     }
 
 
+@app.get("/api/debug/market-health")
+async def market_health_debug(symbol: str = "EURUSD", timeframe: str = "H1", limit: int = 120) -> dict:
+    payload = await asyncio.to_thread(chart_data_service.get_chart, symbol, timeframe)
+    candles = payload.get("candles") if isinstance(payload, dict) and isinstance(payload.get("candles"), list) else []
+    meta = payload.get("meta") if isinstance(payload, dict) and isinstance(payload.get("meta"), dict) else {}
+    health = chart_data_service.get_last_market_health()
+    provider_used = health.get("provider") or payload.get("source") or "unknown"
+    source_symbol = health.get("source_symbol")
+    if not source_symbol:
+        source_symbol = _td_symbol(str(symbol).upper().replace("/", "").strip()) if provider_used == "twelvedata" else str(symbol).upper().replace("/", "").strip()
+    return {
+        "provider_used": provider_used,
+        "request_succeeded": bool(health.get("request_succeeded") or len(candles) > 0),
+        "candles_count": int(health.get("candles_count") or len(candles)),
+        "error": health.get("error"),
+        "source_symbol": source_symbol,
+        "symbol": str(symbol).upper().replace("/", "").strip(),
+        "timeframe": str(timeframe or "H1").upper().strip(),
+        "requested_limit": max(1, int(limit or 1)),
+        "status": payload.get("status"),
+        "meta_provider": meta.get("provider"),
+    }
+
+
 @app.get("/signals/live", response_model=SignalsLiveResponse)
 async def signals_live() -> SignalsLiveResponse:
     return await signal_hub.get_live_response(pairs=DEFAULT_PAIRS)

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -9,6 +9,7 @@ from typing import Any
 import requests
 
 from app.core.env import get_twelvedata_api_key
+from app.services.yahoo_market_data_service import YahooMarketDataService
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,14 @@ class ChartDataService:
         self.api_key = get_twelvedata_api_key() or ""
         self.timeout_seconds = float(os.getenv("TWELVEDATA_TIMEOUT", str(DEFAULT_CHART_TIMEOUT_SECONDS)))
         self.output_size = int(os.getenv("TWELVEDATA_OUTPUTSIZE", str(DEFAULT_CHART_LIMIT)))
+        self.yahoo_service = YahooMarketDataService()
+        self._last_market_health: dict[str, Any] = {
+            "provider": None,
+            "request_succeeded": False,
+            "candles_count": 0,
+            "error": "not_started",
+            "source_symbol": None,
+        }
 
     def get_chart(self, symbol: str, timeframe: str) -> dict[str, Any]:
         logger.info("chart_request_started symbol=%s tf=%s", symbol, timeframe)
@@ -50,20 +59,33 @@ class ChartDataService:
 
         if normalized_tf not in TIMEFRAME_MAPPING:
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=unsupported_timeframe", normalized_symbol, normalized_tf)
-            return self.build_unavailable_payload(
+            payload = self.build_unavailable_payload(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
                 message_ru="Неподдерживаемый таймфрейм для свечного графика.",
                 reason="fetch_error",
             )
+            self._set_market_health(
+                provider="twelvedata",
+                request_succeeded=False,
+                candles_count=0,
+                error="unsupported_timeframe",
+                source_symbol=provider_symbol,
+            )
+            return payload
 
         if not self.api_key:
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=missing_api_key", normalized_symbol, normalized_tf)
-            return self.build_unavailable_payload(
+            return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
-                message_ru="Свечной API не настроен: отсутствует TWELVEDATA_API_KEY.",
-                reason="fetch_error",
+                twelvedata_error="missing_api_key",
+                twelvedata_payload=self.build_unavailable_payload(
+                    symbol=normalized_symbol,
+                    timeframe=normalized_tf,
+                    message_ru="Свечной API не настроен: отсутствует TWELVEDATA_API_KEY.",
+                    reason="fetch_error",
+                ),
             )
 
         params = {
@@ -80,19 +102,29 @@ class ChartDataService:
             payload = response.json()
         except requests.RequestException as exc:
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=request_exception error=%s", normalized_symbol, normalized_tf, exc)
-            return self.build_unavailable_payload(
+            return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
-                message_ru="Не удалось загрузить реальные свечные данные из Twelve Data.",
-                reason="fetch_error",
+                twelvedata_error="fetch_error",
+                twelvedata_payload=self.build_unavailable_payload(
+                    symbol=normalized_symbol,
+                    timeframe=normalized_tf,
+                    message_ru="Не удалось загрузить реальные свечные данные из Twelve Data.",
+                    reason="fetch_error",
+                ),
             )
         except ValueError:
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=invalid_json", normalized_symbol, normalized_tf)
-            return self.build_unavailable_payload(
+            return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
-                message_ru="Свечной API вернул некорректный ответ.",
-                reason="fetch_error",
+                twelvedata_error="fetch_error",
+                twelvedata_payload=self.build_unavailable_payload(
+                    symbol=normalized_symbol,
+                    timeframe=normalized_tf,
+                    message_ru="Свечной API вернул некорректный ответ.",
+                    reason="fetch_error",
+                ),
             )
 
         payload, candles = self.normalize_provider_payload(payload)
@@ -115,21 +147,38 @@ class ChartDataService:
                     payload.get("message"),
                 )
                 reason = "rate_limited" if str(payload.get("code")) == "429" else "fetch_error"
-                return self.build_unavailable_payload(
+                return self._fallback_to_yahoo(
                     symbol=normalized_symbol,
                     timeframe=normalized_tf,
-                    message_ru=f"Twelve Data недоступен: {payload.get('message') or 'неизвестная ошибка'}.",
-                    reason=reason,
+                    twelvedata_error=reason,
+                    twelvedata_payload=self.build_unavailable_payload(
+                        symbol=normalized_symbol,
+                        timeframe=normalized_tf,
+                        message_ru=f"Twelve Data недоступен: {payload.get('message') or 'неизвестная ошибка'}.",
+                        reason=reason,
+                    ),
                 )
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=empty_candles", normalized_symbol, normalized_tf)
-            return self.build_unavailable_payload(
+            return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
-                message_ru="Свечной API не вернул candles/values для выбранной идеи.",
-                reason="no_data",
+                twelvedata_error="no_data",
+                twelvedata_payload=self.build_unavailable_payload(
+                    symbol=normalized_symbol,
+                    timeframe=normalized_tf,
+                    message_ru="Свечной API не вернул candles/values для выбранной идеи.",
+                    reason="no_data",
+                ),
             )
 
         logger.info("twelvedata_success symbol=%s tf=%s candles=%s", normalized_symbol, normalized_tf, len(candles))
+        self._set_market_health(
+            provider="twelvedata",
+            request_succeeded=True,
+            candles_count=len(candles),
+            error=None,
+            source_symbol=provider_symbol,
+        )
 
         return {
             "symbol": normalized_symbol,
@@ -144,6 +193,85 @@ class ChartDataService:
                 "outputsize": len(candles),
             },
         }
+
+    def get_last_market_health(self) -> dict[str, Any]:
+        return dict(self._last_market_health)
+
+    def _fallback_to_yahoo(
+        self,
+        *,
+        symbol: str,
+        timeframe: str,
+        twelvedata_error: str,
+        twelvedata_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        logger.warning(
+            "twelvedata_failed_yahoo_fallback symbol=%s tf=%s twelvedata_error=%s",
+            symbol,
+            timeframe,
+            twelvedata_error,
+        )
+        yahoo = self.yahoo_service.get_candles(symbol, timeframe, self.output_size)
+        yahoo_candles = yahoo.get("candles") if isinstance(yahoo.get("candles"), list) else []
+        yahoo_error = yahoo.get("error")
+        if yahoo_candles:
+            logger.info("yahoo_fallback_success symbol=%s tf=%s candles=%s", symbol, timeframe, len(yahoo_candles))
+            self._set_market_health(
+                provider="yahoo_finance",
+                request_succeeded=True,
+                candles_count=len(yahoo_candles),
+                error=None,
+                source_symbol=str(yahoo.get("source_symbol") or symbol),
+            )
+            return {
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "source": "yahoo_finance",
+                "status": "ok",
+                "message_ru": "Twelve Data недоступен, использован fallback Yahoo Finance.",
+                "candles": yahoo_candles,
+                "meta": {
+                    "provider": "Yahoo Finance",
+                    "interval": self.yahoo_service.map_timeframe(timeframe).get("interval") if self.yahoo_service.map_timeframe(timeframe) else None,
+                    "outputsize": len(yahoo_candles),
+                    "fallback_from": "twelvedata",
+                    "provider_error": twelvedata_error,
+                },
+            }
+        logger.warning("yahoo_fallback_failed symbol=%s tf=%s error=%s", symbol, timeframe, yahoo_error)
+        self._set_market_health(
+            provider="twelvedata",
+            request_succeeded=False,
+            candles_count=0,
+            error=f"twelvedata:{twelvedata_error};yahoo:{yahoo_error or 'unknown_error'}",
+            source_symbol=str(yahoo.get("source_symbol") or symbol),
+        )
+        return twelvedata_payload
+
+    def _set_market_health(
+        self,
+        *,
+        provider: str,
+        request_succeeded: bool,
+        candles_count: int,
+        error: str | None,
+        source_symbol: str | None,
+    ) -> None:
+        self._last_market_health = {
+            "provider": provider,
+            "request_succeeded": request_succeeded,
+            "candles_count": max(0, int(candles_count or 0)),
+            "error": error,
+            "source_symbol": source_symbol,
+        }
+        logger.info(
+            "market_provider_selected provider=%s request_succeeded=%s candles=%s error=%s source_symbol=%s",
+            provider,
+            request_succeeded,
+            candles_count,
+            error,
+            source_symbol,
+        )
 
     @staticmethod
     def _normalize_symbol(symbol: str) -> str:

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -66,6 +66,7 @@ CHART_OVERLAY_ALIASES = {
 }
 SNAPSHOT_RETRY_INTERVAL_SECONDS = int(os.getenv("IDEAS_SNAPSHOT_RETRY_INTERVAL_SECONDS", "1800"))
 NARRATIVE_REFRESH_COOLDOWN_SECONDS = int(os.getenv("IDEAS_NARRATIVE_REFRESH_COOLDOWN_SECONDS", "300"))
+MIN_IDEA_CANDLES_REQUIRED = max(2, int(os.getenv("IDEAS_MIN_CANDLES_REQUIRED", "20")))
 logger = logging.getLogger(__name__)
 
 
@@ -337,7 +338,14 @@ class TradeIdeaService:
             timeframe = str(current.get("timeframe", "H1")).upper()
             chart_payload = self.chart_data_service.get_chart(symbol, timeframe)
             candles = chart_payload.get("candles") if isinstance(chart_payload.get("candles"), list) else []
-            if not candles:
+            if len(candles) < MIN_IDEA_CANDLES_REQUIRED:
+                logger.info(
+                    "idea_live_refresh_skipped symbol=%s timeframe=%s candles=%s min_required=%s",
+                    symbol,
+                    timeframe,
+                    len(candles),
+                    MIN_IDEA_CANDLES_REQUIRED,
+                )
                 refreshed.append(current)
                 continue
             latest_candle = candles[-1] if isinstance(candles[-1], dict) else {}
@@ -728,7 +736,7 @@ class TradeIdeaService:
             symbol = str(signal.get("symbol", "")).upper()
             timeframe = str(signal.get("timeframe", "H1")).upper()
             candles_count = int(signal.get("source_candle_count") or 0)
-            if candles_count > 0:
+            if candles_count >= MIN_IDEA_CANDLES_REQUIRED:
                 symbols_with_candles.add((symbol, timeframe))
             action = signal.get("action", "NO_TRADE")
             pipeline_debug = signal.get("pipeline_debug", {}) if isinstance(signal.get("pipeline_debug"), dict) else {}
@@ -742,6 +750,16 @@ class TradeIdeaService:
                 pipeline_debug.get("reason_if_skipped"),
                 action,
             )
+            if candles_count < MIN_IDEA_CANDLES_REQUIRED:
+                skipped_reasons["insufficient_candles"] = skipped_reasons.get("insufficient_candles", 0) + 1
+                logger.info(
+                    "ideas_pipeline_skip_update_insufficient_candles symbol=%s timeframe=%s candles_count=%s min_required=%s",
+                    symbol,
+                    timeframe,
+                    candles_count,
+                    MIN_IDEA_CANDLES_REQUIRED,
+                )
+                continue
             if action == "NO_TRADE":
                 skipped_by_no_trade += 1
                 skip_reason = str(pipeline_debug.get("reason_if_skipped") or "no_trade_signal")

--- a/app/services/yahoo_market_data_service.py
+++ b/app/services/yahoo_market_data_service.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from typing import Any
+
+import pandas as pd
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+_YAHOO_TIMEFRAME_CONFIG: dict[str, dict[str, str]] = {
+    "M15": {"interval": "15m", "period": "7d"},
+    "H1": {"interval": "60m", "period": "60d"},
+    "H4": {"interval": "60m", "period": "60d"},
+}
+
+
+class YahooMarketDataService:
+    def map_symbol(self, symbol: str) -> str:
+        normalized = self._normalize_symbol(symbol)
+        explicit = {
+            "EURUSD": "EURUSD=X",
+            "GBPUSD": "GBPUSD=X",
+            "USDJPY": "USDJPY=X",
+            "AUDUSD": "AUDUSD=X",
+            "USDCAD": "USDCAD=X",
+            "USDCHF": "USDCHF=X",
+            "NZDUSD": "NZDUSD=X",
+            "EURGBP": "EURGBP=X",
+            "EURCHF": "EURCHF=X",
+            "XAUUSD": "XAUUSD=X",
+        }
+        if normalized in explicit:
+            return explicit[normalized]
+        if len(normalized) == 6 and normalized.isalpha():
+            return f"{normalized}=X"
+        return normalized
+
+    def map_timeframe(self, timeframe: str) -> dict[str, str] | None:
+        return _YAHOO_TIMEFRAME_CONFIG.get(str(timeframe or "H1").upper().strip())
+
+    def get_candles(self, symbol: str, timeframe: str, limit: int = 120) -> dict[str, Any]:
+        normalized_symbol = self._normalize_symbol(symbol)
+        normalized_tf = str(timeframe or "H1").upper().strip()
+        mapped_tf = self.map_timeframe(normalized_tf)
+        source_symbol = self.map_symbol(normalized_symbol)
+
+        if mapped_tf is None:
+            return {
+                "symbol": normalized_symbol,
+                "timeframe": normalized_tf,
+                "source": "yahoo_finance",
+                "source_symbol": source_symbol,
+                "candles": [],
+                "error": "unsupported_timeframe",
+            }
+
+        try:
+            raw = yf.download(
+                tickers=source_symbol,
+                interval=mapped_tf["interval"],
+                period=mapped_tf["period"],
+                auto_adjust=False,
+                progress=False,
+                threads=False,
+            )
+        except Exception as exc:
+            logger.warning("yahoo_fetch_failed symbol=%s tf=%s error=%s", normalized_symbol, normalized_tf, exc)
+            return {
+                "symbol": normalized_symbol,
+                "timeframe": normalized_tf,
+                "source": "yahoo_finance",
+                "source_symbol": source_symbol,
+                "candles": [],
+                "error": "request_failed",
+            }
+
+        if not isinstance(raw, pd.DataFrame) or raw.empty:
+            return {
+                "symbol": normalized_symbol,
+                "timeframe": normalized_tf,
+                "source": "yahoo_finance",
+                "source_symbol": source_symbol,
+                "candles": [],
+                "error": "empty_history",
+            }
+
+        if normalized_tf == "H4":
+            candles = self._aggregate_h4(raw)
+        else:
+            candles = self._normalize_rows(raw)
+
+        bounded = candles[-max(1, min(int(limit or 1), 5000)) :]
+        return {
+            "symbol": normalized_symbol,
+            "timeframe": normalized_tf,
+            "source": "yahoo_finance",
+            "source_symbol": source_symbol,
+            "last_updated_utc": datetime.now(timezone.utc).isoformat(),
+            "candles": bounded,
+            "error": None if bounded else "empty_candles",
+        }
+
+    def _normalize_rows(self, frame: pd.DataFrame) -> list[dict[str, Any]]:
+        candles: list[dict[str, Any]] = []
+        for idx, row in frame.iterrows():
+            ts = self._to_timestamp(idx)
+            if ts is None:
+                continue
+            open_price = self._to_float(row.get("Open"))
+            high_price = self._to_float(row.get("High"))
+            low_price = self._to_float(row.get("Low"))
+            close_price = self._to_float(row.get("Close"))
+            volume = self._to_float(row.get("Volume"))
+            if None in {open_price, high_price, low_price, close_price}:
+                continue
+            candles.append(
+                {
+                    "time": ts,
+                    "open": open_price,
+                    "high": high_price,
+                    "low": low_price,
+                    "close": close_price,
+                    "volume": 0.0 if volume is None else volume,
+                }
+            )
+        candles.sort(key=lambda candle: int(candle["time"]))
+        return candles
+
+    def _aggregate_h4(self, frame: pd.DataFrame) -> list[dict[str, Any]]:
+        normalized = frame.copy()
+        idx = normalized.index
+        if idx.tz is None:
+            idx = idx.tz_localize("UTC")
+        else:
+            idx = idx.tz_convert("UTC")
+        normalized.index = idx
+
+        aggregated = pd.DataFrame(
+            {
+                "Open": normalized["Open"].resample("4h").first(),
+                "High": normalized["High"].resample("4h").max(),
+                "Low": normalized["Low"].resample("4h").min(),
+                "Close": normalized["Close"].resample("4h").last(),
+                "Volume": normalized["Volume"].resample("4h").sum(min_count=1),
+            }
+        ).dropna(subset=["Open", "High", "Low", "Close"], how="any")
+
+        return self._normalize_rows(aggregated)
+
+    @staticmethod
+    def _normalize_symbol(symbol: str) -> str:
+        return str(symbol or "MARKET").upper().replace("/", "").strip()
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        try:
+            if hasattr(value, "iloc"):
+                value = value.iloc[0]
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _to_timestamp(value: Any) -> int | None:
+        try:
+            if isinstance(value, pd.Timestamp):
+                ts = value
+            else:
+                ts = pd.Timestamp(value)
+            if ts.tzinfo is None:
+                ts = ts.tz_localize("UTC")
+            else:
+                ts = ts.tz_convert("UTC")
+            return int(ts.timestamp())
+        except Exception:
+            return None

--- a/tests/test_chart_api.py
+++ b/tests/test_chart_api.py
@@ -38,6 +38,11 @@ def test_chart_data_service_normalizes_twelvedata_payload(monkeypatch) -> None:
 def test_chart_data_service_treats_blank_env_key_as_missing(monkeypatch) -> None:
     monkeypatch.setenv('TWELVEDATA_API_KEY', '   ')
     service = ChartDataService()
+    monkeypatch.setattr(
+        service.yahoo_service,
+        'get_candles',
+        lambda symbol, timeframe, limit: {'symbol': symbol, 'timeframe': timeframe, 'candles': [], 'error': 'empty_history'},
+    )
 
     payload = service.get_chart('GBPUSD', 'H1')
 
@@ -48,12 +53,40 @@ def test_chart_data_service_treats_blank_env_key_as_missing(monkeypatch) -> None
 def test_chart_data_service_returns_unavailable_without_key(monkeypatch) -> None:
     service = ChartDataService()
     monkeypatch.setattr(service, 'api_key', '')
+    monkeypatch.setattr(
+        service.yahoo_service,
+        'get_candles',
+        lambda symbol, timeframe, limit: {'symbol': symbol, 'timeframe': timeframe, 'candles': [], 'error': 'empty_history'},
+    )
 
     payload = service.get_chart('GBPUSD', 'H1')
 
     assert payload['status'] == 'unavailable'
     assert payload['candles'] == []
     assert 'TWELVEDATA_API_KEY' in payload['message_ru']
+
+
+def test_chart_data_service_uses_yahoo_fallback_on_missing_twelvedata_key(monkeypatch) -> None:
+    service = ChartDataService()
+    monkeypatch.setattr(service, 'api_key', '')
+    monkeypatch.setattr(
+        service.yahoo_service,
+        'get_candles',
+        lambda symbol, timeframe, limit: {
+            'symbol': symbol,
+            'timeframe': timeframe,
+            'source_symbol': 'GBPUSD=X',
+            'candles': [{'time': 1710929700, 'open': 1.27, 'high': 1.271, 'low': 1.269, 'close': 1.2705, 'volume': 0}],
+            'error': None,
+        },
+    )
+
+    payload = service.get_chart('GBPUSD', 'H1')
+
+    assert payload['status'] == 'ok'
+    assert payload['source'] == 'yahoo_finance'
+    assert payload['meta']['fallback_from'] == 'twelvedata'
+    assert len(payload['candles']) == 1
 
 
 def test_chart_route_returns_candles_array(monkeypatch) -> None:
@@ -149,3 +182,37 @@ def test_twelvedata_debug_health_endpoint(monkeypatch) -> None:
     assert payload['probe']['provider_interval'] == '15min'
     assert payload['probe']['candles_count'] == 1
     assert payload['probe']['request_succeeded'] is True
+
+
+def test_market_health_debug_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(
+        'app.main.chart_data_service.get_chart',
+        lambda symbol, timeframe: {
+            'symbol': symbol,
+            'timeframe': timeframe,
+            'source': 'yahoo_finance',
+            'status': 'ok',
+            'candles': [{'time': 1710929700, 'open': 1.086, 'high': 1.087, 'low': 1.085, 'close': 1.0865}],
+            'meta': {'provider': 'Yahoo Finance'},
+        },
+    )
+    monkeypatch.setattr(
+        'app.main.chart_data_service.get_last_market_health',
+        lambda: {
+            'provider': 'yahoo_finance',
+            'request_succeeded': True,
+            'candles_count': 1,
+            'error': None,
+            'source_symbol': 'EURUSD=X',
+        },
+    )
+
+    client = TestClient(app)
+    response = client.get('/api/debug/market-health?symbol=EURUSD&timeframe=H1')
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['provider_used'] == 'yahoo_finance'
+    assert payload['request_succeeded'] is True
+    assert payload['candles_count'] == 1
+    assert payload['error'] is None
+    assert payload['source_symbol'] == 'EURUSD=X'


### PR DESCRIPTION
### Motivation
- Обеспечить продолжение генерации идей и рендеринга графиков при rate‑limit/ошибках TwelveData посредством резервного источника без требования ключа. 
- Избежать деградации существующих идей при недостатке или отсутствии свечных данных. 
- Дать инструмент для отладки состояния market‑data с указанием использованного провайдера и причины фолбека. 

### Description
- Добавлен сервис `app/services/yahoo_market_data_service.py` с маппингом FX-символов (`EURUSD -> EURUSD=X`), маппингом таймфреймов, загрузкой через `yfinance`, нормализацией OHLCV и агрегацией H4 из 1h; файл не требует ключа. 
- В `app/services/chart_data_service.py` оставлен TwelveData как первичный источник и реализован безопасный fallback на Yahoo; добавлено хранение последнего состояния провайдера, логирование фолбека и выбор финального провайдера. 
- В `app/services/trade_idea_service.py` добавлен порог `IDEAS_MIN_CANDLES_REQUIRED` (по умолчанию 20) и логика пропуска создания/обновления идеи, если свечей недостаточно. 
- Добавлен debug‑endpoint `GET /api/debug/market-health` в `app/main.py`, который возвращает используемый провайдер, успех запроса, количество свечей, ошибку и source_symbol. 
- Тесты расширены/адаптированы в `tests/test_chart_api.py` для покрытия поведения фолбека Yahoo и нового debug endpoint; зависимости `pandas` и `yfinance` уже присутствовали в `requirements.txt`. 

### Testing
- Выполнена компиляция изменённых модулей через `python -m compileall ...` и ошибок синтаксиса не обнаружено. 
- Запущены модульные тесты `pytest -q tests/test_chart_api.py` и все тесты в этом наборе прошли успешно (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e00ee7908331884fa081063f229b)