### PR TITLE
Автоматические предупреждения качества данных на карточках и в модалке идей

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -5430,6 +5430,17 @@ class TradeIdeaService:
         payload["candles_count_sent"] = int(TradeIdeaService._extract_numeric(payload.get("candles_count_sent")) or 0)
         if payload.get("chart_overlays_present") is None:
             payload["chart_overlays_present"] = TradeIdeaService.is_meaningful_overlay_payload(payload.get("chart_overlays"))
+        payload["data_provider"] = str(payload.get("data_provider") or "unknown").lower()
+        payload["fallback_used"] = bool(payload.get("fallback_used"))
+        data_quality = str(payload.get("data_quality") or "").lower()
+        payload["data_quality"] = data_quality if data_quality in {"high", "medium", "low"} else ("medium" if payload["fallback_used"] else "high")
+        chart_snapshot_status = str(payload.get("chartSnapshotStatus") or payload.get("chart_snapshot_status") or "no_data").lower()
+        payload["chartSnapshotStatus"] = chart_snapshot_status
+        payload["chart_snapshot_status"] = chart_snapshot_status
+        chart_status = str(payload.get("chart_status") or payload.get("chartStatus") or "").lower()
+        payload["chart_status"] = chart_status or ("fallback_candles" if chart_snapshot_status != "ok" else "snapshot")
+        payload["chartStatus"] = payload["chart_status"]
+        payload["confidence"] = int(TradeIdeaService._extract_numeric(payload.get("confidence")) or 0)
         return payload
 
     @classmethod

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -312,6 +312,29 @@
       border-top: 1px solid rgba(39, 58, 90, 0.5);
     }
 
+    .card-warning-badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 8px;
+    }
+
+    .warning-badge {
+      display: inline-flex;
+      align-items: center;
+      max-width: 100%;
+      padding: 4px 8px;
+      border-radius: 999px;
+      border: 1px solid rgba(251, 191, 36, 0.34);
+      background: rgba(120, 53, 15, 0.28);
+      color: #fde68a;
+      font-size: 11px;
+      line-height: 1.25;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .tag {
       background: var(--tag);
       color: #dbe7f7;
@@ -417,6 +440,37 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    .detail-warnings {
+      margin-bottom: 12px;
+      padding: 10px 12px;
+      border-radius: 14px;
+      border: 1px solid rgba(251, 191, 36, 0.35);
+      background: linear-gradient(180deg, rgba(120, 53, 15, 0.3) 0%, rgba(69, 26, 3, 0.28) 100%);
+    }
+
+    .detail-warnings-title {
+      margin: 0 0 8px;
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #fde68a;
+      font-weight: 700;
+    }
+
+    .detail-warnings-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 6px;
+    }
+
+    .detail-warnings-list li {
+      color: #fde68a;
+      font-size: 13px;
+      line-height: 1.45;
     }
 
     .close-btn {
@@ -840,6 +894,11 @@
           <div id="modal-sub" class="modal-sub"></div>
         </div>
         <button id="close-modal" class="close-btn">Закрыть</button>
+      </div>
+
+      <div id="detail-warnings" class="detail-warnings" style="display:none;">
+        <h3 class="detail-warnings-title">Предупреждения по качеству данных</h3>
+        <ul id="detail-warnings-list" class="detail-warnings-list"></ul>
       </div>
 
       <div class="detail-grid">

--- a/app/static/js/chart-page.js
+++ b/app/static/js/chart-page.js
@@ -8,6 +8,8 @@ const modalCard = document.getElementById("modal-card");
 const modalTitle = document.getElementById("modal-title");
 const modalSub = document.getElementById("modal-sub");
 const closeModalBtn = document.getElementById("close-modal");
+const detailWarnings = document.getElementById("detail-warnings");
+const detailWarningsList = document.getElementById("detail-warnings-list");
 
 const analysisText = document.getElementById("analysis-text");
 const tradingPlanText = document.getElementById("trading-plan-text");
@@ -834,6 +836,9 @@ function buildIdeaCardMarkup(idea) {
   const h4 = normalizeWhitespace(idea?.htf_bias_summary) || "H4: нет данных";
   const h1 = normalizeWhitespace(idea?.mtf_structure_summary) || "H1: нет данных";
   const m15 = normalizeWhitespace(idea?.ltf_trigger_summary) || "M15: нет данных";
+  const warnings = collectIdeaWarnings(idea);
+  const compactWarnings = warnings.slice(0, 2);
+  const hiddenWarningsCount = Math.max(0, warnings.length - compactWarnings.length);
 
   return `
     <div class="card-head">
@@ -859,6 +864,12 @@ function buildIdeaCardMarkup(idea) {
       <div class="level-pill level-pill-tp">TP: ${escapeHtml(formatLevel(idea?.takeProfit))}</div>
       <div class="level-pill level-pill-rr">RR: ${escapeHtml(calculateRiskReward(idea))}</div>
     </div>
+    ${compactWarnings.length ? `
+      <div class="card-warning-badges">
+        ${compactWarnings.map((message) => `<span class="warning-badge">${escapeHtml(message.replace("⚠️ ", ""))}</span>`).join("")}
+        ${hiddenWarningsCount > 0 ? `<span class="warning-badge">+${hiddenWarningsCount}</span>` : ""}
+      </div>
+    ` : ""}
     <div class="tags">
       ${tags.filter((tag) => !["created", "status", "debug"].includes(String(tag).toLowerCase())).map(tag => `<span class="tag">${escapeHtml(tag)}</span>`).join("")}
     </div>
@@ -1045,6 +1056,38 @@ function calculateRiskReward(idea) {
   const reward = Math.abs(target - entry);
   if (!risk || !Number.isFinite(risk) || !Number.isFinite(reward)) return "—";
   return `${(reward / risk).toFixed(2)}R`;
+}
+
+function collectIdeaWarnings(idea) {
+  const warnings = [];
+  const provider = normalizeWhitespace(idea?.data_provider).toLowerCase();
+  const fallbackUsed = idea?.fallback_used === true;
+  const dataQuality = normalizeWhitespace(idea?.data_quality).toLowerCase();
+  const overlaysPresent = idea?.chart_overlays_present;
+  const snapshotStatus = normalizeWhitespace(idea?.chartSnapshotStatus || idea?.chart_snapshot_status).toLowerCase();
+  const chartStatus = normalizeWhitespace(idea?.chart_status || idea?.chartStatus).toLowerCase();
+  const confidence = Number(idea?.confidence);
+
+  if (provider === "yahoo_finance" || fallbackUsed) warnings.push("⚠️ Используется Yahoo fallback — анализ упрощён");
+  if (dataQuality === "medium" || dataQuality === "low") warnings.push("⚠️ Качество данных снижено");
+  if (overlaysPresent === false) warnings.push("⚠️ OB/FVG/ликвидность не подтверждены");
+  if ((snapshotStatus && snapshotStatus !== "ok") || chartStatus.includes("fallback")) {
+    warnings.push("⚠️ График построен в fallback-режиме");
+  }
+  if (Number.isFinite(confidence) && confidence < 50) warnings.push("⚠️ Низкая уверенность");
+  return warnings;
+}
+
+function renderModalWarnings(idea) {
+  if (!detailWarnings || !detailWarningsList) return;
+  const warnings = collectIdeaWarnings(idea);
+  if (!warnings.length) {
+    detailWarnings.style.display = "none";
+    detailWarningsList.innerHTML = "";
+    return;
+  }
+  detailWarningsList.innerHTML = warnings.map((message) => `<li>${escapeHtml(message)}</li>`).join("");
+  detailWarnings.style.display = "";
 }
 
 function setTextContent(node, value, fallback = "—") {
@@ -2157,6 +2200,7 @@ async function openIdea(idea) {
   modal.classList.add("open");
 
   renderDetailText(idea);
+  renderModalWarnings(idea);
   renderCleanDetailStatus(idea);
   const snapshotUrl = getValidChartUrl(idea);
   const cachedSnapshotUrl = getCachedChartUrl(idea);


### PR DESCRIPTION
### Motivation
- Пользователю нужно ясно видеть причины, по которым идея ослаблена или построена в fallback-режиме, чтобы принимать обоснованные решения на UI. 
- Интерфейс и API должны последовательно передавать метрики качества данных и статусы графика для корректного отображения предупредительных сообщений.

### Description
- Добавлена логика сбора предупреждений в `app/static/js/chart-page.js` по правилам: `data_provider == "yahoo_finance"` или `fallback_used == true`, `data_quality` в `medium|low`, `chart_overlays_present == false`, `chartSnapshotStatus != "ok"` или `chart_status` содержит `fallback`, и `confidence < 50`, с русскими текстами предупреждений. 
- На карточках идей показаны компактные бейджи предупреждений (до 2 бейджей + счётчик оставшихся), а в модальном окне добавлен подробный блок `detail-warnings` с полными сообщениями и стилями в тёмной теме; изменения в `app/static/ideas.html` и `app/static/js/chart-page.js`. 
- Backend усиливает нормализацию полей API-идеи в `_decorate_api_idea`, чтобы `/api/ideas` стабильно возвращал `data_provider`, `fallback_used`, `data_quality`, `chart_overlays_present`, `chartSnapshotStatus`, `chart_status` и `confidence` в `app/services/trade_idea_service.py`.

### Testing
- Выполнена проверка синтаксиса Python команды `python -m py_compile app/services/trade_idea_service.py`, которая завершилась успешно. 
- Визуальные UI-тесты не запускались в этой среде (скриншоты/браузер недоступны), рекомендуется ручная проверка карточек и модалки в браузере после деплоя.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae395491883319a13071f3524bc9d)