### PR TITLE
Исправить формат символов для TwelveData и добавить отладочную информацию запроса

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -163,18 +163,20 @@ async def twelvedata_health_debug() -> dict:
     probe_results: list[dict] = []
     for symbol, timeframe in probe_pairs:
         probe = await asyncio.to_thread(provider.get_candles, symbol, timeframe, 30)
+        request_debug = provider.get_last_request_debug() if hasattr(provider, "get_last_request_debug") else {}
         probe_error = probe.get("error")
         probe_candles = probe.get("candles") or []
         probe_results.append(
             {
                 "symbol": symbol,
                 "timeframe": timeframe,
-                "provider_symbol": _td_symbol(symbol),
+                "provider_symbol_used": request_debug.get("provider_symbol_used") or _td_symbol(symbol),
                 "provider_interval": _TIMEFRAME_TO_TD.get(timeframe),
                 "candles_count": len(probe_candles),
                 "request_succeeded": probe_error is None and len(probe_candles) > 0,
                 "error": probe_error,
                 "source_symbol": probe.get("source_symbol"),
+                "raw_request_url": request_debug.get("raw_request_url"),
             }
         )
 

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -141,6 +141,11 @@ class ChartDataService:
             "apikey": self.api_key,
             "format": "JSON",
         }
+        logger.info(
+            "twelvedata_chart_request_symbol_sent requested_symbol=%s provider_symbol=%s",
+            normalized_symbol,
+            provider_symbol,
+        )
 
         try:
             response = requests.get(self.api_url, params=params, timeout=self.timeout_seconds)
@@ -444,8 +449,6 @@ class ChartDataService:
 
     @staticmethod
     def _format_twelvedata_symbol(symbol: str) -> str:
-        if len(symbol) == 6 and symbol.isalpha():
-            return f"{symbol[:3]}/{symbol[3:]}"
         return symbol
 
     @staticmethod

--- a/app/services/market_providers.py
+++ b/app/services/market_providers.py
@@ -7,6 +7,7 @@ import os
 from threading import Lock
 from time import monotonic
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import requests
 import yfinance as yf
@@ -53,6 +54,7 @@ class TwelveDataProvider(RealMarketDataProvider):
         self._cycle_api_calls = 0
         self._cycle_cache_hits = 0
         self._cycle_cache_misses = 0
+        self._last_request_debug: dict[str, Any] = {}
         logger.info(
             "twelvedata_init api_key_present=%s api_key_length=%s",
             bool(self.api_key),
@@ -238,10 +240,18 @@ class TwelveDataProvider(RealMarketDataProvider):
     def _request(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
         query = {**params, "apikey": self.api_key}
         safe_query = {**params, "apikey_present": bool(self.api_key), "apikey_length": len(self.api_key) if self.api_key else 0}
+        raw_request_url = self._build_sanitized_url(endpoint=endpoint, query=query)
+        self._last_request_debug = {
+            "endpoint": endpoint,
+            "provider_symbol_used": str(params.get("symbol") or ""),
+            "raw_request_url": raw_request_url,
+        }
         logger.info(
-            "twelvedata_http_request endpoint=%s api_key_present=%s query=%s",
+            "twelvedata_http_request endpoint=%s api_key_present=%s provider_symbol_sent=%s raw_request_url=%s query=%s",
             endpoint,
             bool(self.api_key),
+            str(params.get("symbol") or ""),
+            raw_request_url,
             safe_query,
         )
         try:
@@ -275,6 +285,18 @@ class TwelveDataProvider(RealMarketDataProvider):
         except requests.RequestException as exc:
             logger.warning("twelvedata_request_failed endpoint=%s error=%s", endpoint, exc)
             return {"status": "error", "message": str(exc)}
+
+    def get_last_request_debug(self) -> dict[str, Any]:
+        return dict(self._last_request_debug)
+
+    @staticmethod
+    def _build_sanitized_url(endpoint: str, query: dict[str, Any]) -> str:
+        prepared = requests.Request("GET", f"{_TWELVEDATA_BASE}/{endpoint}", params=query).prepare()
+        parsed = urlsplit(prepared.url or "")
+        sanitized_query: list[tuple[str, str]] = []
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+            sanitized_query.append((key, "***" if key.lower() == "apikey" else value))
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(sanitized_query), parsed.fragment))
 
     def begin_request_cycle(self) -> int:
         with self._lock:
@@ -541,19 +563,17 @@ def _normalize_symbol(symbol: str) -> str:
 
 def _td_symbol(symbol: str) -> str:
     symbol_map = {
-        "EURUSD": "EUR/USD",
-        "GBPUSD": "GBP/USD",
-        "USDJPY": "USD/JPY",
-        "AUDUSD": "AUD/USD",
-        "USDCAD": "USD/CAD",
-        "USDCHF": "USD/CHF",
-        "NZDUSD": "NZD/USD",
-        "XAUUSD": "XAU/USD",
+        "EURUSD": "EURUSD",
+        "GBPUSD": "GBPUSD",
+        "USDJPY": "USDJPY",
+        "AUDUSD": "AUDUSD",
+        "USDCAD": "USDCAD",
+        "USDCHF": "USDCHF",
+        "NZDUSD": "NZDUSD",
+        "XAUUSD": "XAUUSD",
     }
     if symbol in symbol_map:
         return symbol_map[symbol]
-    if len(symbol) == 6 and symbol.isalpha():
-        return f"{symbol[:3]}/{symbol[3:]}"
     return symbol
 
 

--- a/tests/test_chart_api.py
+++ b/tests/test_chart_api.py
@@ -144,10 +144,10 @@ def test_market_endpoint_never_returns_synthetic_contract_fields() -> None:
 
 
 def test_twelvedata_symbol_and_timeframe_mapping_contract() -> None:
-    assert _td_symbol('EURUSD') == 'EUR/USD'
-    assert _td_symbol('GBPUSD') == 'GBP/USD'
-    assert _td_symbol('USDJPY') == 'USD/JPY'
-    assert _td_symbol('XAUUSD') == 'XAU/USD'
+    assert _td_symbol('EURUSD') == 'EURUSD'
+    assert _td_symbol('GBPUSD') == 'GBPUSD'
+    assert _td_symbol('USDJPY') == 'USDJPY'
+    assert _td_symbol('XAUUSD') == 'XAUUSD'
 
     assert _TIMEFRAME_TO_TD['M15'] == '15min'
     assert _TIMEFRAME_TO_TD['H1'] == '1h'
@@ -163,9 +163,17 @@ def test_twelvedata_debug_health_endpoint(monkeypatch) -> None:
         lambda symbol, timeframe, limit: {
             'symbol': symbol,
             'timeframe': timeframe,
-            'source_symbol': 'EUR/USD',
+            'source_symbol': 'EURUSD',
             'candles': [{'time': 1710929700, 'open': 1.086, 'high': 1.087, 'low': 1.085, 'close': 1.0865}],
             'error': None,
+        },
+    )
+    monkeypatch.setattr(
+        provider,
+        'get_last_request_debug',
+        lambda: {
+            'provider_symbol_used': 'EURUSD',
+            'raw_request_url': 'https://api.twelvedata.com/time_series?symbol=EURUSD&interval=15min&apikey=%2A%2A%2A',
         },
     )
 
@@ -176,12 +184,13 @@ def test_twelvedata_debug_health_endpoint(monkeypatch) -> None:
 
     assert payload['provider'] == 'twelvedata'
     assert payload['api_key_present'] is True
-    assert payload['symbol_mapping']['EURUSD'] == 'EUR/USD'
+    assert payload['symbol_mapping']['EURUSD'] == 'EURUSD'
     assert payload['timeframe_mapping']['M15'] == '15min'
-    assert payload['probe']['provider_symbol'] == 'EUR/USD'
+    assert payload['probe']['provider_symbol_used'] == 'EURUSD'
     assert payload['probe']['provider_interval'] == '15min'
     assert payload['probe']['candles_count'] == 1
     assert payload['probe']['request_succeeded'] is True
+    assert payload['probe']['raw_request_url']
 
 
 def test_market_health_debug_endpoint(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Исправить некорректный формат символов для запросов к TwelveData, чтобы провайдер получал пары без слэша (`EURUSD`, `GBPUSD`, `USDJPY`, `XAUUSD`).
- Упростить диагностику проблем с TwelveData, возвращая в debug-информации реально отправленный символ и безопасный URL запроса.

### Description
- Обновлён маппинг в `_td_symbol` в `app/services/market_providers.py`, теперь явные пары возвращаются в формате без `/` (например, `"EURUSD": "EURUSD"`).
- Убран fallback, который ранее генерировал формат с `/`, и в `ChartDataService` больше не форматируется символ в `XXX/YYY` перед отправкой.
- Добавлены отладочные метаданные в `TwelveDataProvider`: сохранение последнего `provider_symbol_used` и `raw_request_url` с замаскированным `apikey`, а также метод `get_last_request_debug`.
- Расширено логирование отправляемого символа в `ChartDataService` и обновлён `/api/debug/twelvedata-health` для возврата `provider_symbol_used` и `raw_request_url` (sanitized).

### Testing
- Обновлены и запущены контрактные тесты в `tests/test_chart_api.py`, включая проверку маппинга и debug endpoint; результат: `pytest -q tests/test_chart_api.py` — 10 passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae42d05f0833190ff01552a6c5215)