### PR TITLE
Отдавать приоритет модельному нарративу (idea_thesis → unified_narrative → full_text → fallback)

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -3468,9 +3468,9 @@ class TradeIdeaService:
 
     @staticmethod
     def _resolve_narrative_source_label(value: Any, *, is_fallback: bool = False, combined: bool = False) -> str:
-        if is_fallback:
-            return "fallback_template"
         raw = str(value or "").strip().lower()
+        if is_fallback and raw not in {"grok", "llm", "model"}:
+            return "fallback_template"
         if raw == "grok":
             return "grok"
         if raw in {"llm", "model"}:
@@ -4364,13 +4364,21 @@ class TradeIdeaService:
             idea_thesis = str(row.get("idea_thesis") or "").strip()
             unified_narrative = str(row.get("unified_narrative") or "").strip()
             full_text = str(row.get("full_text") or row.get("fullText") or "").strip()
+            raw_narrative_source = row.get("narrative_source")
             resolved_source = self._resolve_narrative_source_label(
-                row.get("narrative_source"),
+                raw_narrative_source,
                 is_fallback=bool(row.get("is_fallback")),
                 combined=bool(row.get("combined")),
             )
+            has_model_narrative = any(
+                str(value or "").strip()
+                and not re.search(r"\b(status\s+created|idea_created|debug|schema|payload)\b", str(value), re.IGNORECASE)
+                for value in (idea_thesis, unified_narrative, full_text)
+            )
+            if resolved_source == "fallback_template" and has_model_narrative:
+                raw_source = str(raw_narrative_source or "").strip().lower()
+                resolved_source = "grok" if raw_source == "grok" else "model"
             is_fallback_narrative = resolved_source == "fallback_template"
-            has_model_narrative = bool(idea_thesis or unified_narrative or full_text) and not is_fallback_narrative
             if not has_model_narrative:
                 full_text = self._build_full_text(
                     row,
@@ -4385,12 +4393,10 @@ class TradeIdeaService:
             if not idea_thesis:
                 idea_thesis = unified_narrative or full_text
             fallback_narrative = ""
-            if is_fallback_narrative or not has_model_narrative:
+            if not has_model_narrative:
                 fallback_narrative = full_text
-                if is_fallback_narrative:
-                    idea_thesis = ""
-                    unified_narrative = ""
-                    full_text = ""
+            elif is_fallback_narrative:
+                fallback_narrative = full_text
             short_text = self._build_short_text(
                 row,
                 direction=direction,

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -223,33 +223,19 @@ function buildShortText(idea) {
 }
 
 function buildFullText(idea) {
-  const thesis = normalizeWhitespace(idea?.idea_thesis || idea?.ideaThesis);
-  if (isRenderableNarrative(thesis) && !isCompactTechnicalSummary(thesis)) return thesis;
-  const unified = normalizeWhitespace(idea?.unified_narrative);
-  if (isRenderableNarrative(unified) && !isCompactTechnicalSummary(unified)) return unified;
-  const legacyNarrative = normalizeWhitespace(idea?.legacy_narrative || idea?.legacyNarrative);
-  if (isRenderableNarrative(legacyNarrative) && !isCompactTechnicalSummary(legacyNarrative)) return legacyNarrative;
-  const legacyNarrativeCandidates = [
-    idea?.full_text,
-    idea?.fullText,
-    idea?.narrative,
-    idea?.description_ru,
-    idea?.reason_ru,
-    idea?.rationale,
-    idea?.idea_context_ru,
-    idea?.ideaContext,
+  const modelNarrativeCandidates = [
+    idea?.idea_thesis || idea?.ideaThesis,
+    idea?.unified_narrative,
+    idea?.full_text || idea?.fullText,
   ];
-  for (const candidate of legacyNarrativeCandidates) {
+  for (const candidate of modelNarrativeCandidates) {
     const text = normalizeWhitespace(candidate);
     if (isRenderableNarrative(text) && !isCompactTechnicalSummary(text)) return text;
   }
-  const { summaryStructured, tradePlanStructured } = getStructuredNarrativeBlocks(idea);
-  const structuredText = normalizeWhitespace(summaryStructured?.situation) || normalizeWhitespace(tradePlanStructured?.entry_trigger);
-  if (isRenderableNarrative(structuredText) && !isCompactTechnicalSummary(structuredText)) return structuredText;
-  const detailSummary = normalizeWhitespace(idea?.detail_brief?.summary_narrative);
-  if (isRenderableNarrative(detailSummary) && !isCompactTechnicalSummary(detailSummary)) return detailSummary;
-  const legacySummary = normalizeWhitespace(idea?.summary || idea?.summary_ru);
-  if (isRenderableNarrative(legacySummary)) return legacySummary;
+
+  const fallbackNarrative = normalizeWhitespace(idea?.fallback_narrative);
+  if (isRenderableNarrative(fallbackNarrative) && !isCompactTechnicalSummary(fallbackNarrative)) return fallbackNarrative;
+
   return "Подробное описание пока не получено. Дождитесь обновления идеи перед входом в сделку.";
 }
 
@@ -367,6 +353,9 @@ function normalizeIdea(idea) {
     summary,
     summary_ru: summary,
   });
+  const thesis = normalizeWhitespace(idea?.idea_thesis || idea?.ideaThesis);
+  const unifiedNarrative = normalizeWhitespace(idea?.unified_narrative);
+  const fallbackNarrative = normalizeWhitespace(idea?.fallback_narrative);
   const shortText = buildShortText({
     ...idea,
     summary,
@@ -390,8 +379,10 @@ function normalizeIdea(idea) {
     summary_ru: shortText,
     short_text: shortText,
     full_text: fullText,
-    idea_thesis: normalizeWhitespace(idea?.idea_thesis || idea?.ideaThesis) || fullText,
-    unified_narrative: normalizeWhitespace(idea?.unified_narrative) || fullText,
+    idea_thesis: thesis,
+    unified_narrative: unifiedNarrative,
+    fallback_narrative: fallbackNarrative,
+    narrative_source: normalizeWhitespace(idea?.narrative_source || idea?.narrativeSource || "fallback_template").toLowerCase(),
     detail_brief: buildDetailBrief({
       ...idea,
       summary,

--- a/tests/api/test_ideas_api.py
+++ b/tests/api/test_ideas_api.py
@@ -102,6 +102,37 @@ def test_build_api_ideas_expands_detail_payload_and_fallbacks(tmp_path: Path) ->
     assert "fundamental" in payload[0]["supported_sections"]
 
 
+def test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    service.idea_store.write(
+        {
+            "updated_at_utc": "2026-03-20T00:00:00+00:00",
+            "ideas": [
+                {
+                    "idea_id": "idea-3",
+                    "symbol": "USDJPY",
+                    "timeframe": "H1",
+                    "bias": "bullish",
+                    "confidence": 71,
+                    "summary_ru": "Fallback summary не должен стать главным текстом.",
+                    "idea_thesis": "USDJPY удержал bullish BOS и после снятия sell-side ликвидности вернулся выше OB, поэтому приоритет остаётся за continuation вверх.",
+                    "full_text": "Модельный full_text, который тоже допустим для отображения.",
+                    "narrative_source": "fallback_template",
+                    "is_fallback": True,
+                    "status": "active",
+                }
+            ],
+        }
+    )
+
+    payload = service.build_api_ideas()
+
+    assert payload[0]["idea_thesis"].startswith("USDJPY удержал bullish BOS")
+    assert payload[0]["full_text"].startswith("Модельный full_text")
+    assert payload[0]["fallback_narrative"] == ""
+    assert payload[0]["narrative_source"] == "model"
+
+
 def test_build_api_ideas_returns_empty_when_storage_empty(tmp_path: Path) -> None:
     service = _service(tmp_path)
 


### PR DESCRIPTION
### Motivation
- Исправить ситуацию, когда карточки показывали «шаблонный» текст из fallback-шаблонов вместо сырого текста от модели, из‑за чего видимый текст выглядел модульно и синтетически.
- Обеспечить, чтобы основной видимый абзац всегда брался из полей, сгенерированных моделью, а шаблон оставался лишь аварийным fallback'ом.

### Description
- В `app/services/trade_idea_service.py` изменена логика нормализации: если в записи есть реальный модельный текст (`idea_thesis`/`unified_narrative`/`full_text`), то запись больше не принудительно маркируется как `fallback_template`, а `narrative_source` переводится в `model` или `grok` при явном указании. (функции: `_resolve_narrative_source_label`, обработка в `build_api_ideas`).
- Убрано прежнее поведение, которое очищало модельные поля при обнаружении `fallback_template`, и `fallback_narrative` теперь используется только как аварийный текст при полном отсутствии model-текста.
- В фронтенде `app/static/js/chart-page.js` ужесточён порядок выбора видимого текста: сначала `idea_thesis`, затем `unified_narrative`, потом `full_text`, и только затем `fallback_narrative`, причём удалён путь, который собирал основной текст из структурированных/legacy-фрагментов.
- Добавлен тест-регрессия `tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, и сохранены мелкие правки нормализации в `normalizeIdea` для явной передачи `narrative_source` и `fallback_narrative`.

### Testing
- Запущен целевой набор API-тестов: `pytest -q tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, `tests/api/test_ideas_api.py::test_build_api_ideas_expands_detail_payload_and_fallbacks`, `tests/api/test_ideas_api.py::test_build_api_ideas_normalizes_trade_ideas`; все указанные тесты прошли успешно (3 passed).
- При одном раннем запуске полного набора тестов была обнаружена отдельная нестабильность в `tests/test_idea_update.py::test_trade_idea_archives_on_tp_and_keeps_history`, не связанная с изменяемой логикой нарратива (тот прогон завершился с 1 failing, остальное прошло); целевые изменения покрыты новыми и существующими тестами.
- Добавленный регрессионный тест подтверждает, что при наличии модельного текста и старом флаге `is_fallback` отображается модельный текст, `fallback_narrative` остаётся пустой, а `narrative_source` устанавливается в `model`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea42d5a5808331b9262be70b767f87)