### PR TITLE
Принудительная регенерация идей при восстановлении свечных данных

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -678,6 +678,16 @@ class TradeIdeaService:
         )
         chart_payload = self.chart_data_service.get_chart(symbol, timeframe)
         final_candles = chart_payload.get("candles") if isinstance(chart_payload.get("candles"), list) else []
+        candles_count = len(final_candles)
+        data_is_available = candles_count > 50
+        should_regenerate = (
+            data_is_available
+            and latest_matching_idea is not None
+            and (
+                bool(latest_matching_idea.get("is_fallback"))
+                or str(latest_matching_idea.get("status") or "").lower() == IDEA_STATUS_WAITING
+            )
+        )
         if len(final_candles) < MIN_IDEA_CANDLES_REQUIRED:
             logger.info(
                 "ideas_pipeline_skip_upsert_final_provider_candles symbol=%s timeframe=%s candles_count=%s min_required=%s provider=%s",
@@ -704,12 +714,32 @@ class TradeIdeaService:
             ),
             None,
         )
-
-        if active_index is None and action == "NO_TRADE":
-            if latest_matching_idea is not None:
-                return latest_matching_idea
-
-        if active_index is not None:
+        if data_is_available:
+            target_index = active_index
+            if target_index is None and latest_matching_idea is not None:
+                try:
+                    target_index = ideas.index(latest_matching_idea)
+                except ValueError:
+                    target_index = None
+            updated = self._build_idea(signal, existing=None, now=now)
+            updated["is_fallback"] = False
+            updated["status"] = IDEA_STATUS_ACTIVE
+            updated["regenerated"] = True
+            if target_index is not None:
+                previous = ideas[target_index]
+                ideas[target_index] = updated
+                self._append_snapshot(updated, previous=previous)
+            else:
+                ideas.append(updated)
+                self._append_snapshot(updated, previous=None)
+            logger.info(
+                "ideas_regenerated_on_data_recovery symbol=%s timeframe=%s candles_count=%s had_fallback_or_waiting=%s",
+                symbol,
+                timeframe,
+                candles_count,
+                should_regenerate,
+            )
+        elif active_index is not None:
             current = ideas[active_index]
             updated = self._build_idea(signal, existing=current, now=now)
             ideas[active_index] = updated


### PR DESCRIPTION
### Motivation
- Исправить ситуацию, когда fallback/ожидающие идеи «залипают» и не заменяются после того, как свечные данные стали доступны снова (нужно заставлять пересоздавать идею при восстановлении данных). 

### Description
- Добавлена детекция восстановления данных в `upsert_trade_idea` через `candles_count = len(final_candles)` и `data_is_available = candles_count > 50` в файле `app/services/trade_idea_service.py`.
- При `data_is_available` идея теперь всегда генерируется заново вызовом `_build_idea(..., existing=None, ...)`, а при наличии существующей записи по символу/ТФ она заменяется вместо повторного использования старой fallback/waiting идеи.
- После регенерации явно выставляются флаги `is_fallback = False`, `status = "active"` и добавляется отладочное поле `regenerated = True`.
- Убран ранний возврат существующей идеи в сценариях, когда данные восстановились, чтобы снять «fallback lock» и принудительно перейти в активный поток генерации.

### Testing
- Запущена проверка компиляции файла командой `python -m compileall app/services/trade_idea_service.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f6e2c45c8331a81902db1a10b3af)