### PR TITLE
Добавить режим SMC/ICT анализа свечей со строгим JSON-контрактом

### DIFF
--- a/backend/chat_service.py
+++ b/backend/chat_service.py
@@ -52,6 +52,46 @@ IDEA_EXPLANATION_RESPONSE_SHAPE = {
     "full_text": "полное связное объяснение",
 }
 
+SMC_ANALYSIS_RESPONSE_SHAPE = {
+    "idea_thesis": "краткий тезис идеи по SMC/ICT",
+    "signal": "ПОКУПКА | ПРОДАЖА | ОЖИДАНИЕ",
+    "entry": 0.0,
+    "stopLoss": 0.0,
+    "takeProfit": 0.0,
+    "trigger": "условие активации сценария",
+    "order_blocks": [
+        {"type": "bullish | bearish", "top": 0.0, "bottom": 0.0, "label": "метка зоны", "confidence": 0.0}
+    ],
+    "liquidity": [{"type": "buy_side | sell_side", "price": 0.0, "label": "метка ликвидности", "confidence": 0.0}],
+    "fvg": [{"type": "bullish | bearish", "top": 0.0, "bottom": 0.0, "label": "метка FVG", "confidence": 0.0}],
+    "structure_levels": [
+        {"type": "bos | choch | support | resistance", "price": 0.0, "label": "метка структуры", "confidence": 0.0}
+    ],
+    "patterns": [
+        {
+            "name": "название паттерна",
+            "bias": "bullish | bearish | neutral",
+            "from_index": 0,
+            "to_index": 0,
+            "label": "метка паттерна",
+            "confidence": 0.0,
+        }
+    ],
+}
+
+SMC_ANALYSIS_SYSTEM_PROMPT = """
+Ты профессиональный SMC/ICT аналитик Forex.
+Твоя задача: по массиву свечей определить идею и графические объекты для отрисовки.
+
+Критические правила:
+1) Верни строго JSON-объект без markdown и без текста вне JSON.
+2) Все поля и комментарии только на русском языке.
+3) Обязательно верни поля: order_blocks, liquidity, fvg, structure_levels, patterns (даже если массивы пустые).
+4) Если есть хотя бы умеренное основание, не пропускай разметку overlay.
+5) Даже при сигнале ОЖИДАНИЕ верни рабочую зону, ликвидность, возможный order block, FVG/имбаланс и уровни структуры, если они читаются.
+6) Если массив свечей пустой — всё равно верни полный JSON-контракт и пустые массивы overlay.
+""".strip()
+
 
 class ChatRequest(BaseModel):
     message: str = Field(min_length=2, max_length=4000)
@@ -100,12 +140,21 @@ class ForexChatService:
         try:
             context_text = self._context_to_text(payload.context)
             explanation_mode = self._is_trade_idea_explanation_request(message=message, context=payload.context)
+            smc_analysis_mode = self._is_smc_overlay_request(message=message, context=payload.context)
             prompt = (
                 self._build_trade_idea_explanation_prompt(message=message, context=payload.context)
                 if explanation_mode
+                else self._build_smc_overlay_prompt(message=message, context=payload.context)
+                if smc_analysis_mode
                 else message if not context_text else f"{message}\n\nКонтекст платформы:\n{context_text}"
             )
-            system_prompt = IDEA_EXPLANATION_SYSTEM_PROMPT if explanation_mode else CHAT_SYSTEM_PROMPT
+            system_prompt = (
+                IDEA_EXPLANATION_SYSTEM_PROMPT
+                if explanation_mode
+                else SMC_ANALYSIS_SYSTEM_PROMPT
+                if smc_analysis_mode
+                else CHAT_SYSTEM_PROMPT
+            )
             response = await self.client.responses.create(
                 model=self.model,
                 input=[
@@ -173,6 +222,32 @@ class ForexChatService:
         return "объясн" in lowered and "иде" in lowered and "signal" in lowered
 
     @staticmethod
+    def _is_smc_overlay_request(*, message: str, context: dict[str, Any]) -> bool:
+        lowered = message.lower()
+        has_keywords = any(
+            token in lowered
+            for token in (
+                "smc",
+                "ict",
+                "свеч",
+                "candles",
+                "order block",
+                "ликвид",
+                "fvg",
+                "имбаланс",
+                "structure_levels",
+                "patterns",
+                "json",
+            )
+        )
+        if has_keywords:
+            return True
+        if not isinstance(context, dict):
+            return False
+        candles = context.get("candles")
+        return isinstance(candles, list)
+
+    @staticmethod
     def _build_trade_idea_explanation_prompt(*, message: str, context: dict[str, Any]) -> str:
         safe_context = context if isinstance(context, dict) else {}
         payload = {
@@ -184,6 +259,24 @@ class ForexChatService:
                 "Не менять числовые значения direction/entry/stop loss/take profit/status/confidence.",
                 "Не придумывать отсутствующие факты.",
                 "При нехватке данных явно указывать ограниченность подтверждений.",
+            ],
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    @staticmethod
+    def _build_smc_overlay_prompt(*, message: str, context: dict[str, Any]) -> str:
+        safe_context = context if isinstance(context, dict) else {}
+        payload = {
+            "task": "analyze_candles_with_smc_ict_overlays",
+            "user_message": message,
+            "input": safe_context,
+            "response_format": SMC_ANALYSIS_RESPONSE_SHAPE,
+            "hard_rules": [
+                "Верни строго JSON-объект.",
+                "Все поля и строки только на русском.",
+                "Всегда возвращай массивы order_blocks, liquidity, fvg, structure_levels, patterns.",
+                "Для ОЖИДАНИЕ не обнуляй разметку, если структура читается по свечам.",
+                "Если свечей нет, массивы overlay остаются пустыми, но поля обязательны.",
             ],
         }
         return json.dumps(payload, ensure_ascii=False)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -63,3 +63,22 @@ def test_trade_idea_explanation_prompt_contains_json_contract() -> None:
     assert "\"response_format\"" in prompt
     assert "\"headline\"" in prompt
     assert "\"target_logic\"" in prompt
+
+
+def test_smc_overlay_mode_detected_by_message_keywords() -> None:
+    assert ForexChatService._is_smc_overlay_request(
+        message="Проанализируй массив свечей SMC/ICT и верни JSON с order_blocks, liquidity и fvg.",
+        context={},
+    )
+
+
+def test_smc_overlay_prompt_contains_required_overlay_keys() -> None:
+    prompt = ForexChatService._build_smc_overlay_prompt(
+        message="Сделай разметку по свечам",
+        context={"candles": [{"i": 0, "o": 1.1, "h": 1.2, "l": 1.0, "c": 1.15}]},
+    )
+
+    assert "\"response_format\"" in prompt
+    assert "\"order_blocks\"" in prompt
+    assert "\"liquidity\"" in prompt
+    assert "\"structure_levels\"" in prompt


### PR DESCRIPTION
### Motivation
- Нужно дать модели отдельный режим для SMC/ICT-анализа свечей, который возвращает строгую структурированную JSON-разметку overlay-объектов для отрисовки на графике и исключает свободный текст.

### Description
- Добавлен контракт `SMC_ANALYSIS_RESPONSE_SHAPE` и системный промпт `SMC_ANALYSIS_SYSTEM_PROMPT` с требованием строгого JSON и обязательными полями `order_blocks`, `liquidity`, `fvg`, `structure_levels`, `patterns`.
- Добавлены детектор `_is_smc_overlay_request` и билдeр промпта `_build_smc_overlay_prompt`, и интеграция нового режима в `ForexChatService.chat` (три режима: объяснение идеи, SMC-разметка, общий чат).
- Обновлена логика выбора `system_prompt` и формирования `prompt` в `backend/chat_service.py` для корректной генерации payload-а модели.
- Добавлены тесты в `tests/test_chat.py` для проверки детекции SMC-режима и наличия обязательных ключей в SMC-промпте.

### Testing
- Запущен набор тестов `pytest -q tests/test_chat.py`, все тесты прошли успешно (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea565badfc8331b625a6fd0250dc9b)