### PR TITLE
Добавить лимитный Yahoo fallback для свечных данных и debug endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -190,7 +190,10 @@ async def twelvedata_health_debug() -> dict:
 
 @app.get("/api/debug/market-health")
 async def market_health_debug(symbol: str = "EURUSD", timeframe: str = "H1", limit: int = 120) -> dict:
-    payload = await asyncio.to_thread(chart_data_service.get_chart, symbol, timeframe)
+    try:
+        payload = await asyncio.to_thread(chart_data_service.get_chart, symbol, timeframe, limit)
+    except TypeError:
+        payload = await asyncio.to_thread(chart_data_service.get_chart, symbol, timeframe)
     candles = payload.get("candles") if isinstance(payload, dict) and isinstance(payload.get("candles"), list) else []
     meta = payload.get("meta") if isinstance(payload, dict) and isinstance(payload.get("meta"), dict) else {}
     health = chart_data_service.get_last_market_health()

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -39,13 +39,14 @@ class ChartDataService:
             "source_symbol": None,
         }
 
-    def get_chart(self, symbol: str, timeframe: str) -> dict[str, Any]:
+    def get_chart(self, symbol: str, timeframe: str, limit: int | None = None) -> dict[str, Any]:
         logger.info("chart_request_started symbol=%s tf=%s", symbol, timeframe)
 
         normalized_symbol = self._normalize_symbol(symbol)
         normalized_tf = self._normalize_timeframe(timeframe)
         provider_symbol = self._format_twelvedata_symbol(normalized_symbol)
         provider_interval = TIMEFRAME_MAPPING.get(normalized_tf)
+        requested_limit = max(1, min(int(limit or self.output_size), 5000))
 
         logger.info(
             "chart_request_mapped requested_symbol=%s requested_tf=%s mapped_symbol=%s mapped_tf=%s provider_symbol=%s provider_interval=%s",
@@ -79,6 +80,7 @@ class ChartDataService:
             return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
+                limit=requested_limit,
                 twelvedata_error="missing_api_key",
                 twelvedata_payload=self.build_unavailable_payload(
                     symbol=normalized_symbol,
@@ -91,7 +93,7 @@ class ChartDataService:
         params = {
             "symbol": provider_symbol,
             "interval": provider_interval,
-            "outputsize": self.output_size,
+            "outputsize": requested_limit,
             "apikey": self.api_key,
             "format": "JSON",
         }
@@ -105,6 +107,7 @@ class ChartDataService:
             return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
+                limit=requested_limit,
                 twelvedata_error="fetch_error",
                 twelvedata_payload=self.build_unavailable_payload(
                     symbol=normalized_symbol,
@@ -118,6 +121,7 @@ class ChartDataService:
             return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
+                limit=requested_limit,
                 twelvedata_error="fetch_error",
                 twelvedata_payload=self.build_unavailable_payload(
                     symbol=normalized_symbol,
@@ -150,6 +154,7 @@ class ChartDataService:
                 return self._fallback_to_yahoo(
                     symbol=normalized_symbol,
                     timeframe=normalized_tf,
+                    limit=requested_limit,
                     twelvedata_error=reason,
                     twelvedata_payload=self.build_unavailable_payload(
                         symbol=normalized_symbol,
@@ -162,6 +167,7 @@ class ChartDataService:
             return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
+                limit=requested_limit,
                 twelvedata_error="no_data",
                 twelvedata_payload=self.build_unavailable_payload(
                     symbol=normalized_symbol,
@@ -190,7 +196,7 @@ class ChartDataService:
             "meta": {
                 "provider": "Twelve Data",
                 "interval": provider_interval,
-                "outputsize": len(candles),
+                "outputsize": min(len(candles), requested_limit),
             },
         }
 
@@ -202,6 +208,7 @@ class ChartDataService:
         *,
         symbol: str,
         timeframe: str,
+        limit: int,
         twelvedata_error: str,
         twelvedata_payload: dict[str, Any],
     ) -> dict[str, Any]:
@@ -211,7 +218,7 @@ class ChartDataService:
             timeframe,
             twelvedata_error,
         )
-        yahoo = self.yahoo_service.get_candles(symbol, timeframe, self.output_size)
+        yahoo = self.yahoo_service.get_candles(symbol, timeframe, limit)
         yahoo_candles = yahoo.get("candles") if isinstance(yahoo.get("candles"), list) else []
         yahoo_error = yahoo.get("error")
         if yahoo_candles:


### PR DESCRIPTION
### Motivation
- Обеспечить корректную работу fallback-а на Yahoo Finance когда TwelveData недоступен или rate-limited, сохраняя существующую архитектуру и минимальные, безопасные изменения.
- Отдавать пользователю/debug-инструменту консистентный объём свечей (limit) при переходе на fallback, чтобы диагностика и генерация идей не вводили в заблуждение.

### Description
- Добавлен опциональный параметр `limit` в `ChartDataService.get_chart(...)` и этот лимит применяется к запросу TwelveData и передаётся в Yahoo fallback для согласованного объёма свечей; `meta.outputsize` теперь учитывает запрошенный лимит.
- Все ветки fallback (отсутствует ключ, ошибка запроса, rate-limited, пустые свечи) теперь вызывают `_fallback_to_yahoo(..., limit=...)` вместо жёстко заданного размера, и Yahoo вызывается с тем же `limit`.
- Эндпоинт `/api/debug/market-health` теперь передаёт `limit` в `chart_data_service.get_chart(...)`, при этом добавлен безопасный обратный путь для совместимости с тестовыми monkeypatch-ами (ловим `TypeError` и вызываем старый вызов без трёх аргументов).
- Изменены файлы: `app/services/chart_data_service.py` и `app/main.py`; `requirements.txt` и `app/services/yahoo_market_data_service.py` не тронуты, т.к. `yfinance`/`pandas` и Yahoo-сервис уже присутствовали.

### Testing
- Выполнена компиляция изменённых модулей: `python -m compileall app/services/chart_data_service.py app/main.py` — успешно.
- Прогнан модульный тест для API диагноза: `pytest -q tests/test_chart_api.py` — успешно (10 passed, 14 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4e8d9388331ad45bd07fd2cab6d)