### PR TITLE
Показывать WAIT-идеи на /ideas — ослаблена фильтрация агрегированных WAIT

### DIFF
--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -613,9 +613,7 @@ function shouldDisplayAggregatedIdea(idea) {
     && hasValidTradeLevels(idea);
   if (isStrongIdea) return true;
 
-  const isMeaningfulWait = signal === "WAIT"
-    && confidence >= 45
-    && hasNarrative;
+  const isMeaningfulWait = signal === "WAIT" && hasNarrative;
   if (isMeaningfulWait) return true;
 
   if (!idea?.combined) return false;


### PR DESCRIPTION
### Motivation
- Аггрегированные идеи с `signal === "WAIT"` отбрасывались в `shouldDisplayAggregatedIdea()` из-за порога `confidence >= 45`, в реальных данных встречались WAIT с `confidence` ~42 и валидным narrative, поэтому страница `/ideas` показывала пустое состояние.

### Description
- В `shouldDisplayAggregatedIdea()` изменено условие `isMeaningfulWait` с `signal === "WAIT" && confidence >= 45 && hasNarrative` на `signal === "WAIT" && hasNarrative`, при этом логика для `BUY`/`SELL` (`confidence >= 40` + `hasValidTradeLevels`) не изменилась.

### Testing
- Проверены изменения через `git diff -- app/static/js/chart-page.js` и коммит через `git commit`, оба шага выполнены успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3e63580c8331a05e27276d72327a)