### PR TITLE
Fix: сохранять last-good chart и улучшить рендер аналитических оверлеев (levels/zones/OB/FVG/liquidity/patterns)

### DIFF
--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -59,6 +59,24 @@ class ChartSnapshotService:
         overlay_fvg = chart_overlays.get("fvg") if isinstance(chart_overlays.get("fvg"), list) else []
         overlay_structure = chart_overlays.get("structure_levels") if isinstance(chart_overlays.get("structure_levels"), list) else []
         overlay_patterns = chart_overlays.get("patterns") if isinstance(chart_overlays.get("patterns"), list) else []
+        generic_zones = chart_overlays.get("zones") if isinstance(chart_overlays.get("zones"), list) else []
+        generic_levels = chart_overlays.get("levels") if isinstance(chart_overlays.get("levels"), list) else []
+        if generic_zones:
+            for zone in generic_zones:
+                zone_type = str(zone.get("type") or zone.get("label") or "").lower()
+                if any(token in zone_type for token in ("fvg", "imbalance", "imb")):
+                    overlay_fvg.append(zone)
+                elif "liquidity" in zone_type:
+                    overlay_liquidity.append(zone)
+                else:
+                    overlay_order_blocks.append(zone)
+        if generic_levels:
+            for level in generic_levels:
+                level_type = str(level.get("type") or level.get("label") or "").lower()
+                if "liq" in level_type:
+                    overlay_liquidity.append(level)
+                else:
+                    overlay_structure.append(level)
         if overlay_order_blocks or overlay_liquidity or overlay_fvg or overlay_structure or overlay_patterns:
             logger.info(
                 "snapshot_chart_overlays_applied symbol=%s timeframe=%s counts=%s",

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -61,7 +61,7 @@ CHART_OVERLAY_ALIASES = {
     "order_blocks": ("order_blocks", "orderBlocks", "orderblock", "order_blocks_zones"),
     "liquidity": ("liquidity", "liquidity_levels", "liquidityLevels"),
     "fvg": ("fvg", "imbalances", "imbalance", "fair_value_gap"),
-    "structure_levels": ("structure_levels", "structure", "structureLevels"),
+    "structure_levels": ("structure_levels", "structure", "structureLevels", "levels"),
     "patterns": ("patterns", "chart_patterns", "pattern_overlays"),
 }
 SNAPSHOT_RETRY_INTERVAL_SECONDS = int(os.getenv("IDEAS_SNAPSHOT_RETRY_INTERVAL_SECONDS", "1800"))
@@ -2104,7 +2104,28 @@ class TradeIdeaService:
                 if isinstance(candidate, list):
                     values.extend(candidate)
             normalized[key] = cls._normalize_overlay_items(key=key, items=values)
-        return normalized
+
+        generic_zones = payload.get("zones")
+        if isinstance(generic_zones, list):
+            for zone in cls._normalize_overlay_items(key="order_blocks", items=generic_zones):
+                zone_type = str(zone.get("type") or zone.get("label") or "").lower()
+                if any(token in zone_type for token in ("fvg", "imbalance", "imb")):
+                    normalized["fvg"].append(zone)
+                elif "liquidity" in zone_type:
+                    normalized["liquidity"].append(zone)
+                else:
+                    normalized["order_blocks"].append(zone)
+
+        generic_levels = payload.get("levels")
+        if isinstance(generic_levels, list):
+            for level in cls._normalize_overlay_items(key="structure_levels", items=generic_levels):
+                level_type = str(level.get("type") or level.get("label") or "").lower()
+                if "liq" in level_type:
+                    normalized["liquidity"].append(level)
+                else:
+                    normalized["structure_levels"].append(level)
+
+        return {k: cls._normalize_overlay_items(key=k, items=v) for k, v in normalized.items()}
 
     @classmethod
     def is_meaningful_overlay_payload(cls, payload: dict[str, Any] | None) -> bool:

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -882,7 +882,7 @@
         </div>
         <div id="chart-placeholder" class="chart-placeholder">
           <strong>График недоступен</strong>
-          <span id="chart-placeholder-text">График недоступен: сначала показываем snapshot, при его отсутствии — свечной chart fallback.</span>
+          <span id="chart-placeholder-text">Нет snapshot и свечей. Панель не остаётся пустой: показываем статус и ожидаем следующее обновление данных.</span>
         </div>
       </div>
 

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -944,9 +944,9 @@ function ensureChart() {
   });
 }
 
-function resetChartState() {
+function resetChartState({ keepSnapshot = true } = {}) {
   currentChartPayload = null;
-  if (chartSnapshotImage) {
+  if (chartSnapshotImage && !keepSnapshot) {
     chartSnapshotImage.removeAttribute("src");
   }
   if (chart) {
@@ -1056,6 +1056,12 @@ function hasRenderableCandles(idea) {
   return hasCandles(idea?.chartData) || hasCandles(idea?.chart_data);
 }
 
+function hasMeaningfulChartOverlays(overlays) {
+  if (!overlays || typeof overlays !== "object") return false;
+  const keys = ["order_blocks", "liquidity", "fvg", "structure_levels", "patterns", "zones", "levels"];
+  return keys.some((key) => Array.isArray(overlays[key]) && overlays[key].length > 0);
+}
+
 function mergeWithPreviousIdeaState(nextIdea, prevIdea) {
   if (!prevIdea || typeof prevIdea !== "object") return nextIdea;
   const nextSnapshot = normalizeChartImageUrl(nextIdea?.chartImageUrl || nextIdea?.chart_image || "");
@@ -1063,11 +1069,16 @@ function mergeWithPreviousIdeaState(nextIdea, prevIdea) {
   const mergedSnapshot = nextSnapshot || prevSnapshot;
   const nextChartData = hasRenderableCandles(nextIdea) ? (nextIdea.chartData || nextIdea.chart_data) : null;
   const prevChartData = hasRenderableCandles(prevIdea) ? (prevIdea.chartData || prevIdea.chart_data) : null;
+  const nextOverlays = nextIdea?.chart_overlays;
+  const prevOverlays = prevIdea?.chart_overlays;
+  const mergedOverlays = hasMeaningfulChartOverlays(nextOverlays) ? nextOverlays : prevOverlays || nextOverlays || null;
+
   return {
     ...nextIdea,
     chartImageUrl: mergedSnapshot,
     chart_image: mergedSnapshot,
     chartData: nextChartData || prevChartData || nextIdea.chartData || null,
+    chart_overlays: mergedOverlays,
   };
 }
 
@@ -1218,67 +1229,79 @@ function normalizeSmcOverlays(payload) {
     ?? payload?.overlays?.chart_overlays
     ?? {};
 
-  const orderBlocks = Array.isArray(base?.order_blocks)
-    ? base.order_blocks
-      .map((item) => {
-        const from = toFiniteNumber(item?.from ?? item?.low);
-        const to = toFiniteNumber(item?.to ?? item?.high);
-        if (from == null || to == null) return null;
-        return {
-          from: Math.min(from, to),
-          to: Math.max(from, to),
-          type: String(item?.type || "").toLowerCase(),
-          label: normalizeWhitespace(item?.label || ""),
-        };
-      })
-      .filter(Boolean)
-    : [];
+  const asZone = (item, fallbackLabel = "Zone") => {
+    const from = toFiniteNumber(item?.from ?? item?.low);
+    const to = toFiniteNumber(item?.to ?? item?.high);
+    if (from == null || to == null) return null;
+    return {
+      from: Math.min(from, to),
+      to: Math.max(from, to),
+      type: String(item?.type || "").toLowerCase(),
+      label: normalizeWhitespace(item?.label || fallbackLabel),
+      start_index: Number.isFinite(Number(item?.start_index)) ? Number(item.start_index) : null,
+      end_index: Number.isFinite(Number(item?.end_index)) ? Number(item.end_index) : null,
+    };
+  };
 
-  const fvg = Array.isArray(base?.fvg)
-    ? base.fvg
-      .map((item) => {
-        const from = toFiniteNumber(item?.from ?? item?.low);
-        const to = toFiniteNumber(item?.to ?? item?.high);
-        if (from == null || to == null) return null;
-        return {
-          from: Math.min(from, to),
-          to: Math.max(from, to),
-          label: normalizeWhitespace(item?.label || "FVG"),
-        };
-      })
-      .filter(Boolean)
-    : [];
+  const orderBlocksRaw = Array.isArray(base?.order_blocks) ? base.order_blocks : [];
+  const fvgRaw = Array.isArray(base?.fvg) ? base.fvg : [];
+  const liquidityRaw = Array.isArray(base?.liquidity) ? base.liquidity : [];
+  const structureRaw = Array.isArray(base?.structure_levels) ? base.structure_levels : Array.isArray(base?.structure) ? base.structure : [];
+  const patternsRaw = Array.isArray(base?.patterns) ? base.patterns : [];
+  const genericZones = Array.isArray(base?.zones) ? base.zones : [];
+  const genericLevels = Array.isArray(base?.levels) ? base.levels : [];
 
-  const liquidity = Array.isArray(base?.liquidity)
-    ? base.liquidity
-      .map((item) => {
-        const level = toFiniteNumber(item?.level);
-        if (level == null) return null;
-        return { level, label: normalizeWhitespace(item?.label || "Liquidity") };
-      })
-      .filter(Boolean)
-    : [];
+  const orderBlocks = orderBlocksRaw.map((item) => asZone(item, "Order Block")).filter(Boolean);
+  const fvg = fvgRaw.map((item) => asZone(item, "FVG")).filter(Boolean);
 
-  const structureSource = Array.isArray(base?.structure_levels) ? base.structure_levels : Array.isArray(base?.structure) ? base.structure : [];
-  const structure = Array.isArray(structureSource)
-    ? structureSource
-      .map((item) => {
-        const level = toFiniteNumber(item?.level ?? item?.price);
-        if (level == null) return null;
-        return {
-          level,
-          type: normalizeWhitespace(item?.type || "structure"),
-          label: normalizeWhitespace(item?.label || item?.type || "Structure"),
-        };
-      })
-      .filter(Boolean)
-    : [];
+  genericZones.forEach((item) => {
+    const normalized = asZone(item, "Zone");
+    if (!normalized) return;
+    const t = String(item?.type || item?.label || "").toLowerCase();
+    if (t.includes("fvg") || t.includes("imbalance")) {
+      fvg.push(normalized);
+    } else if (t.includes("liquidity")) {
+      liquidityRaw.push(item);
+    } else {
+      orderBlocks.push(normalized);
+    }
+  });
+
+  const liquidity = liquidityRaw
+    .map((item) => {
+      const level = toFiniteNumber(item?.level ?? item?.price);
+      if (level == null) return null;
+      return { level, label: normalizeWhitespace(item?.label || "Liquidity") };
+    })
+    .filter(Boolean);
+
+  const structure = [...structureRaw, ...genericLevels]
+    .map((item) => {
+      const level = toFiniteNumber(item?.level ?? item?.price);
+      if (level == null) return null;
+      return {
+        level,
+        type: normalizeWhitespace(item?.type || "structure"),
+        label: normalizeWhitespace(item?.label || item?.type || "Level"),
+      };
+    })
+    .filter(Boolean);
+
+  const patterns = patternsRaw
+    .map((item) => {
+      const label = normalizeWhitespace(item?.label || item?.name || item?.type || item?.pattern || "");
+      if (!label) return null;
+      const level = toFiniteNumber(item?.level ?? item?.price ?? item?.y ?? item?.high ?? item?.low);
+      return { label, level };
+    })
+    .filter(Boolean);
 
   return {
     order_blocks: orderBlocks,
     fvg,
     liquidity,
     structure,
+    patterns,
   };
 }
 
@@ -1290,7 +1313,8 @@ const overlayPlugin = {
     const hasAnyOverlay = smcOverlays.order_blocks.length
       || smcOverlays.fvg.length
       || smcOverlays.liquidity.length
-      || smcOverlays.structure.length;
+      || smcOverlays.structure.length
+      || smcOverlays.patterns.length;
     if (!hasAnyOverlay) return;
 
     const startX = timeScale.timeToCoordinate(candles[0]?.time);
@@ -1358,6 +1382,13 @@ const overlayPlugin = {
       ctx.stroke();
       ctx.restore();
       drawLabel(ctx, Math.max(8, rightX - 180), y - 4, item.label || `Structure: ${item.type}`, "#fbbf24");
+    });
+
+    smcOverlays.patterns.forEach((item, index) => {
+      const y = candleSeries.priceToCoordinate(item.level);
+      if (y == null) return;
+      const x = Math.max(leftX + 12, rightX - 220 + (index % 2) * 110);
+      drawLabel(ctx, x, y - 4, item.label || "Pattern", "#f9a8d4", "rgba(38, 12, 30, 0.86)");
     });
   },
 };
@@ -1561,7 +1592,7 @@ async function openIdea(idea) {
   const snapshotStatus = idea.chartSnapshotStatus || idea.chart_snapshot_status || "";
   const liveFallbackMessage = snapshotStatusRu(snapshotStatus);
 
-  resetChartState();
+  resetChartState({ keepSnapshot: true });
   showUnavailableChart("Загружаем график…");
 
   if (snapshotUrl) {
@@ -1624,6 +1655,7 @@ function closeModal() {
   }
   activeIdea = null;
   detailRequestId += 1;
+  resetChartState({ keepSnapshot: false });
   showUnavailableChart("График недоступен");
 }
 


### PR DESCRIPTION
### Motivation
- Исправить исчезновение snapshot при слабом refresh и предотвратить затирание рабочей разметки оверлеев пустыми payload. 
- Обеспечить рендер реальных аналитических элементов (уровни, зоны, order blocks, FVG/imbalance, liquidity, patterns) и аккуратный fallback на свечной chart. 
- Сохранить текущую архитектуру и совместимость, внеся минимальные и безопасные правки в нормализацию/рендеринг и UI-поведение.

### Description
- Расширена нормализация overlay на backend в `app/services/trade_idea_service.py`: `normalize_chart_overlays` теперь учитывает generic поля `zones`/`levels`, классифицирует их в `order_blocks`, `fvg`, `liquidity`, `structure_levels` и корректно обрабатывает alias `levels` в `CHART_OVERLAY_ALIASES`.
- Обновлён `app/services/chart_snapshot_service.py` чтобы при генерации snapshot подтягивать и правильно маппить generic `zones`/`levels` в соответствующие группы overlay, чтобы снимок не терял аналитические области при несовпадении форматов payload.
- Клиентская логика в `app/static/js/chart-page.js` изменена для устойчивости UI: `resetChartState` получает опцию `keepSnapshot`, добавлен `hasMeaningfulChartOverlays` + слияние предыдущих и новых состояний (`mergeWithPreviousIdeaState`) для сохранения last-good `chartImageUrl` и last-good `chart_overlays`, расширена `normalizeSmcOverlays` и overlay-плагин для отрисовки order blocks, zones, FVG/imbalance, liquidity, structure/levels и patterns.
- Текст placeholder в `app/static/ideas.html` обновлён для явного сообщения при отсутствии snapshot и свечей, чтобы не оставлять пустую панель.
- Изменения направлены на минимальное вмешательство в существующий пайплайн (сохранены контрактные поля `chartImageUrl`, `chart_overlays`, `chart_status`, `fallback_to_candles`).

### Testing
- Запущена компиляция Python файлов: `python -m py_compile app/services/trade_idea_service.py app/services/chart_snapshot_service.py` — успешно.
- Проверка JS синтаксиса: `node --check app/static/js/chart-page.js` — успешно.
- Локальное поведение UI проверялось логикой fallback (ручной инспекцией кода) — snapshot теперь не удаляется преждевременно, overlay-элементы нормализуются и рендерятся в fallback/live режиме.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea309555048331b958a2327fb2af4e)