### PR TITLE
Показ WAIT-идей с narrative — убрать строгий порог confidence

### DIFF
--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -614,7 +614,6 @@ function shouldDisplayAggregatedIdea(idea) {
   if (isStrongIdea) return true;
 
   const isMeaningfulWait = signal === "WAIT"
-    && confidence >= 45
     && hasNarrative;
   if (isMeaningfulWait) return true;
 


### PR DESCRIPTION
### Motivation
- Причина: фронтенд-фильтр `shouldDisplayAggregatedIdea()` требовал `signal === "WAIT" && confidence >= 45 && hasNarrative`, из‑за чего валидные WAIT‑идеи с narrative и `confidence ≈ 42` скрывались и страница `/ideas` показывала пустое состояние.

### Description
- Убрана проверка `confidence >= 45` в `shouldDisplayAggregatedIdea()` в `app/static/js/chart-page.js`, оставив условие `signal === "WAIT" && hasNarrative`, при этом логика для `BUY/SELL` и агрегация «одна объединённая карточка на символ» не изменены.

### Testing
- Автоматических тестов не запускалось; корректность правки подтверждена просмотром `git show` и участка файла (`nl`/`sed`), diff совпадает с ожидаемым и изменение успешно закоммичено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4052e84483319fc22f1af69753d7)