### PR TITLE
Исправить Yahoo fallback: надежный history(), маппинг пар и явный debug

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ from app.services.signal_hub import DEFAULT_PAIRS, SignalHubService
 from app.services.signal_service import SignalService
 from app.services.storage.json_storage import JsonStorage
 from app.services.trade_idea_service import TradeIdeaService
+from app.services.yahoo_market_data_service import YahooMarketDataService
 from app.api.ideas_routes import IdeasRouteServices, build_ideas_router
 from backend.market.services.snapshot_service import MarketSnapshotService
 from backend.chat_service import ChatRequest, ChatResponse, ForexChatService
@@ -57,6 +58,7 @@ signal_service = SignalService(market_data_service=market_data_service)
 signal_analytics_service = SignalAnalyticsService(signal_engine=signal_engine)
 mt4_bridge_service = Mt4BridgeService()
 chart_data_service = ChartDataService()
+yahoo_market_data_service = YahooMarketDataService()
 canonical_market_service = get_canonical_market_service()
 market_snapshot_service = MarketSnapshotService()
 trade_idea_service = TradeIdeaService(signal_engine=signal_engine, chart_data_service=chart_data_service)
@@ -197,12 +199,17 @@ async def market_health_debug(symbol: str = "EURUSD", timeframe: str = "H1", lim
     candles = payload.get("candles") if isinstance(payload, dict) and isinstance(payload.get("candles"), list) else []
     meta = payload.get("meta") if isinstance(payload, dict) and isinstance(payload.get("meta"), dict) else {}
     health = chart_data_service.get_last_market_health()
-    provider_used = health.get("provider") or payload.get("source") or "unknown"
+    final_provider_used = health.get("final_provider_used") or payload.get("source") or "unknown"
     source_symbol = health.get("source_symbol")
     if not source_symbol:
-        source_symbol = _td_symbol(str(symbol).upper().replace("/", "").strip()) if provider_used == "twelvedata" else str(symbol).upper().replace("/", "").strip()
+        source_symbol = _td_symbol(str(symbol).upper().replace("/", "").strip()) if final_provider_used == "twelvedata" else str(symbol).upper().replace("/", "").strip()
     return {
-        "provider_used": provider_used,
+        "primary_provider": health.get("primary_provider") or "twelvedata",
+        "primary_error": health.get("primary_error"),
+        "fallback_attempted": bool(health.get("fallback_attempted")),
+        "fallback_provider": health.get("fallback_provider"),
+        "fallback_error": health.get("fallback_error"),
+        "final_provider_used": final_provider_used,
         "request_succeeded": bool(health.get("request_succeeded") or len(candles) > 0),
         "candles_count": int(health.get("candles_count") or len(candles)),
         "error": health.get("error"),
@@ -212,6 +219,24 @@ async def market_health_debug(symbol: str = "EURUSD", timeframe: str = "H1", lim
         "requested_limit": max(1, int(limit or 1)),
         "status": payload.get("status"),
         "meta_provider": meta.get("provider"),
+    }
+
+
+@app.get("/api/debug/yahoo-test")
+@app.get("/api/debug/yahoo-test/{symbol}/{timeframe}")
+async def yahoo_test_debug(symbol: str = "EURUSD", timeframe: str = "H1", limit: int = 120) -> dict:
+    yahoo_payload = await asyncio.to_thread(yahoo_market_data_service.get_candles, symbol, timeframe, limit)
+    candles = yahoo_payload.get("candles") if isinstance(yahoo_payload.get("candles"), list) else []
+    return {
+        "provider": "yahoo",
+        "request_succeeded": len(candles) > 0,
+        "candles_count": len(candles),
+        "error": yahoo_payload.get("error"),
+        "source_symbol": yahoo_payload.get("source_symbol"),
+        "symbol": str(symbol).upper().replace("/", "").strip(),
+        "timeframe": str(timeframe or "H1").upper().strip(),
+        "first_candle": candles[0] if candles else None,
+        "last_candle": candles[-1] if candles else None,
     }
 
 

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -32,7 +32,12 @@ class ChartDataService:
         self.output_size = int(os.getenv("TWELVEDATA_OUTPUTSIZE", str(DEFAULT_CHART_LIMIT)))
         self.yahoo_service = YahooMarketDataService()
         self._last_market_health: dict[str, Any] = {
-            "provider": None,
+            "primary_provider": "twelvedata",
+            "primary_error": None,
+            "fallback_attempted": False,
+            "fallback_provider": "yahoo_finance",
+            "fallback_error": None,
+            "final_provider_used": None,
             "request_succeeded": False,
             "candles_count": 0,
             "error": "not_started",
@@ -67,7 +72,12 @@ class ChartDataService:
                 reason="fetch_error",
             )
             self._set_market_health(
-                provider="twelvedata",
+                primary_provider="twelvedata",
+                primary_error="unsupported_timeframe",
+                fallback_attempted=False,
+                fallback_provider="yahoo_finance",
+                fallback_error=None,
+                final_provider_used="twelvedata",
                 request_succeeded=False,
                 candles_count=0,
                 error="unsupported_timeframe",
@@ -179,7 +189,12 @@ class ChartDataService:
 
         logger.info("twelvedata_success symbol=%s tf=%s candles=%s", normalized_symbol, normalized_tf, len(candles))
         self._set_market_health(
-            provider="twelvedata",
+            primary_provider="twelvedata",
+            primary_error=None,
+            fallback_attempted=False,
+            fallback_provider="yahoo_finance",
+            fallback_error=None,
+            final_provider_used="twelvedata",
             request_succeeded=True,
             candles_count=len(candles),
             error=None,
@@ -224,7 +239,12 @@ class ChartDataService:
         if yahoo_candles:
             logger.info("yahoo_fallback_success symbol=%s tf=%s candles=%s", symbol, timeframe, len(yahoo_candles))
             self._set_market_health(
-                provider="yahoo_finance",
+                primary_provider="twelvedata",
+                primary_error=twelvedata_error,
+                fallback_attempted=True,
+                fallback_provider="yahoo_finance",
+                fallback_error=None,
+                final_provider_used="yahoo_finance",
                 request_succeeded=True,
                 candles_count=len(yahoo_candles),
                 error=None,
@@ -247,7 +267,12 @@ class ChartDataService:
             }
         logger.warning("yahoo_fallback_failed symbol=%s tf=%s error=%s", symbol, timeframe, yahoo_error)
         self._set_market_health(
-            provider="twelvedata",
+            primary_provider="twelvedata",
+            primary_error=twelvedata_error,
+            fallback_attempted=True,
+            fallback_provider="yahoo_finance",
+            fallback_error=yahoo_error or "unknown_error",
+            final_provider_used=None,
             request_succeeded=False,
             candles_count=0,
             error=f"twelvedata:{twelvedata_error};yahoo:{yahoo_error or 'unknown_error'}",
@@ -258,22 +283,34 @@ class ChartDataService:
     def _set_market_health(
         self,
         *,
-        provider: str,
+        primary_provider: str,
+        primary_error: str | None,
+        fallback_attempted: bool,
+        fallback_provider: str | None,
+        fallback_error: str | None,
+        final_provider_used: str | None,
         request_succeeded: bool,
         candles_count: int,
         error: str | None,
         source_symbol: str | None,
     ) -> None:
         self._last_market_health = {
-            "provider": provider,
+            "primary_provider": primary_provider,
+            "primary_error": primary_error,
+            "fallback_attempted": fallback_attempted,
+            "fallback_provider": fallback_provider,
+            "fallback_error": fallback_error,
+            "final_provider_used": final_provider_used,
             "request_succeeded": request_succeeded,
             "candles_count": max(0, int(candles_count or 0)),
             "error": error,
             "source_symbol": source_symbol,
         }
         logger.info(
-            "market_provider_selected provider=%s request_succeeded=%s candles=%s error=%s source_symbol=%s",
-            provider,
+            "market_provider_selected primary_provider=%s final_provider=%s fallback_attempted=%s request_succeeded=%s candles=%s error=%s source_symbol=%s",
+            primary_provider,
+            final_provider_used,
+            fallback_attempted,
             request_succeeded,
             candles_count,
             error,

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -671,6 +671,25 @@ class TradeIdeaService:
         ideas = store.get("ideas", [])
         symbol = str(signal.get("symbol", "")).upper()
         timeframe = str(signal.get("timeframe", "H1")).upper()
+        latest_matching_idea = self._latest_matching_idea(
+            ideas=ideas,
+            symbol=symbol,
+            timeframe=timeframe,
+        )
+        chart_payload = self.chart_data_service.get_chart(symbol, timeframe)
+        final_candles = chart_payload.get("candles") if isinstance(chart_payload.get("candles"), list) else []
+        if len(final_candles) < MIN_IDEA_CANDLES_REQUIRED:
+            logger.info(
+                "ideas_pipeline_skip_upsert_final_provider_candles symbol=%s timeframe=%s candles_count=%s min_required=%s provider=%s",
+                symbol,
+                timeframe,
+                len(final_candles),
+                MIN_IDEA_CANDLES_REQUIRED,
+                chart_payload.get("source"),
+            )
+            if latest_matching_idea is not None:
+                return latest_matching_idea
+            return signal
         setup_type = self._setup_type(signal)
         action = str(signal.get("action", "NO_TRADE")).upper()
         now = datetime.now(timezone.utc)
@@ -687,11 +706,6 @@ class TradeIdeaService:
         )
 
         if active_index is None and action == "NO_TRADE":
-            latest_matching_idea = self._latest_matching_idea(
-                ideas=ideas,
-                symbol=symbol,
-                timeframe=timeframe,
-            )
             if latest_matching_idea is not None:
                 return latest_matching_idea
 

--- a/app/services/yahoo_market_data_service.py
+++ b/app/services/yahoo_market_data_service.py
@@ -9,87 +9,76 @@ import yfinance as yf
 
 logger = logging.getLogger(__name__)
 
-_YAHOO_TIMEFRAME_CONFIG: dict[str, dict[str, str]] = {
-    "M15": {"interval": "15m", "period": "7d"},
-    "H1": {"interval": "60m", "period": "60d"},
-    "H4": {"interval": "60m", "period": "60d"},
+_YAHOO_TIMEFRAME_CONFIG: dict[str, dict[str, Any]] = {
+    "M15": {"interval": "15m", "periods": ["2d", "5d"]},
+    "H1": {"interval": "60m", "periods": ["5d", "1mo"]},
+    "H4": {"interval": "60m", "periods": ["5d", "1mo"]},
 }
 
 
 class YahooMarketDataService:
     def map_symbol(self, symbol: str) -> str:
+        return self.map_symbol_candidates(symbol)[0]
+
+    def map_symbol_candidates(self, symbol: str) -> list[str]:
         normalized = self._normalize_symbol(symbol)
         explicit = {
-            "EURUSD": "EURUSD=X",
-            "GBPUSD": "GBPUSD=X",
-            "USDJPY": "USDJPY=X",
-            "AUDUSD": "AUDUSD=X",
-            "USDCAD": "USDCAD=X",
-            "USDCHF": "USDCHF=X",
-            "NZDUSD": "NZDUSD=X",
-            "EURGBP": "EURGBP=X",
-            "EURCHF": "EURCHF=X",
-            "XAUUSD": "XAUUSD=X",
+            "EURUSD": ["EURUSD=X"],
+            "GBPUSD": ["GBPUSD=X"],
+            "USDJPY": ["JPY=X"],
+            "XAUUSD": ["XAUUSD=X", "GC=F"],
         }
         if normalized in explicit:
             return explicit[normalized]
         if len(normalized) == 6 and normalized.isalpha():
-            return f"{normalized}=X"
-        return normalized
+            return [f"{normalized}=X"]
+        return [normalized]
 
-    def map_timeframe(self, timeframe: str) -> dict[str, str] | None:
+    def map_timeframe(self, timeframe: str) -> dict[str, Any] | None:
         return _YAHOO_TIMEFRAME_CONFIG.get(str(timeframe or "H1").upper().strip())
 
     def get_candles(self, symbol: str, timeframe: str, limit: int = 120) -> dict[str, Any]:
         normalized_symbol = self._normalize_symbol(symbol)
         normalized_tf = str(timeframe or "H1").upper().strip()
         mapped_tf = self.map_timeframe(normalized_tf)
-        source_symbol = self.map_symbol(normalized_symbol)
+        symbol_candidates = self.map_symbol_candidates(normalized_symbol)
 
         if mapped_tf is None:
             return {
                 "symbol": normalized_symbol,
                 "timeframe": normalized_tf,
                 "source": "yahoo_finance",
-                "source_symbol": source_symbol,
+                "source_symbol": symbol_candidates[0],
                 "candles": [],
                 "error": "unsupported_timeframe",
             }
 
-        try:
-            raw = yf.download(
-                tickers=source_symbol,
-                interval=mapped_tf["interval"],
-                period=mapped_tf["period"],
-                auto_adjust=False,
-                progress=False,
-                threads=False,
-            )
-        except Exception as exc:
-            logger.warning("yahoo_fetch_failed symbol=%s tf=%s error=%s", normalized_symbol, normalized_tf, exc)
-            return {
-                "symbol": normalized_symbol,
-                "timeframe": normalized_tf,
-                "source": "yahoo_finance",
-                "source_symbol": source_symbol,
-                "candles": [],
-                "error": "request_failed",
-            }
+        interval = str(mapped_tf["interval"])
+        periods = [str(period) for period in list(mapped_tf.get("periods") or [])[:2]]
+        if not periods:
+            periods = ["5d"]
 
-        if not isinstance(raw, pd.DataFrame) or raw.empty:
-            return {
-                "symbol": normalized_symbol,
-                "timeframe": normalized_tf,
-                "source": "yahoo_finance",
-                "source_symbol": source_symbol,
-                "candles": [],
-                "error": "empty_history",
-            }
+        last_error = "empty_history"
+        source_symbol = symbol_candidates[0]
+        candles: list[dict[str, Any]] = []
 
-        if normalized_tf == "H4":
-            candles = self._aggregate_h4(raw)
-        else:
-            candles = self._normalize_rows(raw)
+        for candidate in symbol_candidates:
+            source_symbol = candidate
+            for period in periods:
+                frame, error = self._fetch_history(candidate, interval, period)
+                if error is not None:
+                    last_error = error
+                    continue
+                if frame is None or frame.empty:
+                    last_error = "empty_history"
+                    continue
+
+                candles = self._aggregate_h4(frame) if normalized_tf == "H4" else self._normalize_rows(frame)
+                if candles:
+                    break
+                last_error = "empty_candles"
+            if candles:
+                break
 
         bounded = candles[-max(1, min(int(limit or 1), 5000)) :]
         return {
@@ -99,8 +88,19 @@ class YahooMarketDataService:
             "source_symbol": source_symbol,
             "last_updated_utc": datetime.now(timezone.utc).isoformat(),
             "candles": bounded,
-            "error": None if bounded else "empty_candles",
+            "error": None if bounded else last_error,
         }
+
+    def _fetch_history(self, symbol: str, interval: str, period: str) -> tuple[pd.DataFrame | None, str | None]:
+        try:
+            ticker = yf.Ticker(symbol)
+            history = ticker.history(period=period, interval=interval, auto_adjust=False)
+            if isinstance(history, pd.DataFrame) and not history.empty:
+                return history, None
+            return history, "empty_history"
+        except Exception as exc:
+            logger.warning("yahoo_fetch_failed symbol=%s interval=%s period=%s error=%s", symbol, interval, period, exc)
+            return None, "request_failed"
 
     def _normalize_rows(self, frame: pd.DataFrame) -> list[dict[str, Any]]:
         candles: list[dict[str, Any]] = []


### PR DESCRIPTION
### Motivation
- Yahoo через `yf.download(...)` возвращал пустую историю для FX-пар, поэтому fallback не давал свечей и идеи не генерировались.
- Нужно было оставить текущую цепочку (TwelveData -> Yahoo) и минимально повысить надёжность получения свечей без API-ключей.

### Description
- Переписан Yahoo fetch в `app/services/yahoo_market_data_service.py` на `yfinance.Ticker(...).history(...)` с консервативным маппингом символов и пробными периодами; добавлены кандидаты символов (`USDJPY -> JPY=X`, `XAUUSD -> XAUUSD=X` затем `GC=F`).
- Введены правила временных интервалов и повторных попыток: `M15` — `interval="15m"` с `periods=["2d","5d"]`, `H1` — `interval="60m"` с `periods=["5d","1mo"]`, `H4` — забираем `60m` и агрегируем в 4h свечи.
- Нормализован выход в формате свечи `{ "time", "open", "high", "low", "close", "volume" }` и сохранена агрегация H4.
- Обновлён health-инструмент `app/services/chart_data_service.py` и combined debug `GET /api/debug/market-health` для явного отображения `primary_provider`, `primary_error`, `fallback_attempted`, `fallback_provider`, `fallback_error`, `final_provider_used`.
- Добавлен Yahoo-only debug endpoint `GET /api/debug/yahoo-test` и `GET /api/debug/yahoo-test/{symbol}/{timeframe}` в `app/main.py` для тестирования только Yahoo-fallback.
- В `app/services/trade_idea_service.py` добавлена защита: при недостатке финальных свечей от выбранного провайдера апдейт/создание идеи не выполняется и существующая идея сохраняется.
- Изменён список изменённых файлов: `app/services/yahoo_market_data_service.py`, `app/services/chart_data_service.py`, `app/main.py`, `app/services/trade_idea_service.py`.

### Testing
- Выполнена статическая компиляция Python-файлов: `python -m compileall app/main.py app/services/chart_data_service.py app/services/yahoo_market_data_service.py app/services/trade_idea_service.py` — сборка прошла успешно.
- Запущена ручная проверка Yahoo через скрипт импорта сервиса: `YahooMarketDataService().get_candles(...)` для `EURUSD M15`, `USDJPY H1`, `XAUUSD H1` — свечи получены (включая fallback на `GC=F` для золота) и ошибки не возникли.
- Серверные изменения собраны и endpoint `GET /api/debug/yahoo-test` возвращает поля `provider`, `request_succeeded`, `candles_count`, `error`, `source_symbol`, `first_candle`, `last_candle` (проверено вручную).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f0bb51848331b2938a01faa67b98)