### PR TITLE
Исправить приоритет narrative в карточке идеи и устойчивость рендера графика

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -255,11 +255,20 @@ class TradeIdeaService:
                 "sell": "План: работать только от short-сценария при подтверждении M15, SL выше структуры, TP по ближайшей ликвидности.",
                 "wait": "План: без входа до синхронизации H4/H1 и появления чистого M15-триггера.",
             }.get(final_signal, "План: сохранять дисциплину риска и дождаться подтверждения.")
+            invalidation_text = (
+                "Инвалидация: сценарий теряет силу при сломе структуры H1/H4 или если M15 закрепляется против базового направления."
+            )
             unified_narrative = (
                 f"Ситуация: {symbol} торгуется в режиме MTF-оценки, текущий фокус — {direction_ru}. "
                 f"Причина: H4 — {h4_structure or h4_dir}, H1 — {h1_structure or h1_dir}, M15 — {m15_trigger or m15_dir}. "
+                f"Подтверждение: {final_reason} "
                 f"Ожидание: {expectation_text} "
-                f"Действие: {action_text} ({final_reason})"
+                f"Действие: {action_text} "
+                f"{invalidation_text}"
+            )
+            compact_summary = (
+                f"{symbol}: H4={h4_dir if h4 else 'нет данных'}; H1={h1_dir if h1 else 'нет данных'}; "
+                f"M15={m15_dir if m15 else 'нет данных'}. Итог: {final_signal.upper()}."
             )
 
             preferred_timeframe_idea = m15 or h1 or h4 or symbol_ideas[0]
@@ -284,14 +293,12 @@ class TradeIdeaService:
                     "direction": final_direction,
                     "bias": final_direction,
                     "confidence": final_confidence,
-                    "idea_thesis": (
-                        f"{symbol}: H4={h4_dir if h4 else 'нет данных'}; H1={h1_dir if h1 else 'нет данных'}; "
-                        f"M15={m15_dir if m15 else 'нет данных'}. Итог: {final_signal.upper()}."
-                    ),
+                    "idea_thesis": unified_narrative,
                     "unified_narrative": unified_narrative,
                     "summary": final_reason,
                     "summary_ru": final_reason,
                     "short_text": final_reason,
+                    "compact_summary": compact_summary,
                     "combined": True,
                     "final_signal": final_signal,
                     "final_confidence": final_confidence,

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -125,6 +125,12 @@ function normalizeWhitespace(value) {
   return String(value ?? "").replace(/\s+/g, " ").trim();
 }
 
+function isCompactTechnicalSummary(value) {
+  const text = normalizeWhitespace(value).toLowerCase();
+  if (!text) return false;
+  return /h4\s*=\s*(bullish|bearish|neutral|нет данных).+h1\s*=\s*(bullish|bearish|neutral|нет данных).+m15\s*=\s*(bullish|bearish|neutral|нет данных).+итог:\s*(buy|sell|wait)/i.test(text);
+}
+
 function formatDateTime(value) {
   const text = normalizeWhitespace(value);
   if (!text) return "—";
@@ -210,23 +216,28 @@ function buildShortText(idea) {
 
 function buildFullText(idea) {
   const thesis = normalizeWhitespace(idea?.idea_thesis || idea?.ideaThesis);
-  if (isRenderableNarrative(thesis)) return thesis;
+  if (isRenderableNarrative(thesis) && !isCompactTechnicalSummary(thesis)) return thesis;
   const unified = normalizeWhitespace(idea?.unified_narrative);
-  if (isRenderableNarrative(unified)) return unified;
-  const direct = normalizeWhitespace(
-    idea?.full_text
-      || idea?.fullText
-      || idea?.narrative
-      || idea?.description_ru
-      || idea?.reason_ru
-      || idea?.rationale
-  );
-  if (isRenderableNarrative(direct)) return direct;
+  if (isRenderableNarrative(unified) && !isCompactTechnicalSummary(unified)) return unified;
+  const legacyNarrativeCandidates = [
+    idea?.full_text,
+    idea?.fullText,
+    idea?.narrative,
+    idea?.description_ru,
+    idea?.reason_ru,
+    idea?.rationale,
+    idea?.idea_context_ru,
+    idea?.ideaContext,
+  ];
+  for (const candidate of legacyNarrativeCandidates) {
+    const text = normalizeWhitespace(candidate);
+    if (isRenderableNarrative(text) && !isCompactTechnicalSummary(text)) return text;
+  }
   const { summaryStructured, tradePlanStructured } = getStructuredNarrativeBlocks(idea);
   const structuredText = normalizeWhitespace(summaryStructured?.situation) || normalizeWhitespace(tradePlanStructured?.entry_trigger);
-  if (isRenderableNarrative(structuredText)) return structuredText;
+  if (isRenderableNarrative(structuredText) && !isCompactTechnicalSummary(structuredText)) return structuredText;
   const detailSummary = normalizeWhitespace(idea?.detail_brief?.summary_narrative);
-  if (isRenderableNarrative(detailSummary)) return detailSummary;
+  if (isRenderableNarrative(detailSummary) && !isCompactTechnicalSummary(detailSummary)) return detailSummary;
   const legacySummary = normalizeWhitespace(idea?.summary || idea?.summary_ru);
   if (isRenderableNarrative(legacySummary)) return legacySummary;
   return "Подробное описание пока не получено. Дождитесь обновления идеи перед входом в сделку.";
@@ -384,6 +395,10 @@ function normalizeIdea(idea) {
     stopLoss: idea?.stopLoss ?? idea?.stop_loss ?? "—",
     takeProfit: idea?.takeProfit ?? idea?.take_profit ?? "—",
     chartData: idea?.chartData ?? idea?.chart_data ?? null,
+    chartImageUrl: normalizeChartImageUrl(idea?.chartImageUrl || idea?.chart_image || ""),
+    chart_image: normalizeChartImageUrl(idea?.chart_image || idea?.chartImageUrl || ""),
+    chartSnapshotStatus: idea?.chartSnapshotStatus || idea?.chart_snapshot_status || "",
+    chart_snapshot_status: idea?.chart_snapshot_status || idea?.chartSnapshotStatus || "",
     chart_overlays: idea?.chart_overlays
       ?? idea?.chartOverlays
       ?? idea?.chart_data?.chart_overlays


### PR DESCRIPTION
### Motivation
- В combined-карточках основной текст превращался в компактную техническую строку вида "H4=...; H1=...; M15=...", потому что это записывалось в `idea_thesis`, а frontend отдаёт ей приоритет. 
- В результате трейдерское объяснение было нечитабельно сухим, а область графика иногда оставалась пустой из‑за потери URL снапшота при нормализации в UI.

### Description
- Заменил формирование combined-идеи в `app/services/trade_idea_service.py`, теперь `idea_thesis` получает полноценный трейдерский narrative с блоками «Ситуация / Причина / Подтверждение / Ожидание / Действие / Инвалидация», а компактная TF-строка вынесена в поле `compact_summary` (сохранена совместимость). 
- Защитил frontend выбор основного текста в `app/static/js/chart-page.js`, добавив проверку и исключение компактных технических summary из приоритетных полей и расширив порядок поиска текста: `idea_thesis -> unified_narrative -> legacy candidates -> structured/detail -> fallback`. 
- Исправил привязку snapshot URL и статусов в `normalizeIdea()` так, чтобы `chartImageUrl`/`chart_image` и `chartSnapshotStatus` корректно проходили в нормализованный объект и изображение рендерилось приоритетно в модальном окне. 
- Оставил существующую логику fallback для графика: при отсутствии снимка используется payload свечей (`chartData` либо `/api/chart/...`), иначе показывается плейсхолдер; кеш последнего валидного графика (`lastValidChartByIdeaId`) сохраняется для устойчивости при слабых обновлениях.
- Изменённые файлы: `app/services/trade_idea_service.py`, `app/static/js/chart-page.js`.

### Testing
- Выполнена проверка синтаксиса Python: `python -m py_compile app/services/trade_idea_service.py app/services/chart_snapshot_service.py` — успешно. 
- Выполнена проверка синтаксиса JS: `node --check app/static/js/chart-page.js` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fc38f51083319e5ecfb819eb49fc)