### PR TITLE
Исправление: согласование статусов снапшотов графиков и сохранение последнего валидного графика

### DIFF
--- a/app/services/chart_snapshot_service.py
+++ b/app/services/chart_snapshot_service.py
@@ -290,6 +290,23 @@ class ChartSnapshotService:
             "fallback_to_candles": False,
         }
 
+    def normalize_snapshot_state(
+        self,
+        *,
+        chart_image_url: str | None,
+        status: str | None,
+        has_candles: bool,
+    ) -> str:
+        normalized_status = str(status or "").strip().lower()
+        has_image = bool(str(chart_image_url or "").strip())
+        if normalized_status == "ok" and not has_image:
+            return "snapshot_failed" if has_candles else "no_data"
+        if normalized_status:
+            return normalized_status
+        if has_image:
+            return "ok"
+        return "snapshot_failed" if has_candles else "no_data"
+
     def preserve_last_good_chart(self, *, existing_chart: str | None, incoming_chart: str | None) -> str | None:
         incoming_normalized = str(incoming_chart or "").strip()
         existing_normalized = str(existing_chart or "").strip()

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -538,14 +538,21 @@ class TradeIdeaService:
                     status=str(current.get("status") or IDEA_STATUS_WAITING),
                 )
                 chart_url = chart_snapshot.get("chartImageUrl")
-                if chart_url:
-                    current["chart_image"] = chart_url
-                    current["chartImageUrl"] = chart_url
-                    current["chart_snapshot_status"] = chart_snapshot.get("status") or "ok"
-                    current["chartSnapshotStatus"] = chart_snapshot.get("status") or "ok"
-                    current["chart_status"] = chart_snapshot.get("chart_status") or "snapshot"
-                    current["chartStatus"] = chart_snapshot.get("chart_status") or "snapshot"
-                    current["fallback_to_candles"] = bool(chart_snapshot.get("fallback_to_candles"))
+                normalized_chart_state = self._normalize_chart_state(
+                    chart_image_url=chart_url,
+                    chart_snapshot_status=chart_snapshot.get("status"),
+                    chart_status=chart_snapshot.get("chart_status"),
+                    fallback_to_candles=chart_snapshot.get("fallback_to_candles"),
+                    has_candles=bool(chart_snapshot.get("candles")),
+                )
+                if normalized_chart_state["chart_image_url"]:
+                    current["chart_image"] = normalized_chart_state["chart_image_url"]
+                    current["chartImageUrl"] = normalized_chart_state["chart_image_url"]
+                    current["chart_snapshot_status"] = normalized_chart_state["chart_snapshot_status"]
+                    current["chartSnapshotStatus"] = normalized_chart_state["chart_snapshot_status"]
+                    current["chart_status"] = normalized_chart_state["chart_status"]
+                    current["chartStatus"] = normalized_chart_state["chart_status"]
+                    current["fallback_to_candles"] = normalized_chart_state["fallback_to_candles"]
                     current["last_chart_refresh_at"] = now_iso
                     previous_chart_url = str(idea.get("chartImageUrl") or idea.get("chart_image") or "")
                     if chart_url != previous_chart_url:
@@ -558,13 +565,11 @@ class TradeIdeaService:
                         current["update_reason"] = "Обновлён снимок графика и разметка сценария."
                     changed = True
                 else:
-                    current["chart_snapshot_status"] = chart_snapshot.get("status") or "snapshot_failed"
-                    current["chartSnapshotStatus"] = chart_snapshot.get("status") or "snapshot_failed"
-                    current["chart_status"] = chart_snapshot.get("chart_status") or (
-                        "fallback_candles" if chart_snapshot.get("fallback_to_candles") else "no_data"
-                    )
+                    current["chart_snapshot_status"] = normalized_chart_state["chart_snapshot_status"]
+                    current["chartSnapshotStatus"] = normalized_chart_state["chart_snapshot_status"]
+                    current["chart_status"] = normalized_chart_state["chart_status"]
                     current["chartStatus"] = current["chart_status"]
-                    current["fallback_to_candles"] = bool(chart_snapshot.get("fallback_to_candles"))
+                    current["fallback_to_candles"] = normalized_chart_state["fallback_to_candles"]
                     current["last_candle_fingerprint"] = candle_hash
                     changed = True
             current["internal_refresh_at"] = now_iso
@@ -827,9 +832,11 @@ class TradeIdeaService:
                         "source": "contextual_wait",
                         "is_fallback": False,
                         "data_status": data_status,
-                        "fallback_to_candles": False,
-                        "chart_snapshot_status": "ok",
-                        "chartSnapshotStatus": "ok",
+                        "fallback_to_candles": True,
+                        "chart_snapshot_status": "snapshot_failed",
+                        "chartSnapshotStatus": "snapshot_failed",
+                        "chart_status": "fallback_candles",
+                        "chartStatus": "fallback_candles",
                         "meta": {
                             "fallback_reason": reason,
                             "provider": chart_payload.get("source"),
@@ -1355,6 +1362,13 @@ class TradeIdeaService:
             existing_chart_url = existing.get("chartImageUrl") or existing.get("chart_image")
             if self.chart_snapshot_service.is_valid_snapshot_path(existing_chart_url):
                 resolved_chart_url = existing_chart_url
+        normalized_chart_state = self._normalize_chart_state(
+            chart_image_url=resolved_chart_url,
+            chart_snapshot_status=chart_snapshot.get("status"),
+            chart_status=chart_snapshot.get("chart_status"),
+            fallback_to_candles=chart_snapshot.get("fallback_to_candles"),
+            has_candles=bool(chart_snapshot.get("candles")),
+        )
 
         payload = {
             "idea_id": idea_id,
@@ -1431,13 +1445,13 @@ class TradeIdeaService:
             "trade_plan": trade_plan_payload,
             "detail_brief": detail_brief,
             "supported_sections": detail_brief.get("supported_sections", []),
-            "chart_image": resolved_chart_url,
-            "chartImageUrl": resolved_chart_url,
-            "chart_snapshot_status": chart_snapshot["status"],
-            "chartSnapshotStatus": chart_snapshot["status"],
-            "chart_status": chart_snapshot.get("chart_status") or ("snapshot" if resolved_chart_url else "no_data"),
-            "chartStatus": chart_snapshot.get("chart_status") or ("snapshot" if resolved_chart_url else "no_data"),
-            "fallback_to_candles": bool(chart_snapshot.get("fallback_to_candles")),
+            "chart_image": normalized_chart_state["chart_image_url"],
+            "chartImageUrl": normalized_chart_state["chart_image_url"],
+            "chart_snapshot_status": normalized_chart_state["chart_snapshot_status"],
+            "chartSnapshotStatus": normalized_chart_state["chart_snapshot_status"],
+            "chart_status": normalized_chart_state["chart_status"],
+            "chartStatus": normalized_chart_state["chart_status"],
+            "fallback_to_candles": normalized_chart_state["fallback_to_candles"],
             "last_price_update_at": now.isoformat(),
             "last_chart_refresh_at": now.isoformat() if resolved_chart_url else existing.get("last_chart_refresh_at") if existing else None,
             "chart_version": (int(existing.get("chart_version") or 0) + 1 if resolved_chart_url else int(existing.get("chart_version") or 0)) if existing else (1 if resolved_chart_url else 0),
@@ -1504,6 +1518,42 @@ class TradeIdeaService:
                 payload["take_profit"] = round(tp, 6)
                 payload["takeProfit"] = cls._format_price(payload["take_profit"])
         return payload
+
+    @classmethod
+    def _normalize_chart_state(
+        cls,
+        *,
+        chart_image_url: Any,
+        chart_snapshot_status: Any,
+        chart_status: Any,
+        fallback_to_candles: Any,
+        has_candles: bool = False,
+    ) -> dict[str, Any]:
+        normalized_chart_url = cls._clean_text(chart_image_url)
+        has_chart = bool(normalized_chart_url)
+        normalized_status = str(chart_snapshot_status or "").strip().lower()
+        fallback_flag = bool(fallback_to_candles)
+
+        if not normalized_status:
+            normalized_status = "ok" if has_chart else ("snapshot_failed" if has_candles or fallback_flag else "no_data")
+        if normalized_status == "ok" and not has_chart:
+            normalized_status = "snapshot_failed" if has_candles or fallback_flag else "no_data"
+
+        normalized_chart_status = str(chart_status or "").strip().lower()
+        if not normalized_chart_status:
+            if has_chart:
+                normalized_chart_status = "snapshot"
+            elif fallback_flag or has_candles:
+                normalized_chart_status = "fallback_candles"
+            else:
+                normalized_chart_status = "no_data"
+
+        return {
+            "chart_image_url": normalized_chart_url,
+            "chart_snapshot_status": normalized_status,
+            "chart_status": normalized_chart_status,
+            "fallback_to_candles": fallback_flag,
+        }
 
     @staticmethod
     def _meaningful_reason_from_status(status: str) -> str:
@@ -1934,7 +1984,11 @@ class TradeIdeaService:
             )
             return {
                 "chartImageUrl": resolved_snapshot.get("chartImageUrl"),
-                "status": resolved_snapshot.get("status") or "snapshot_failed",
+                "status": self.chart_snapshot_service.normalize_snapshot_state(
+                    chart_image_url=resolved_snapshot.get("chartImageUrl"),
+                    status=resolved_snapshot.get("status") or "snapshot_failed",
+                    has_candles=bool(candles),
+                ),
                 "candles": candles,
                 "chart_status": resolved_snapshot.get("chart_status"),
                 "fallback_to_candles": bool(resolved_snapshot.get("fallback_to_candles")),
@@ -1948,7 +2002,11 @@ class TradeIdeaService:
         )
         return {
             "chartImageUrl": resolved_snapshot.get("chartImageUrl"),
-            "status": resolved_snapshot.get("status") or "ok",
+            "status": self.chart_snapshot_service.normalize_snapshot_state(
+                chart_image_url=resolved_snapshot.get("chartImageUrl"),
+                status=resolved_snapshot.get("status") or "ok",
+                has_candles=bool(candles),
+            ),
             "candles": candles,
             "chart_status": resolved_snapshot.get("chart_status") or "snapshot",
             "fallback_to_candles": bool(resolved_snapshot.get("fallback_to_candles")),
@@ -2570,14 +2628,21 @@ class TradeIdeaService:
             if previous_retry_at != now_iso:
                 changed = True
 
-            if snapshot.get("chartImageUrl") and snapshot.get("status") == "ok":
-                current["chart_image"] = snapshot["chartImageUrl"]
-                current["chartImageUrl"] = snapshot["chartImageUrl"]
-                current["chart_snapshot_status"] = "ok"
-                current["chartSnapshotStatus"] = "ok"
-                current["chart_status"] = snapshot.get("chart_status") or "snapshot"
-                current["chartStatus"] = snapshot.get("chart_status") or "snapshot"
-                current["fallback_to_candles"] = bool(snapshot.get("fallback_to_candles"))
+            normalized_chart_state = self._normalize_chart_state(
+                chart_image_url=snapshot.get("chartImageUrl"),
+                chart_snapshot_status=snapshot.get("status"),
+                chart_status=snapshot.get("chart_status"),
+                fallback_to_candles=snapshot.get("fallback_to_candles"),
+                has_candles=bool(snapshot.get("candles")),
+            )
+            if normalized_chart_state["chart_image_url"] and normalized_chart_state["chart_snapshot_status"] == "ok":
+                current["chart_image"] = normalized_chart_state["chart_image_url"]
+                current["chartImageUrl"] = normalized_chart_state["chart_image_url"]
+                current["chart_snapshot_status"] = normalized_chart_state["chart_snapshot_status"]
+                current["chartSnapshotStatus"] = normalized_chart_state["chart_snapshot_status"]
+                current["chart_status"] = normalized_chart_state["chart_status"]
+                current["chartStatus"] = normalized_chart_state["chart_status"]
+                current["fallback_to_candles"] = normalized_chart_state["fallback_to_candles"]
                 current["last_chart_refresh_at"] = now_iso
                 current["chart_version"] = int(current.get("chart_version") or 0) + 1
                 current["updated_at"] = now_iso
@@ -2590,14 +2655,11 @@ class TradeIdeaService:
                     current.get("chartImageUrl"),
                 )
             else:
-                retry_status = str(snapshot.get("status") or "snapshot_failed").lower()
-                current["chart_snapshot_status"] = retry_status
-                current["chartSnapshotStatus"] = retry_status
-                current["chart_status"] = snapshot.get("chart_status") or (
-                    "fallback_candles" if snapshot.get("fallback_to_candles") else "no_data"
-                )
+                current["chart_snapshot_status"] = normalized_chart_state["chart_snapshot_status"]
+                current["chartSnapshotStatus"] = normalized_chart_state["chart_snapshot_status"]
+                current["chart_status"] = normalized_chart_state["chart_status"]
                 current["chartStatus"] = current["chart_status"]
-                current["fallback_to_candles"] = bool(snapshot.get("fallback_to_candles"))
+                current["fallback_to_candles"] = normalized_chart_state["fallback_to_candles"]
                 changed = True
                 logger.info(
                     "idea_snapshot_retry_finished_without_image idea_id=%s symbol=%s timeframe=%s status=%s final_chart_url=%s",
@@ -4466,8 +4528,16 @@ class TradeIdeaService:
             chart_overlays = self.normalize_chart_overlays(row.get("chart_overlays"))
             if not self.is_meaningful_overlay_payload(chart_overlays):
                 chart_overlays = self._chart_overlays_from_legacy_overlay_payload(overlay_payload)
-            chart_image_url = row.get("chartImageUrl") or row.get("chart_image")
-            chart_snapshot_status = row.get("chartSnapshotStatus") or row.get("chart_snapshot_status") or "ok"
+            normalized_chart_state = self._normalize_chart_state(
+                chart_image_url=row.get("chartImageUrl") or row.get("chart_image"),
+                chart_snapshot_status=row.get("chartSnapshotStatus") or row.get("chart_snapshot_status"),
+                chart_status=row.get("chart_status") or row.get("chartStatus"),
+                fallback_to_candles=row.get("fallback_to_candles"),
+                has_candles=False,
+            )
+            chart_image_url = normalized_chart_state["chart_image_url"]
+            chart_snapshot_status = normalized_chart_state["chart_snapshot_status"]
+            chart_status = normalized_chart_state["chart_status"]
             tags = row.get("tags")
             if not isinstance(tags, list) or not tags:
                 tags = [source, symbol, timeframe, direction]
@@ -4539,6 +4609,9 @@ class TradeIdeaService:
                         "chart_image": chart_image_url,
                         "chartSnapshotStatus": chart_snapshot_status,
                         "chart_snapshot_status": chart_snapshot_status,
+                        "chart_status": chart_status,
+                        "chartStatus": chart_status,
+                        "fallback_to_candles": normalized_chart_state["fallback_to_candles"],
                         "ideaContext": str(idea_context),
                         "trigger": str(trigger),
                         "invalidation": str(invalidation),

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -365,6 +365,13 @@ function normalizeIdea(idea) {
 
   const normalizedChartImageUrl = normalizeChartImageUrl(idea?.chartImageUrl || idea?.chart_image || "");
   const normalizedChartData = idea?.chartData ?? idea?.chart_data ?? null;
+  const normalizedSnapshotStatus = normalizeSnapshotStatus(
+    idea?.chartSnapshotStatus || idea?.chart_snapshot_status || "",
+    {
+      hasImage: Boolean(normalizedChartImageUrl),
+      hasCandles: hasCandles(normalizedChartData),
+    },
+  );
   return {
     ...idea,
     id: idea?.id || idea?.idea_id || `${symbol}-${timeframe}-${direction}`,
@@ -400,8 +407,8 @@ function normalizeIdea(idea) {
     chartData: normalizedChartData,
     chartImageUrl: normalizedChartImageUrl,
     chart_image: normalizedChartImageUrl,
-    chartSnapshotStatus: idea?.chartSnapshotStatus || idea?.chart_snapshot_status || "",
-    chart_snapshot_status: idea?.chart_snapshot_status || idea?.chartSnapshotStatus || "",
+    chartSnapshotStatus: normalizedSnapshotStatus,
+    chart_snapshot_status: normalizedSnapshotStatus,
     chart_overlays: idea?.chart_overlays
       ?? idea?.chartOverlays
       ?? idea?.chart_data?.chart_overlays
@@ -1170,6 +1177,21 @@ function normalizeChartImageUrl(url) {
   return `/static/${raw.replace(/^\/+/, "")}`;
 }
 
+function hasValidSnapshotImage(idea) {
+  return Boolean(normalizeChartImageUrl(idea?.chartImageUrl || idea?.chart_image || ""));
+}
+
+function normalizeSnapshotStatus(rawStatus, { hasImage = false, hasCandles = false } = {}) {
+  const normalized = normalizeWhitespace(rawStatus).toLowerCase();
+  if (hasImage && normalized === "ok") return "ok";
+  if (normalized === "ok" && !hasImage) {
+    return hasCandles ? "snapshot_failed" : "no_data";
+  }
+  if (normalized) return normalized;
+  if (hasImage) return "ok";
+  return hasCandles ? "snapshot_failed" : "no_data";
+}
+
 function snapshotStatusRu(status) {
   const key = String(status || "").toLowerCase();
   const reason = {
@@ -1241,7 +1263,7 @@ function showSnapshotChart(imageUrl) {
 }
 
 function hasRenderableSnapshot(idea) {
-  return Boolean(normalizeChartImageUrl(idea?.chartImageUrl || idea?.chart_image || ""));
+  return hasValidSnapshotImage(idea);
 }
 
 function hasRenderableCandles(idea) {
@@ -1733,17 +1755,36 @@ async function resolveChartData(idea) {
 }
 
 function cacheIdeaChart(ideaId, chartRef) {
-  if (!ideaId || !chartRef) return;
-  lastValidChartByIdeaId.set(String(ideaId), chartRef);
+  if (!chartRef) return;
+  const cacheKeys = new Set();
+  if (ideaId) cacheKeys.add(String(ideaId));
+  if (activeIdea) cacheKeys.add(getIdeaChartCacheKey(activeIdea));
+  for (const cacheKey of cacheKeys) {
+    if (!cacheKey) continue;
+    lastValidChartByIdeaId.set(cacheKey, chartRef);
+  }
 }
 
-function readCachedIdeaChart(ideaId) {
-  if (!ideaId) return null;
-  return lastValidChartByIdeaId.get(String(ideaId)) || null;
+function getIdeaChartCacheKey(idea) {
+  if (!idea || typeof idea !== "object") return "";
+  const symbol = normalizeWhitespace(idea.symbol || idea.pair || idea.instrument).toUpperCase();
+  const timeframe = normalizeWhitespace(idea.timeframe || idea.tf || "H1").toUpperCase();
+  if (!symbol) return "";
+  return `${symbol}:${timeframe}`;
+}
+
+function readCachedIdeaChart(idea) {
+  const idKey = normalizeWhitespace(idea?.id);
+  const symbolKey = getIdeaChartCacheKey(idea);
+  return (
+    (idKey ? lastValidChartByIdeaId.get(idKey) : null)
+    || (symbolKey ? lastValidChartByIdeaId.get(symbolKey) : null)
+    || null
+  );
 }
 
 function showCachedChartIfAny(idea) {
-  const cached = readCachedIdeaChart(idea?.id);
+  const cached = readCachedIdeaChart(idea);
   if (!cached) return false;
   if (cached.type === "snapshot") return showSnapshotChart(cached.value);
   if (cached.type === "live") return showLiveChart(cached.value);
@@ -1781,7 +1822,13 @@ async function openIdea(idea) {
   renderCleanDetailStatus(idea);
   const rawSnapshotUrl = idea.chartImageUrl || idea.chart_image || "";
   const snapshotUrl = normalizeChartImageUrl(rawSnapshotUrl);
-  const snapshotStatus = idea.chartSnapshotStatus || idea.chart_snapshot_status || "";
+  const snapshotStatus = normalizeSnapshotStatus(
+    idea.chartSnapshotStatus || idea.chart_snapshot_status || "",
+    {
+      hasImage: Boolean(snapshotUrl),
+      hasCandles: hasRenderableCandles(idea),
+    },
+  );
   const liveFallbackMessage = snapshotStatusRu(snapshotStatus);
 
   resetChartState({ keepSnapshot: true });


### PR DESCRIPTION
### Motivation
- Обнаружена рассинхронизация между реальным наличием изображения (`chartImageUrl`/`chart_image`) и статусом снапшота (`chartSnapshotStatus`), из‑за чего фронтенд при «слабом» обновлении очищал видимый график. 
- Цель изменений — никогда не помечать снапшот как `ok` без реального URL, не перезаписывать последний валидный график пустыми/невалидными обновлениями и корректно отдавать fallback (свечи → кэш → placeholder).

### Description
- Backend: добавлена нормализация состояния снапшота в `ChartSnapshotService.normalize_snapshot_state` и единый helper `_normalize_chart_state` в `TradeIdeaService`, которые приводят `ok` в `snapshot_failed`/`no_data`, если отсутствует URL, и выставляют корректный `chart_status` (`snapshot` / `fallback_candles` / `no_data`).
- Backend: применена нормализация во всех ключевых потоках (при сборке идеи, при обновлении/refresh, при восстановлении снапшотов и при нормализации входящих записей), а также исправлён кейс `contextual_wait` — теперь без картинки статус не будет `ok`.
- Frontend: добавлены `normalizeSnapshotStatus` и `hasValidSnapshotImage`, статус нормализуется при `normalizeIdea` и при открытии модалки; `chartSnapshotStatus='ok'` без URL теперь считается невалидным и не приводит к очистке UI.
- Frontend: кеш последнего валидного графика усилен — хранение по `idea id` и по ключу `symbol:timeframe`, чтение пытает оба ключа, чтобы при слабом refresh не терялся последний рабочий снимок; рендерный приоритет реализован как: 1) `chartImageUrl`, 2) `chartData` (candles), 3) cached last chart, 4) placeholder.
- Изменённые файлы: `app/services/chart_snapshot_service.py`, `app/services/trade_idea_service.py`, `app/static/js/chart-page.js`.

### Testing
- Запуск компиляции Python-модулей: `python -m compileall app/services/chart_snapshot_service.py app/services/trade_idea_service.py` — успешно.
- Проверка синтаксиса JS: `node --check app/static/js/chart-page.js` — успешно.
- Локальные логические проверки ручного сценария: проверена последовательность при слабом refresh (пустой URL + статус ok → статус нормализуется и предыдущий график остаётся в кэше); поведение модалки проверено: snapshot → candles → cached → placeholder.

Если нужно, могу приложить точные фрагменты диффа или помочь с интеграционным тестом, который симулирует weak refresh и проверяет, что картинка не исчезает.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4673e76483319fb3eb79374d624b)