### PR TITLE
Усиление валидации свечей и улучшение тезиса WAIT / MTF идей

### DIFF
--- a/app/services/canonical_market_service.py
+++ b/app/services/canonical_market_service.py
@@ -84,7 +84,8 @@ class CanonicalMarketService:
                 return derived
 
         primary = self.live_provider.get_candles(symbol, normalized_tf, limit)
-        primary_candles = primary.get("candles") or []
+        primary_raw = primary.get("candles") or []
+        primary_candles = [item for item in (self._normalize_candle(candle) for candle in primary_raw) if item is not None]
         primary_error = primary.get("error")
         if primary_candles:
             contract = self._contract(
@@ -106,7 +107,8 @@ class CanonicalMarketService:
             return contract
 
         fallback = self.historical_fallback.get_candles(symbol, normalized_tf, limit)
-        fallback_candles = fallback.get("candles") or []
+        fallback_raw = fallback.get("candles") or []
+        fallback_candles = [item for item in (self._normalize_candle(candle) for candle in fallback_raw) if item is not None]
         if fallback_candles:
             contract = self._contract(
                 symbol=symbol,
@@ -191,8 +193,11 @@ class CanonicalMarketService:
             ts = candle.get("time")
             if ts is None:
                 continue
+            normalized = CanonicalMarketService._normalize_candle(candle)
+            if normalized is None:
+                continue
             bucket_start = (int(ts) // 14400) * 14400
-            buckets.setdefault(bucket_start, []).append(candle)
+            buckets.setdefault(bucket_start, []).append(normalized)
 
         output: list[dict[str, Any]] = []
         for bucket_start in sorted(buckets.keys()):
@@ -214,9 +219,34 @@ class CanonicalMarketService:
                     "close": float(closes),
                 }
             )
+        output = [candle for candle in output if CanonicalMarketService._normalize_candle(candle) is not None]
         if limit > 0:
             return output[-limit:]
         return output
+
+    @staticmethod
+    def _normalize_candle(candle: dict[str, Any]) -> dict[str, float | int] | None:
+        try:
+            timestamp = int(candle.get("time"))
+            open_price = float(candle.get("open"))
+            high_price = float(candle.get("high"))
+            low_price = float(candle.get("low"))
+            close_price = float(candle.get("close"))
+        except (TypeError, ValueError):
+            return None
+        lower_bound = min(open_price, close_price)
+        upper_bound = max(open_price, close_price)
+        repaired_low = min(low_price, lower_bound)
+        repaired_high = max(high_price, upper_bound)
+        if repaired_low > repaired_high:
+            return None
+        return {
+            "time": timestamp,
+            "open": open_price,
+            "high": repaired_high,
+            "low": repaired_low,
+            "close": close_price,
+        }
 
     @staticmethod
     def _contract(

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -377,6 +377,15 @@ class ChartDataService:
             close_price = cls._to_float(item.get("close"))
             if None in {timestamp, open_price, high_price, low_price, close_price}:
                 continue
+            normalized_ohlc = cls._normalize_ohlc(
+                open_price=open_price,
+                high_price=high_price,
+                low_price=low_price,
+                close_price=close_price,
+            )
+            if normalized_ohlc is None:
+                continue
+            open_price, high_price, low_price, close_price = normalized_ohlc
             candles.append(
                 {
                     "timestamp": timestamp,
@@ -389,6 +398,22 @@ class ChartDataService:
             )
         candles.sort(key=lambda candle: int(candle["time"]))
         return candles
+
+    @staticmethod
+    def _normalize_ohlc(
+        *,
+        open_price: float,
+        high_price: float,
+        low_price: float,
+        close_price: float,
+    ) -> tuple[float, float, float, float] | None:
+        lower_bound = min(open_price, close_price)
+        upper_bound = max(open_price, close_price)
+        repaired_low = min(low_price, lower_bound)
+        repaired_high = max(high_price, upper_bound)
+        if repaired_low > repaired_high:
+            return None
+        return open_price, repaired_high, repaired_low, close_price
 
     @classmethod
     def _extract_timestamp(cls, item: dict[str, Any]) -> int | None:

--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -44,6 +44,10 @@ class ChartSnapshotService:
         if not candles:
             logger.info("idea_snapshot_skipped reason=no_candles symbol=%s timeframe=%s", symbol, timeframe)
             return None
+        candles = self._sanitize_candles(candles)
+        if not candles:
+            logger.info("idea_snapshot_skipped reason=invalid_candles symbol=%s timeframe=%s", symbol, timeframe)
+            return None
         levels = levels or []
         zones = zones or []
         markers = markers or []
@@ -274,6 +278,39 @@ class ChartSnapshotService:
         if self.is_valid_snapshot_path(existing_chart):
             return str(existing_chart)
         return None
+
+    @classmethod
+    def _sanitize_candles(cls, candles: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        sanitized: list[dict[str, Any]] = []
+        for candle in candles:
+            normalized = cls._sanitize_single_candle(candle)
+            if normalized is None:
+                continue
+            sanitized.append(normalized)
+        return sanitized
+
+    @staticmethod
+    def _sanitize_single_candle(candle: dict[str, Any]) -> dict[str, Any] | None:
+        try:
+            timestamp = int(candle.get("time") or candle.get("timestamp"))
+            open_price = float(candle.get("open"))
+            high_price = float(candle.get("high"))
+            low_price = float(candle.get("low"))
+            close_price = float(candle.get("close"))
+        except (TypeError, ValueError):
+            return None
+        repaired_low = min(low_price, open_price, close_price)
+        repaired_high = max(high_price, open_price, close_price)
+        if repaired_low > repaired_high:
+            return None
+        return {
+            "time": timestamp,
+            "timestamp": timestamp,
+            "open": open_price,
+            "high": repaired_high,
+            "low": repaired_low,
+            "close": close_price,
+        }
 
     def _draw_zones(self, *, ax: Any, zones: list[dict[str, Any]], candles_count: int, max_price: float) -> None:
         styles = {

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -213,21 +213,28 @@ class TradeIdeaService:
             final_signal = "wait"
             final_direction = "neutral"
             final_reason = "Нет согласованного multi-timeframe подтверждения."
+            wait_conflict = "multi_timeframe_conflict"
             if h4 and h1 and h4_dir in {"bullish", "bearish"} and h4_dir == h1_dir:
                 if m15_dir == h4_dir:
                     final_signal = "buy" if h4_dir == "bullish" else "sell"
                     final_direction = h4_dir
                     final_reason = "H4 и H1 согласованы, M15 подтвердил триггер."
+                    wait_conflict = "none"
                 elif m15_dir == "neutral" or not m15:
                     final_reason = "H4 и H1 согласованы, но на M15 ещё нет триггера."
+                    wait_conflict = "missing_m15_trigger"
                 else:
                     final_reason = "H4 и H1 согласованы, но M15 против базового направления."
+                    wait_conflict = "m15_opposes_trend"
             elif h4 and h1 and h4_dir in {"bullish", "bearish"} and h1_dir in {"bullish", "bearish"} and h4_dir != h1_dir:
                 final_reason = "Конфликт HTF и MTF структуры: H4 и H1 разнонаправлены."
+                wait_conflict = "h4_h1_conflict"
             elif h1 and m15 and h1_dir in {"bullish", "bearish"} and m15_dir == h1_dir and not h4:
                 final_reason = "Недостаточно HTF контекста (H4 отсутствует), ожидаем подтверждение старшего ТФ."
+                wait_conflict = "missing_h4_context"
             elif m15 and m15_dir in {"bullish", "bearish"} and (not h4 or h4_dir != m15_dir):
                 final_reason = "LTF сигнал против старшего контекста, идея не продвигается в trade."
+                wait_conflict = "ltf_vs_htf_conflict"
 
             confidence_values = [
                 int(self._extract_numeric(item.get("confidence")) or 0)
@@ -258,6 +265,24 @@ class TradeIdeaService:
             invalidation_text = (
                 "Инвалидация: сценарий теряет силу при сломе структуры H1/H4 или если M15 закрепляется против базового направления."
             )
+            if final_signal == "wait":
+                idea_thesis = self._build_wait_thesis(
+                    symbol=symbol,
+                    h4=h4,
+                    h1=h1,
+                    m15=m15,
+                    h4_dir=h4_dir,
+                    h1_dir=h1_dir,
+                    m15_dir=m15_dir,
+                    wait_conflict=wait_conflict,
+                    final_reason=final_reason,
+                )
+            else:
+                idea_thesis = (
+                    f"{symbol}: сценарий {final_signal.upper()} подтверждён по MTF. "
+                    f"H4 и H1 синхронизированы ({h4_dir}/{h1_dir}), M15 дал рабочий триггер. "
+                    f"Фокус: {expectation_text}"
+                )
             unified_narrative = (
                 f"Ситуация: {symbol} торгуется в режиме MTF-оценки, текущий фокус — {direction_ru}. "
                 f"Причина: H4 — {h4_structure or h4_dir}, H1 — {h1_structure or h1_dir}, M15 — {m15_trigger or m15_dir}. "
@@ -270,6 +295,7 @@ class TradeIdeaService:
                 f"{symbol}: H4={h4_dir if h4 else 'нет данных'}; H1={h1_dir if h1 else 'нет данных'}; "
                 f"M15={m15_dir if m15 else 'нет данных'}. Итог: {final_signal.upper()}."
             )
+            legacy_narrative = self._pick_legacy_narrative(preferred=m15 or h1 or h4 or symbol_ideas[0])
 
             preferred_timeframe_idea = m15 or h1 or h4 or symbol_ideas[0]
             latest_update = max(
@@ -293,8 +319,9 @@ class TradeIdeaService:
                     "direction": final_direction,
                     "bias": final_direction,
                     "confidence": final_confidence,
-                    "idea_thesis": unified_narrative,
+                    "idea_thesis": idea_thesis,
                     "unified_narrative": unified_narrative,
+                    "legacy_narrative": legacy_narrative,
                     "summary": final_reason,
                     "summary_ru": final_reason,
                     "short_text": final_reason,
@@ -324,6 +351,60 @@ class TradeIdeaService:
             )
         )
         return combined_cards
+
+    @staticmethod
+    def _pick_legacy_narrative(preferred: dict[str, Any]) -> str:
+        candidates = (
+            preferred.get("full_text"),
+            preferred.get("fullText"),
+            preferred.get("narrative"),
+            preferred.get("description_ru"),
+            preferred.get("summary_ru"),
+            preferred.get("summary"),
+        )
+        for candidate in candidates:
+            text = str(candidate or "").strip()
+            if text:
+                return text
+        return ""
+
+    @staticmethod
+    def _build_wait_thesis(
+        *,
+        symbol: str,
+        h4: dict[str, Any] | None,
+        h1: dict[str, Any] | None,
+        m15: dict[str, Any] | None,
+        h4_dir: str,
+        h1_dir: str,
+        m15_dir: str,
+        wait_conflict: str,
+        final_reason: str,
+    ) -> str:
+        h4_state = h4_dir if h4 else "нет данных"
+        h1_state = h1_dir if h1 else "нет данных"
+        m15_state = m15_dir if m15 else "нет данных"
+        if wait_conflict == "h4_h1_conflict":
+            confirmation = "дождаться синхронизации H1 в сторону H4 и только потом искать M15-триггер"
+            activation = "активация BUY/SELL произойдёт после совпадения направления H4+H1 и подтверждающей свечной реакции на M15"
+        elif wait_conflict == "missing_m15_trigger":
+            confirmation = "ждём импульсный M15-триггер в сторону согласованных H4/H1"
+            activation = "сценарий активируется после закрепления M15 по направлению H4/H1 с сохранением структуры"
+        elif wait_conflict == "m15_opposes_trend":
+            confirmation = "дождаться, когда M15 перестанет идти против H4/H1 и сформирует разворотный триггер"
+            activation = "активация наступит при возврате M15 к направлению старшей структуры и подтверждении ликвидностного сценария"
+        elif wait_conflict == "missing_h4_context":
+            confirmation = "дождаться восстановления H4-контекста и проверить, что H1/M15 не противоречат ему"
+            activation = "торговый сценарий станет валидным после появления H4 и совпадения направления минимум на двух ТФ"
+        else:
+            confirmation = "ожидается чистое подтверждение структуры без разнонаправленных сигналов"
+            activation = "сценарий активируется после синхронизации MTF и появления рабочего триггера входа"
+        return (
+            f"{symbol}: сейчас режим WAIT, потому что есть конфликт сигналов (H4={h4_state}, H1={h1_state}, M15={m15_state}). "
+            f"Почему без сделки: {final_reason} "
+            f"Что нужно для подтверждения: {confirmation}. "
+            f"Что активирует сценарий: {activation}."
+        )
 
     def _refresh_active_ideas(self, ideas: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
         if not ideas:

--- a/app/services/yahoo_market_data_service.py
+++ b/app/services/yahoo_market_data_service.py
@@ -137,6 +137,10 @@ class YahooMarketDataService:
             ts_value = self._to_int(ts)
             if ts_value is None or None in {o, h, l, c}:
                 continue
+            normalized_ohlc = self._normalize_ohlc(open_price=o, high_price=h, low_price=l, close_price=c)
+            if normalized_ohlc is None:
+                continue
+            o, h, l, c = normalized_ohlc
             candles.append(
                 {
                     "time": ts_value,
@@ -156,25 +160,51 @@ class YahooMarketDataService:
             ts = self._to_int(candle.get("time"))
             if ts is None:
                 continue
+            o = self._to_float(candle.get("open"))
+            h = self._to_float(candle.get("high"))
+            l = self._to_float(candle.get("low"))
+            c = self._to_float(candle.get("close"))
+            if None in {o, h, l, c}:
+                continue
+            normalized_ohlc = self._normalize_ohlc(open_price=o, high_price=h, low_price=l, close_price=c)
+            if normalized_ohlc is None:
+                continue
+            o, h, l, c = normalized_ohlc
             bucket = ts - (ts % (4 * 3600))
             existing = grouped.get(bucket)
             if existing is None:
                 grouped[bucket] = {
                     "time": bucket,
-                    "open": candle["open"],
-                    "high": candle["high"],
-                    "low": candle["low"],
-                    "close": candle["close"],
+                    "open": o,
+                    "high": h,
+                    "low": l,
+                    "close": c,
                     "volume": float(candle.get("volume") or 0.0),
                 }
                 continue
 
-            existing["high"] = max(float(existing["high"]), float(candle["high"]))
-            existing["low"] = min(float(existing["low"]), float(candle["low"]))
-            existing["close"] = candle["close"]
+            existing["high"] = max(float(existing["high"]), h)
+            existing["low"] = min(float(existing["low"]), l)
+            existing["close"] = c
             existing["volume"] = float(existing.get("volume") or 0.0) + float(candle.get("volume") or 0.0)
 
-        aggregated = [grouped[key] for key in sorted(grouped.keys())]
+        aggregated: list[dict[str, Any]] = []
+        for key in sorted(grouped.keys()):
+            candle = grouped[key]
+            normalized_ohlc = self._normalize_ohlc(
+                open_price=float(candle["open"]),
+                high_price=float(candle["high"]),
+                low_price=float(candle["low"]),
+                close_price=float(candle["close"]),
+            )
+            if normalized_ohlc is None:
+                continue
+            o, h, l, c = normalized_ohlc
+            candle["open"] = o
+            candle["high"] = h
+            candle["low"] = l
+            candle["close"] = c
+            aggregated.append(candle)
         return aggregated
 
     @staticmethod
@@ -212,3 +242,19 @@ class YahooMarketDataService:
             return int(value)
         except (TypeError, ValueError):
             return None
+
+    @staticmethod
+    def _normalize_ohlc(
+        *,
+        open_price: float,
+        high_price: float,
+        low_price: float,
+        close_price: float,
+    ) -> tuple[float, float, float, float] | None:
+        lower_bound = min(open_price, close_price)
+        upper_bound = max(open_price, close_price)
+        repaired_low = min(low_price, lower_bound)
+        repaired_high = max(high_price, upper_bound)
+        if repaired_low > repaired_high:
+            return None
+        return open_price, repaired_high, repaired_low, close_price

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -839,7 +839,7 @@
 
       <div class="detail-grid">
         <section class="detail-card detail-card-main">
-          <h3>Основная идея</h3>
+          <h3>Основная идея (тезис сценария)</h3>
           <p id="idea-summary" class="detail-summary detail-summary-strong"></p>
           <div id="detail-metrics" class="detail-metrics"></div>
         </section>

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -219,6 +219,8 @@ function buildFullText(idea) {
   if (isRenderableNarrative(thesis) && !isCompactTechnicalSummary(thesis)) return thesis;
   const unified = normalizeWhitespace(idea?.unified_narrative);
   if (isRenderableNarrative(unified) && !isCompactTechnicalSummary(unified)) return unified;
+  const legacyNarrative = normalizeWhitespace(idea?.legacy_narrative || idea?.legacyNarrative);
+  if (isRenderableNarrative(legacyNarrative) && !isCompactTechnicalSummary(legacyNarrative)) return legacyNarrative;
   const legacyNarrativeCandidates = [
     idea?.full_text,
     idea?.fullText,
@@ -927,7 +929,36 @@ function snapshotStatusRu(status) {
 }
 
 function hasCandles(payload) {
-  return Boolean(payload?.candles && Array.isArray(payload.candles) && payload.candles.length > 0);
+  const normalized = normalizeChartPayload(payload);
+  return Boolean(normalized?.candles?.length);
+}
+
+function normalizeChartPayload(payload) {
+  if (!payload || typeof payload !== "object") return { candles: [] };
+  const candles = normalizeAndValidateCandles(payload.candles);
+  return { ...payload, candles };
+}
+
+function normalizeAndValidateCandles(rawCandles) {
+  if (!Array.isArray(rawCandles)) return [];
+  const normalized = [];
+  for (const candle of rawCandles) {
+    if (!candle || typeof candle !== "object") continue;
+    const timeRaw = Number(candle.time ?? candle.timestamp);
+    const openRaw = Number(candle.open);
+    const highRaw = Number(candle.high);
+    const lowRaw = Number(candle.low);
+    const closeRaw = Number(candle.close);
+    if (![timeRaw, openRaw, highRaw, lowRaw, closeRaw].every(Number.isFinite)) continue;
+    const lowerBound = Math.min(openRaw, closeRaw);
+    const upperBound = Math.max(openRaw, closeRaw);
+    const low = Math.min(lowRaw, lowerBound);
+    const high = Math.max(highRaw, upperBound);
+    if (low > high) continue;
+    normalized.push({ time: Math.trunc(timeRaw), open: openRaw, high, low, close: closeRaw });
+  }
+  normalized.sort((a, b) => a.time - b.time);
+  return normalized;
 }
 
 function setChartMode(mode) {
@@ -956,11 +987,12 @@ function showSnapshotChart(imageUrl) {
 }
 
 function showLiveChart(payload) {
-  if (!hasCandles(payload)) return false;
+  const normalizedPayload = normalizeChartPayload(payload);
+  if (!hasCandles(normalizedPayload)) return false;
   setChartMode("live");
   ensureChart();
-  currentChartPayload = payload;
-  candleSeries.setData(payload.candles);
+  currentChartPayload = normalizedPayload;
+  candleSeries.setData(normalizedPayload.candles);
   chart.timeScale().fitContent();
   requestAnimationFrame(() => {
     requestAnimationFrame(() => drawOverlay());


### PR DESCRIPTION
### Motivation
- Устранить «синтетический» или искажённый вид свечных графиков из-за неисправных OHLC и некорректной агрегации.
- Обеспечить, чтобы агрегированные H4 не формировались из битых H1-свечей и чтобы снимки графиков не рендерили вводящие в заблуждение бары.
- Сделать основной текст идеи (main idea) полезным для трейдера в сценариях `WAIT`, а не сухой компактной сводкой по таймфреймам.

### Description
- Добавлена строгая безопасная нормализация/валидация OHLC в `ChartDataService`, `YahooMarketDataService` и `CanonicalMarketService` с правилами: `low <= min(open, close)`, `high >= max(open, close)` и `low <= high`, при невозможности безопасной починки свеча отбрасывается (файлы: `app/services/chart_data_service.py`, `app/services/yahoo_market_data_service.py`, `app/services/canonical_market_service.py`).
- Усилена агрегация H1→H4: в агрегат попадают только предварительно валидированные H1-свечи, итоговые H4 также проходят валидацию и не создаются из невалидных групп (файл: `app/services/canonical_market_service.py`).
- Снэпшот-сервис теперь санитизирует свечи перед рендером и пропускает создание изображения при отсутствии валидных свечей (файл: `app/services/chart_snapshot_service.py`).
- Frontend live-chart нормализует и валидирует пары свечей перед `setData`, не отображает misleading-график при отсутствии валидных баров, и `buildFullText` учитывает новое поле `legacy_narrative` как следующий по приоритету источник текста (файл: `app/static/js/chart-page.js`).
- Комбайнер MTF-идей (`TradeIdeaService`) теперь формирует в `idea_thesis` человекочитаемый трейдерский тезис для `WAIT`, объясняющий конфликт (какие ТФ в конфликте), причину отсутствия сделки, необходимое подтверждение и что активирует сценарий; при этом компактная строка H4/H1/M15 остаётся мета-данными (файл: `app/services/trade_idea_service.py`).
- Небольшое UI-обновление заголовка основного блока идеи для явного обозначения роли тезиса (файл: `app/static/ideas.html`).

### Testing
- Выполнена проверка компиляции Python-модулей: `python -m compileall app/services/chart_data_service.py app/services/yahoo_market_data_service.py app/services/canonical_market_service.py app/services/chart_snapshot_service.py app/services/trade_idea_service.py` — успешно.
- Выполнена статическая проверка JS: `node --check app/static/js/chart-page.js` — синтаксически успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ffbe5fcc83318f5d4a1516dc050e)