### PR TITLE
Добавить детекцию SMC-оверлеев (OB/FVG/Liquidity) и подключить в pipeline идей

### DIFF
--- a/app/services/smc_detector.py
+++ b/app/services/smc_detector.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class _Candle:
+    index: int
+    open: float
+    high: float
+    low: float
+    close: float
+
+    @property
+    def body(self) -> float:
+        return abs(self.close - self.open)
+
+    @property
+    def bullish(self) -> bool:
+        return self.close > self.open
+
+    @property
+    def bearish(self) -> bool:
+        return self.close < self.open
+
+
+class SmcDetector:
+    """Detects conservative SMC overlays from OHLC candles."""
+
+    def __init__(self, min_candles: int = 30) -> None:
+        self.min_candles = max(3, int(min_candles))
+
+    def detect(self, candles_raw: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        candles = self._normalize(candles_raw)
+        overlays: dict[str, list[dict[str, Any]]] = {
+            "order_blocks": [],
+            "fvg": [],
+            "liquidity": [],
+        }
+        if len(candles) < self.min_candles:
+            return overlays
+
+        overlays["order_blocks"] = self._detect_order_blocks(candles)
+        overlays["fvg"] = self._detect_fvg(candles)
+        overlays["liquidity"] = self._detect_liquidity(candles)
+        return overlays
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return None
+        if numeric != numeric:
+            return None
+        return numeric
+
+    def _normalize(self, candles_raw: list[dict[str, Any]]) -> list[_Candle]:
+        normalized: list[_Candle] = []
+        for index, candle in enumerate(candles_raw or []):
+            open_price = self._to_float(candle.get("open"))
+            high = self._to_float(candle.get("high"))
+            low = self._to_float(candle.get("low"))
+            close_price = self._to_float(candle.get("close"))
+            if None in (open_price, high, low, close_price):
+                continue
+            normalized.append(_Candle(index=index, open=open_price, high=high, low=low, close=close_price))
+        return normalized
+
+    def _detect_order_blocks(self, candles: list[_Candle]) -> list[dict[str, Any]]:
+        if len(candles) < 4:
+            return []
+        avg_body = sum(c.body for c in candles[-20:]) / max(1, len(candles[-20:]))
+        impulse_threshold = max(avg_body * 1.2, (max(c.high for c in candles[-20:]) - min(c.low for c in candles[-20:])) * 0.03)
+        blocks: list[dict[str, Any]] = []
+
+        for i in range(1, len(candles)):
+            prev = candles[i - 1]
+            cur = candles[i]
+            if cur.body < impulse_threshold:
+                continue
+
+            # Demand OB: last bearish candle before bullish impulse.
+            if prev.bearish and cur.bullish and cur.close > prev.high:
+                low = min(prev.open, prev.close)
+                high = max(prev.open, prev.close)
+                blocks.append(
+                    {
+                        "type": "demand",
+                        "low": low,
+                        "high": high,
+                        "index": prev.index,
+                        "start_index": max(prev.index - 2, 0),
+                        "end_index": min(prev.index + 8, candles[-1].index),
+                        "label": "Demand OB",
+                    }
+                )
+
+            # Supply OB: last bullish candle before bearish impulse.
+            if prev.bullish and cur.bearish and cur.close < prev.low:
+                low = min(prev.open, prev.close)
+                high = max(prev.open, prev.close)
+                blocks.append(
+                    {
+                        "type": "supply",
+                        "low": low,
+                        "high": high,
+                        "index": prev.index,
+                        "start_index": max(prev.index - 2, 0),
+                        "end_index": min(prev.index + 8, candles[-1].index),
+                        "label": "Supply OB",
+                    }
+                )
+
+        # Keep the latest structurally relevant blocks.
+        blocks.sort(key=lambda item: int(item.get("index", 0)), reverse=True)
+        return blocks[:6]
+
+    def _detect_fvg(self, candles: list[_Candle]) -> list[dict[str, Any]]:
+        gaps: list[dict[str, Any]] = []
+        for i in range(1, len(candles) - 1):
+            left = candles[i - 1]
+            right = candles[i + 1]
+
+            # Bullish FVG: left.high < right.low.
+            if left.high < right.low:
+                gaps.append(
+                    {
+                        "type": "bullish_fvg",
+                        "low": left.high,
+                        "high": right.low,
+                        "start_index": left.index,
+                        "end_index": right.index,
+                        "label": "Bullish FVG",
+                    }
+                )
+
+            # Bearish FVG: right.high < left.low.
+            if right.high < left.low:
+                gaps.append(
+                    {
+                        "type": "bearish_fvg",
+                        "low": right.high,
+                        "high": left.low,
+                        "start_index": left.index,
+                        "end_index": right.index,
+                        "label": "Bearish FVG",
+                    }
+                )
+
+        gaps.sort(key=lambda item: int(item.get("end_index", 0)), reverse=True)
+        return gaps[:8]
+
+    def _detect_liquidity(self, candles: list[_Candle]) -> list[dict[str, Any]]:
+        window = candles[-40:] if len(candles) > 40 else candles
+        highs = [c.high for c in window]
+        lows = [c.low for c in window]
+        if not highs or not lows:
+            return []
+
+        span = max(highs) - min(lows)
+        ref_price = window[-1].close
+        tolerance = max(span * 0.0015, abs(ref_price) * 0.00025)
+
+        liquidity: list[dict[str, Any]] = []
+        high_clusters = self._cluster_levels(highs, tolerance)
+        low_clusters = self._cluster_levels(lows, tolerance)
+
+        for cluster in high_clusters:
+            if len(cluster) >= 2:
+                liquidity.append({"type": "buy_side", "price": sum(cluster) / len(cluster), "label": "Buy-side liquidity"})
+        for cluster in low_clusters:
+            if len(cluster) >= 2:
+                liquidity.append({"type": "sell_side", "price": sum(cluster) / len(cluster), "label": "Sell-side liquidity"})
+
+        return liquidity[:6]
+
+    @staticmethod
+    def _cluster_levels(levels: list[float], tolerance: float) -> list[list[float]]:
+        clusters: list[list[float]] = []
+        for level in sorted(levels):
+            placed = False
+            for cluster in clusters:
+                center = sum(cluster) / len(cluster)
+                if abs(level - center) <= tolerance:
+                    cluster.append(level)
+                    placed = True
+                    break
+            if not placed:
+                clusters.append([level])
+        return clusters

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -16,6 +16,7 @@ from app.services.chart_data_service import ChartDataService
 from app.services.chart_snapshot_service import ChartSnapshotService
 from app.services.idea_narrative_llm import IdeaNarrativeLLMService, NarrativeResult
 from app.services.narrative_generator import generate_signal_preview_text, generate_signal_text
+from app.services.smc_detector import SmcDetector
 from app.services.storage.json_storage import JsonStorage
 from app.services.trade_idea_stats_service import TradeIdeaStatsService
 from backend.data_provider import DataProvider
@@ -58,6 +59,7 @@ LEVEL_TAKE_PROFIT_OFFSET = 0.0040
 CANDLE_CONTEXT_COUNT = 40
 MODEL_CANDLES_MIN = 50
 MODEL_CANDLES_MAX = 120
+SMC_OVERLAY_CANDLES_MIN = 30
 CHART_OVERLAY_KEYS = ("order_blocks", "liquidity", "fvg", "structure_levels", "patterns", "zones", "levels", "markers", "arrows")
 CHART_OVERLAY_ALIASES = {
     "order_blocks": ("order_blocks", "orderBlocks", "orderblock", "order_blocks_zones"),
@@ -83,6 +85,7 @@ class TradeIdeaService:
         self.data_provider = DataProvider()
         self.chart_data_service = chart_data_service or ChartDataService()
         self.chart_snapshot_service = ChartSnapshotService()
+        self.smc_detector = SmcDetector(min_candles=SMC_OVERLAY_CANDLES_MIN)
         self.refresh_interval_seconds = int(os.getenv("IDEAS_REFRESH_INTERVAL_SECONDS", "180"))
         self.live_price_refresh_seconds = int(os.getenv("IDEAS_LIVE_PRICE_REFRESH_SECONDS", "15"))
         self.live_chart_refresh_seconds = int(os.getenv("IDEAS_LIVE_CHART_REFRESH_SECONDS", "45"))
@@ -2203,9 +2206,9 @@ class TradeIdeaService:
             candles = signal.get("candles") if isinstance(signal.get("candles"), list) else []
         model_chart_overlays = self.normalize_chart_overlays(signal.get("chart_overlays"))
         model_overlays_meaningful = self.is_meaningful_overlay_payload(model_chart_overlays)
-        fallback_chart_overlays = self._extract_conservative_chart_overlays(candles) if len(candles) >= MODEL_CANDLES_MIN else {}
+        fallback_chart_overlays = self._extract_conservative_chart_overlays(candles) if len(candles) >= SMC_OVERLAY_CANDLES_MIN else {}
         fallback_used = False
-        if len(candles) >= MODEL_CANDLES_MIN and not model_overlays_meaningful and self.is_meaningful_overlay_payload(fallback_chart_overlays):
+        if len(candles) >= SMC_OVERLAY_CANDLES_MIN and not model_overlays_meaningful and self.is_meaningful_overlay_payload(fallback_chart_overlays):
             model_chart_overlays = fallback_chart_overlays
             fallback_used = True
         if self.is_meaningful_overlay_payload(model_chart_overlays):
@@ -2225,7 +2228,7 @@ class TradeIdeaService:
             "idea_overlays_prepare symbol=%s timeframe=%s candles_present=%s model_overlays=%s fallback_used=%s categories=%s preserved_existing=%s final_counts=%s",
             str(signal.get("symbol") or "").upper(),
             str(signal.get("timeframe") or "H1").upper(),
-            len(candles) >= MODEL_CANDLES_MIN,
+            len(candles) >= SMC_OVERLAY_CANDLES_MIN,
             model_overlays_meaningful,
             fallback_used,
             [key for key in CHART_OVERLAY_KEYS if final_chart_overlays.get(key)],
@@ -2449,8 +2452,12 @@ class TradeIdeaService:
 
     def _extract_conservative_chart_overlays(self, candles: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
         overlays = self.normalize_chart_overlays({})
-        if len(candles) < 6:
+        if len(candles) < SMC_OVERLAY_CANDLES_MIN:
             return overlays
+        smc_overlays = self.smc_detector.detect(candles)
+        overlays["order_blocks"] = smc_overlays.get("order_blocks") or []
+        overlays["fvg"] = smc_overlays.get("fvg") or []
+        overlays["liquidity"] = smc_overlays.get("liquidity") or []
         opens: list[float] = []
         closes: list[float] = []
         highs: list[float] = []
@@ -2480,49 +2487,6 @@ class TradeIdeaService:
             {"type": "resistance", "price": resistance, "label": "Resistance"},
             {"type": "support", "price": support, "label": "Support"},
         ]
-        current_price = self._extract_numeric(candles[-1].get("close")) or range_high
-        tolerance = max((range_high - range_low) * 0.0015, abs(current_price) * 0.00025)
-        eq_high = sum(1 for value in highs[:-1] if abs(value - range_high) <= tolerance)
-        eq_low = sum(1 for value in lows[:-1] if abs(value - range_low) <= tolerance)
-        anchor_index = max(len(candles) - 8, 0)
-        ob_low = min(opens[-3], closes[-3]) if len(opens) >= 3 and len(closes) >= 3 else min(opens[-1], closes[-1])
-        ob_high = max(opens[-3], closes[-3]) if len(opens) >= 3 and len(closes) >= 3 else max(opens[-1], closes[-1])
-        overlays["order_blocks"] = [
-            {
-                "type": "bullish_order_block" if closes[-1] >= mid_range else "bearish_order_block",
-                "low": min(ob_low, ob_high),
-                "high": max(ob_low, ob_high),
-                "start_index": anchor_index,
-                "end_index": len(candles) - 1,
-                "label": "Conservative OB",
-            }
-        ]
-        if len(highs) >= 3 and len(lows) >= 1 and highs[-3] < lows[-1]:
-            overlays["fvg"].append(
-                {
-                    "type": "bullish_fvg",
-                    "low": highs[-3],
-                    "high": lows[-1],
-                    "start_index": max(len(candles) - 3, 0),
-                    "end_index": len(candles) - 1,
-                    "label": "Conservative FVG",
-                }
-            )
-        if len(lows) >= 3 and len(highs) >= 1 and lows[-3] > highs[-1]:
-            overlays["fvg"].append(
-                {
-                    "type": "bearish_fvg",
-                    "low": highs[-1],
-                    "high": lows[-3],
-                    "start_index": max(len(candles) - 3, 0),
-                    "end_index": len(candles) - 1,
-                    "label": "Conservative FVG",
-                }
-            )
-        if eq_high >= 1:
-            overlays["liquidity"].append({"type": "buy_side", "price": range_high, "label": "Buy-side liquidity"})
-        if eq_low >= 1:
-            overlays["liquidity"].append({"type": "sell_side", "price": range_low, "label": "Sell-side liquidity"})
         overlays["patterns"] = [
             {
                 "name": "range_breakout_setup",

--- a/tests/test_smc_detector.py
+++ b/tests/test_smc_detector.py
@@ -1,0 +1,58 @@
+from app.services.smc_detector import SmcDetector
+
+
+def _base_candles(count: int = 32) -> list[dict[str, float]]:
+    candles: list[dict[str, float]] = []
+    price = 1.1000
+    for i in range(count):
+        open_price = price
+        close_price = price + (0.0002 if i % 2 == 0 else -0.00015)
+        high = max(open_price, close_price) + 0.0002
+        low = min(open_price, close_price) - 0.0002
+        candles.append({"open": open_price, "high": high, "low": low, "close": close_price})
+        price = close_price
+    return candles
+
+
+def test_smc_detector_returns_empty_when_not_enough_candles() -> None:
+    detector = SmcDetector(min_candles=30)
+    overlays = detector.detect(_base_candles(20))
+
+    assert overlays == {"order_blocks": [], "fvg": [], "liquidity": []}
+
+
+def test_smc_detector_detects_order_blocks_fvg_and_liquidity() -> None:
+    detector = SmcDetector(min_candles=30)
+    candles = _base_candles(34)
+
+    # Demand OB: bearish candle then bullish impulse above previous high.
+    candles[20] = {"open": 1.1012, "high": 1.1013, "low": 1.1005, "close": 1.1006}
+    candles[21] = {"open": 1.1007, "high": 1.1033, "low": 1.1006, "close": 1.1030}
+
+    # Supply OB: bullish candle then bearish impulse below previous low.
+    candles[24] = {"open": 1.1022, "high": 1.1028, "low": 1.1021, "close": 1.1027}
+    candles[25] = {"open": 1.1026, "high": 1.1027, "low": 1.0995, "close": 1.0998}
+
+    # Bullish FVG between i-1 and i+1 around i=28.
+    candles[27] = {"open": 1.1000, "high": 1.1002, "low": 1.0996, "close": 1.0997}
+    candles[28] = {"open": 1.0998, "high": 1.1010, "low": 1.0997, "close": 1.1009}
+    candles[29] = {"open": 1.1015, "high": 1.1022, "low": 1.1014, "close": 1.1020}
+
+    # Equal highs/lows liquidity pools.
+    candles[30]["high"] = 1.1035
+    candles[31]["high"] = 1.10349
+    candles[32]["low"] = 1.0990
+    candles[33]["low"] = 1.09901
+
+    overlays = detector.detect(candles)
+
+    assert overlays["order_blocks"]
+    assert any(item["type"] == "demand" for item in overlays["order_blocks"])
+    assert any(item["type"] == "supply" for item in overlays["order_blocks"])
+
+    assert overlays["fvg"]
+    assert any(item["high"] > item["low"] for item in overlays["fvg"])
+
+    assert overlays["liquidity"]
+    assert any(item["type"] == "buy_side" for item in overlays["liquidity"])
+    assert any(item["type"] == "sell_side" for item in overlays["liquidity"])


### PR DESCRIPTION
### Motivation
- Исправить отсутствие SMC-оверлеев в `idea.chart_overlays` (поля `order_blocks`, `fvg`, `liquidity` приходили пустыми), чтобы фронтенд мог отрисовывать OB, FVG и уровни ликвидности.
- Сделать fallback-детекцию более реалистичной и включать её при достаточном количестве свечей (порог 30), а не оставлять пустые массивы в API.

### Description
- Добавлен новый сервис `SmcDetector` в `app/services/smc_detector.py`, реализующий детекцию: `order_blocks` (demand/supply, возвращает `{type, low, high, index, start_index, end_index, label}`), `fvg` (3-свечные гэпы, возвращает `{type, low, high, start_index, end_index, label}`) и `liquidity` (кластеры equal highs/lows, возвращает `{type, price, label}`).
- Интегрирован детектор в `TradeIdeaService` (`self.smc_detector`) и использован в `_extract_conservative_chart_overlays` для заполнения `chart_overlays` при `candles_count >= 30`, добавлена константа `SMC_OVERLAY_CANDLES_MIN = 30` и скорректированы точки вызова fallback-логики (`app/services/trade_idea_service.py`).
- Сохранён существующий формат `chart_overlays` (ключи `order_blocks`, `fvg`, `liquidity`, и т.д.), поэтому фронтенд (`app/static/js/chart-page.js`) сразу отрисовывает зоны как прямоугольники, FVG как полузоны и liquidity как пунктирные линии без изменений на стороне клиента.
- Добавлены unit-тесты `tests/test_smc_detector.py` для базовой валидации детектора.

### Testing
- Запущен unit-тест `pytest -q tests/test_smc_detector.py` и он успешно прошёл (`2 passed`).
- Локально выполнен прогон детектора на синтетических свечах и проверен пример выходного JSON с `order_blocks`, `fvg` и `liquidity` (см. тесты для воспроизводимого примера).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaece21a8c8331aba8cfb7cd15b88e)