### PR TITLE
Исправление приоритета narrative и восстановление аналитических оверлеев на карточке идеи

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -2155,7 +2155,10 @@ class TradeIdeaService:
             candles = signal.get("candles") if isinstance(signal.get("candles"), list) else []
         model_chart_overlays = self.normalize_chart_overlays(signal.get("chart_overlays"))
         model_overlays_meaningful = self.is_meaningful_overlay_payload(model_chart_overlays)
-        fallback_chart_overlays = self._extract_conservative_chart_overlays(candles)
+        fallback_chart_overlays = self._extract_conservative_chart_overlays(
+            candles,
+            entry=self._extract_numeric(signal.get("entry") or signal.get("entry_zone") or signal.get("entry_price")),
+        )
         fallback_used = False
         if candles and not model_overlays_meaningful and self.is_meaningful_overlay_payload(fallback_chart_overlays):
             model_chart_overlays = fallback_chart_overlays
@@ -2357,7 +2360,12 @@ class TradeIdeaService:
             return normalized_new
         return _normalize(existing)
 
-    def _extract_conservative_chart_overlays(self, candles: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    def _extract_conservative_chart_overlays(
+        self,
+        candles: list[dict[str, Any]],
+        *,
+        entry: float | None = None,
+    ) -> dict[str, list[dict[str, Any]]]:
         overlays = self.normalize_chart_overlays({})
         if len(candles) < 6:
             return overlays
@@ -2374,9 +2382,12 @@ class TradeIdeaService:
             return overlays
         range_high = max(highs)
         range_low = min(lows)
+        end_index = max(len(candles) - 1, 0)
+        start_index = max(0, end_index - min(18, len(candles) - 1))
+        range_span = max(range_high - range_low, abs(range_high) * 0.0006)
         overlays["structure_levels"] = [
-            {"type": "range_high", "price": range_high, "label": "Range High"},
-            {"type": "range_low", "price": range_low, "label": "Range Low"},
+            {"type": "resistance", "price": range_high, "label": "Resistance"},
+            {"type": "support", "price": range_low, "label": "Support"},
         ]
         current_price = self._extract_numeric(candles[-1].get("close")) or range_high
         tolerance = max((range_high - range_low) * 0.0015, abs(current_price) * 0.00025)
@@ -2386,6 +2397,29 @@ class TradeIdeaService:
             overlays["liquidity"].append({"type": "buy_side", "price": range_high, "label": "Buy-side liquidity"})
         if eq_low >= 1:
             overlays["liquidity"].append({"type": "sell_side", "price": range_low, "label": "Sell-side liquidity"})
+        overlays["zones"].append(
+            {
+                "type": "working_zone",
+                "label": "Working zone",
+                "low": range_low + range_span * 0.35,
+                "high": range_low + range_span * 0.55,
+                "start_index": start_index,
+                "end_index": end_index,
+            }
+        )
+        if entry is not None:
+            entry_padding = max(abs(entry) * 0.0006, range_span * 0.04)
+            overlays["zones"].append(
+                {
+                    "type": "entry_zone",
+                    "label": "Entry zone",
+                    "low": entry - entry_padding,
+                    "high": entry + entry_padding,
+                    "start_index": max(0, end_index - 8),
+                    "end_index": end_index,
+                }
+            )
+        overlays["levels"] = list(overlays.get("structure_levels") or []) + list(overlays.get("liquidity") or [])
         return overlays
 
     @classmethod
@@ -2401,8 +2435,15 @@ class TradeIdeaService:
                 normalized["fvg"].append(zone)
             elif "liquidity" in zone_type:
                 normalized["liquidity"].append(zone)
+            else:
+                normalized["zones"].append(zone)
+                normalized["order_blocks"].append(zone)
         for level in payload.get("levels") if isinstance(payload.get("levels"), list) else []:
-            normalized["structure_levels"].append(level)
+            level_type = str(level.get("type") or level.get("label") or "").lower()
+            if "liq" in level_type or "bsl" in level_type or "ssl" in level_type:
+                normalized["liquidity"].append(level)
+            else:
+                normalized["structure_levels"].append(level)
         for pattern in payload.get("patterns") if isinstance(payload.get("patterns"), list) else []:
             normalized["patterns"].append(pattern)
         return normalized

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -224,6 +224,13 @@ function buildShortText(idea) {
 }
 
 function buildFullText(idea) {
+  const isPlaceholderNarrative = (value) => {
+    const text = normalizeWhitespace(value).toLowerCase();
+    if (!text) return false;
+    return text.includes("подробное описание пока не получено")
+      || text.includes("дождитесь обновления идеи")
+      || text.includes("описание пока не получено");
+  };
   const modelNarrativeCandidates = [
     idea?.idea_thesis || idea?.ideaThesis,
     idea?.unified_narrative,
@@ -231,11 +238,17 @@ function buildFullText(idea) {
   ];
   for (const candidate of modelNarrativeCandidates) {
     const text = normalizeWhitespace(candidate);
+    if (!text || isPlaceholderNarrative(text)) continue;
     if (isRenderableNarrative(text) && !isCompactTechnicalSummary(text)) return text;
   }
 
   const fallbackNarrative = normalizeWhitespace(idea?.fallback_narrative);
-  if (isRenderableNarrative(fallbackNarrative) && !isCompactTechnicalSummary(fallbackNarrative)) return fallbackNarrative;
+  if (
+    fallbackNarrative
+    && !isPlaceholderNarrative(fallbackNarrative)
+    && isRenderableNarrative(fallbackNarrative)
+    && !isCompactTechnicalSummary(fallbackNarrative)
+  ) return fallbackNarrative;
 
   return "Подробное описание пока не получено. Дождитесь обновления идеи перед входом в сделку.";
 }
@@ -1769,6 +1782,48 @@ function normalizeSmcOverlays(payload) {
       };
     })
     .filter(Boolean);
+
+  const hasAdvancedOverlays = orderBlocks.length || fvg.length || liquidity.length || structure.length || patterns.length;
+  if (!hasAdvancedOverlays && Array.isArray(payload?.candles) && payload.candles.length >= 6) {
+    const recentCandles = payload.candles.slice(-30);
+    const highs = recentCandles.map((c) => toFiniteNumber(c?.high)).filter((v) => v != null);
+    const lows = recentCandles.map((c) => toFiniteNumber(c?.low)).filter((v) => v != null);
+    if (highs.length && lows.length) {
+      const rangeHigh = Math.max(...highs);
+      const rangeLow = Math.min(...lows);
+      const mid = (rangeHigh + rangeLow) / 2;
+      const endIndex = payload.candles.length - 1;
+      const startIndex = Math.max(0, endIndex - Math.min(18, recentCandles.length - 1));
+      structure.push(
+        { level: rangeHigh, type: "resistance", label: "Resistance" },
+        { level: rangeLow, type: "support", label: "Support" },
+      );
+      liquidity.push(
+        { level: rangeHigh, label: "BSL" },
+        { level: rangeLow, label: "SSL" },
+      );
+      orderBlocks.push({
+        from: Math.min(mid, rangeLow + (rangeHigh - rangeLow) * 0.35),
+        to: Math.max(mid, rangeLow + (rangeHigh - rangeLow) * 0.55),
+        type: "working_zone",
+        label: "Working zone",
+        from_index: startIndex,
+        to_index: endIndex,
+      });
+      const entry = toFiniteNumber(payload?.entry ?? payload?.entry_price ?? payload?.trade?.entry);
+      if (entry != null) {
+        const zonePad = Math.max(Math.abs(entry) * 0.0006, (rangeHigh - rangeLow) * 0.04);
+        orderBlocks.push({
+          from: entry - zonePad,
+          to: entry + zonePad,
+          type: "entry_zone",
+          label: "Entry zone",
+          from_index: Math.max(0, endIndex - 8),
+          to_index: endIndex,
+        });
+      }
+    }
+  }
 
   return {
     order_blocks: orderBlocks,


### PR DESCRIPTION
### Motivation
- Главная причина: плейсхолдерный текст мог считаться валидным narrative и показываться вместо реального текста модели, а payload оверлеев иногда нормализовался/терялся так, что на графике оставались только свечи и entry/sl/tp. 
- Цель изменений — гарантировать показ реального model-narrative при наличии и всегда рисовать базовые аналитические оверлеи, если продвинутые оверлеи отсутствуют.

### Description
- Исправлена логика выбора основного текста на фронтенде: теперь по строгому приоритету `idea_thesis -> unified_narrative -> full_text`, при этом явные placeholder‑фразы (например, «Подробное описание пока не получено…») отбрасываются и используются только если все поля пусты/невалидны; файл изменён: `app/static/js/chart-page.js`.
- Добавлен клиентский safety‑fallback в `normalizeSmcOverlays` для генерации базовых оверлеев при наличии свечей и пустых model-overlays: support/resistance, BSL/SSL liquidity, рабочая зона (`working zone`) и зона входа (`entry zone`), чтобы график всегда имел аналитическую разметку; файл изменён: `app/static/js/chart-page.js`.
- Усилен backend fallback и нормализация оверлеев: `_extract_conservative_chart_overlays` теперь принимает `entry`, формирует `structure_levels`, `liquidity`, `zones` (включая working/entry) и объединяет `levels`; legacy‑нормализация больше не теряет неизвестные зоны и правильно квалифицирует liquidity‑уровни; файл изменён: `app/services/trade_idea_service.py`.

### Testing
- Выполнена статическая проверка компиляции Python: `python -m compileall app/services/trade_idea_service.py` — успешно.
- Проверка синтаксиса JS: `node --check app/static/js/chart-page.js` — успешно.
- Локально проверено, что фронтенд возвращает реальный narrative вместо плейсхолдера и что при пустых model overlays при наличии свечей формируются базовые оверлеи (подтверждение через логи/консоль и подготовку payload).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea75d7e5f08331a790a38a439c24b2)