### PR TITLE
Усилить кэш и throttling для TwelveData и отключить spam debug-проб

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 
 import asyncio
+from time import monotonic
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse
@@ -67,6 +68,8 @@ calendar_store = JsonStorage("signals_data/calendar.json", {"updated_at_utc": No
 heatmap_store = JsonStorage("signals_data/heatmap.json", {"updated_at_utc": None, "rows": []})
 logger = logging.getLogger(__name__)
 _ideas_refresh_task: asyncio.Task | None = None
+_twelvedata_probe_cache: dict[str, object] = {"saved_at": 0.0, "probes": []}
+_twelvedata_probe_ttl_seconds = 600.0
 
 
 class SnapshotResponse(BaseModel):
@@ -150,7 +153,7 @@ async def health() -> HealthResponse:
 
 
 @app.get("/api/debug/twelvedata-health")
-async def twelvedata_health_debug() -> dict:
+async def twelvedata_health_debug(run_probe: bool = False) -> dict:
     provider = canonical_market_service.live_provider
     api_key = getattr(provider, "api_key", "") or ""
 
@@ -161,24 +164,33 @@ async def twelvedata_health_debug() -> dict:
 
     probe_pairs = [("EURUSD", "M15"), ("GBPUSD", "H1")]
     probe_results: list[dict] = []
-    for symbol, timeframe in probe_pairs:
-        probe = await asyncio.to_thread(provider.get_candles, symbol, timeframe, 30)
-        request_debug = provider.get_last_request_debug() if hasattr(provider, "get_last_request_debug") else {}
-        probe_error = probe.get("error")
-        probe_candles = probe.get("candles") or []
-        probe_results.append(
-            {
-                "symbol": symbol,
-                "timeframe": timeframe,
-                "provider_symbol_used": request_debug.get("provider_symbol_used") or _td_symbol(symbol),
-                "provider_interval": _TIMEFRAME_TO_TD.get(timeframe),
-                "candles_count": len(probe_candles),
-                "request_succeeded": probe_error is None and len(probe_candles) > 0,
-                "error": probe_error,
-                "source_symbol": probe.get("source_symbol"),
-                "raw_request_url": request_debug.get("raw_request_url"),
-            }
-        )
+    cache_age_seconds = max(0.0, monotonic() - float(_twelvedata_probe_cache.get("saved_at") or 0.0))
+    cached_probes = _twelvedata_probe_cache.get("probes")
+    has_fresh_probe_cache = isinstance(cached_probes, list) and bool(cached_probes) and cache_age_seconds <= _twelvedata_probe_ttl_seconds
+    should_probe = bool(run_probe or not has_fresh_probe_cache)
+    if should_probe:
+        for symbol, timeframe in probe_pairs:
+            probe = await asyncio.to_thread(provider.get_candles, symbol, timeframe, 30)
+            request_debug = provider.get_last_request_debug() if hasattr(provider, "get_last_request_debug") else {}
+            probe_error = probe.get("error")
+            probe_candles = probe.get("candles") or []
+            probe_results.append(
+                {
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "provider_symbol_used": request_debug.get("provider_symbol_used") or _td_symbol(symbol),
+                    "provider_interval": _TIMEFRAME_TO_TD.get(timeframe),
+                    "candles_count": len(probe_candles),
+                    "request_succeeded": probe_error is None and len(probe_candles) > 0,
+                    "error": probe_error,
+                    "source_symbol": probe.get("source_symbol"),
+                    "raw_request_url": request_debug.get("raw_request_url"),
+                }
+            )
+        _twelvedata_probe_cache["saved_at"] = monotonic()
+        _twelvedata_probe_cache["probes"] = probe_results
+    elif isinstance(cached_probes, list):
+        probe_results = list(cached_probes)
 
     return {
         "provider": "twelvedata",
@@ -187,6 +199,9 @@ async def twelvedata_health_debug() -> dict:
         "api_key_length": len(api_key) if api_key else 0,
         "symbol_mapping": symbol_mapping,
         "timeframe_mapping": timeframe_mapping,
+        "run_probe": bool(run_probe),
+        "probe_cache_hit": not should_probe,
+        "probe_cache_age_seconds": cache_age_seconds if has_fresh_probe_cache else None,
         "probe": probe_results[0] if probe_results else None,
         "probes": probe_results,
     }
@@ -208,8 +223,10 @@ async def market_health_debug(symbol: str = "EURUSD", timeframe: str = "H1", lim
         source_symbol = _td_symbol(str(symbol).upper().replace("/", "").strip()) if "twelvedata" in str(provider_used) else str(symbol).upper().replace("/", "").strip()
     return {
         "provider_used": provider_used,
+        "twelvedata_cache_hit": bool(health.get("twelvedata_cache_hit", health.get("cache_hit"))),
         "cache_hit": bool(health.get("cache_hit")),
         "cache_age_seconds": health.get("cache_age_seconds"),
+        "next_allowed_request_at": health.get("next_allowed_request_at"),
         "primary_provider": health.get("primary_provider") or "twelvedata",
         "primary_error": health.get("primary_error"),
         "fallback_attempted": bool(health.get("fallback_attempted")),

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import logging
 import os
 from threading import Lock
-from time import monotonic
+from time import monotonic, time
 from typing import Any
 
 import requests
@@ -33,10 +33,15 @@ class ChartDataService:
         self.timeout_seconds = float(os.getenv("TWELVEDATA_TIMEOUT", str(DEFAULT_CHART_TIMEOUT_SECONDS)))
         self.output_size = int(os.getenv("TWELVEDATA_OUTPUTSIZE", str(DEFAULT_CHART_LIMIT)))
         self.yahoo_service = YahooMarketDataService()
-        self._cache_ttl_seconds = max(60.0, float(os.getenv("TWELVEDATA_CHART_CACHE_TTL_SECONDS", "60")))
+        self._cache_ttl_seconds = max(600.0, float(os.getenv("TWELVEDATA_CHART_CACHE_TTL_SECONDS", "600")))
         self._stale_success_ttl_seconds = max(self._cache_ttl_seconds, float(os.getenv("TWELVEDATA_STALE_CACHE_TTL_SECONDS", "900")))
+        self._request_cooldown_seconds = max(
+            self._cache_ttl_seconds,
+            float(os.getenv("TWELVEDATA_REQUEST_COOLDOWN_SECONDS", str(self._cache_ttl_seconds))),
+        )
         self._cache_lock = Lock()
         self._candles_cache: dict[str, dict[str, Any]] = {}
+        self._next_allowed_request_by_key: dict[str, float] = {}
         self._last_market_health: dict[str, Any] = {
             "primary_provider": "twelvedata",
             "primary_error": None,
@@ -51,6 +56,8 @@ class ChartDataService:
             "provider_used": None,
             "cache_hit": False,
             "cache_age_seconds": None,
+            "twelvedata_cache_hit": False,
+            "next_allowed_request_at": None,
         }
 
     def get_chart(self, symbol: str, timeframe: str, limit: int | None = None) -> dict[str, Any]:
@@ -89,6 +96,7 @@ class ChartDataService:
                 provider_used="twelvedata_cached",
                 cache_hit=True,
                 cache_age_seconds=cache_age_seconds,
+                next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
             )
             return cached_fresh
 
@@ -114,6 +122,7 @@ class ChartDataService:
                 provider_used="twelvedata",
                 cache_hit=False,
                 cache_age_seconds=None,
+                next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
             )
             return payload
 
@@ -129,6 +138,22 @@ class ChartDataService:
                     timeframe=normalized_tf,
                     message_ru="Свечной API не настроен: отсутствует TWELVEDATA_API_KEY.",
                     reason="fetch_error",
+                ),
+                provider_symbol=provider_symbol,
+                cache_key=cache_key,
+            )
+
+        if not self._is_request_allowed(cache_key):
+            return self._fallback_to_yahoo(
+                symbol=normalized_symbol,
+                timeframe=normalized_tf,
+                limit=requested_limit,
+                twelvedata_error="throttled",
+                twelvedata_payload=self.build_unavailable_payload(
+                    symbol=normalized_symbol,
+                    timeframe=normalized_tf,
+                    message_ru="Запрос к Twelve Data отложен: действует локальный throttling.",
+                    reason="rate_limited",
                 ),
                 provider_symbol=provider_symbol,
                 cache_key=cache_key,
@@ -152,6 +177,7 @@ class ChartDataService:
             response.raise_for_status()
             payload = response.json()
         except requests.RequestException as exc:
+            self._set_next_allowed_request(cache_key)
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=request_exception error=%s", normalized_symbol, normalized_tf, exc)
             return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
@@ -168,6 +194,7 @@ class ChartDataService:
                 cache_key=cache_key,
             )
         except ValueError:
+            self._set_next_allowed_request(cache_key)
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=invalid_json", normalized_symbol, normalized_tf)
             return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
@@ -204,6 +231,7 @@ class ChartDataService:
                     payload.get("message"),
                 )
                 reason = "rate_limited" if str(payload.get("code")) == "429" else "fetch_error"
+                self._set_next_allowed_request(cache_key)
                 return self._fallback_to_yahoo(
                     symbol=normalized_symbol,
                     timeframe=normalized_tf,
@@ -219,6 +247,7 @@ class ChartDataService:
                     cache_key=cache_key,
                 )
             logger.warning("twelvedata_failed symbol=%s tf=%s reason=empty_candles", normalized_symbol, normalized_tf)
+            self._set_next_allowed_request(cache_key)
             return self._fallback_to_yahoo(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
@@ -249,6 +278,7 @@ class ChartDataService:
             provider_used="twelvedata",
             cache_hit=False,
             cache_age_seconds=0.0,
+            next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
         )
         response_payload = {
             "symbol": normalized_symbol,
@@ -297,8 +327,31 @@ class ChartDataService:
                 provider_used="twelvedata_cached",
                 cache_hit=True,
                 cache_age_seconds=cache_age_seconds,
+                next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
             )
             return stale_cached
+
+        if twelvedata_error in {"rate_limited", "throttled"}:
+            cached_any_age = self._get_cached_payload_any_age(cache_key=cache_key, limit=limit)
+            if cached_any_age is not None:
+                cache_age_seconds = self._cache_age_seconds(cache_key)
+                self._set_market_health(
+                    primary_provider="twelvedata",
+                    primary_error=twelvedata_error,
+                    fallback_attempted=False,
+                    fallback_provider="yahoo_finance",
+                    fallback_error=None,
+                    final_provider_used="twelvedata_cached",
+                    request_succeeded=True,
+                    candles_count=len(cached_any_age.get("candles") or []),
+                    error=None,
+                    source_symbol=provider_symbol,
+                    provider_used="twelvedata_cached",
+                    cache_hit=True,
+                    cache_age_seconds=cache_age_seconds,
+                    next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
+                )
+                return cached_any_age
 
         logger.warning(
             "twelvedata_failed_yahoo_fallback symbol=%s tf=%s twelvedata_error=%s",
@@ -325,6 +378,7 @@ class ChartDataService:
                 provider_used="yahoo",
                 cache_hit=False,
                 cache_age_seconds=self._cache_age_seconds(cache_key),
+                next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
             )
             return {
                 "symbol": symbol,
@@ -356,6 +410,7 @@ class ChartDataService:
             provider_used="twelvedata",
             cache_hit=False,
             cache_age_seconds=self._cache_age_seconds(cache_key),
+            next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
         )
         return twelvedata_payload
 
@@ -375,6 +430,7 @@ class ChartDataService:
         provider_used: str | None,
         cache_hit: bool,
         cache_age_seconds: float | None,
+        next_allowed_request_at: str | None,
     ) -> None:
         self._last_market_health = {
             "primary_provider": primary_provider,
@@ -389,7 +445,9 @@ class ChartDataService:
             "source_symbol": source_symbol,
             "provider_used": provider_used,
             "cache_hit": bool(cache_hit),
+            "twelvedata_cache_hit": bool(cache_hit),
             "cache_age_seconds": cache_age_seconds,
+            "next_allowed_request_at": next_allowed_request_at,
         }
         logger.info(
             "market_provider_selected primary_provider=%s final_provider=%s fallback_attempted=%s request_succeeded=%s candles=%s error=%s source_symbol=%s",
@@ -412,6 +470,7 @@ class ChartDataService:
         with self._cache_lock:
             self._candles_cache[cache_key] = {
                 "saved_at": monotonic(),
+                "saved_at_epoch": time(),
                 "payload": dict(payload),
             }
 
@@ -438,6 +497,25 @@ class ChartDataService:
                 return None
             saved_at = float(cache_entry.get("saved_at") or 0.0)
             return max(0.0, monotonic() - saved_at)
+
+    def _get_cached_payload_any_age(self, *, cache_key: str, limit: int) -> dict[str, Any] | None:
+        return self._get_cached_payload(cache_key=cache_key, limit=limit, max_age_seconds=float("inf"))
+
+    def _is_request_allowed(self, cache_key: str) -> bool:
+        with self._cache_lock:
+            next_allowed = float(self._next_allowed_request_by_key.get(cache_key) or 0.0)
+        return time() >= next_allowed
+
+    def _set_next_allowed_request(self, cache_key: str) -> None:
+        with self._cache_lock:
+            self._next_allowed_request_by_key[cache_key] = time() + self._request_cooldown_seconds
+
+    def _get_next_allowed_request_at(self, cache_key: str) -> str | None:
+        with self._cache_lock:
+            next_allowed = float(self._next_allowed_request_by_key.get(cache_key) or 0.0)
+        if next_allowed <= 0:
+            return None
+        return datetime.utcfromtimestamp(next_allowed).isoformat() + "Z"
 
     @staticmethod
     def _normalize_symbol(symbol: str) -> str:


### PR DESCRIPTION
### Motivation
- Снизить избыточные запросы к TwelveData при частых обновлениях и избежать падения на `rate_limited` с автоматическим переходом на Yahoo каждый refresh. 
- Сохранить использование один раз удачных ответов TwelveData (из кэша) даже при последующем лимитировании провайдера.

### Description
- Усилен кэш в `ChartDataService`: минимальный TTL теперь `600s` и ключ кэша остаётся `symbol::timeframe`, при сохранении — добавлено поле `saved_at_epoch` и `saved_at` (монотонное время). 
- Добавлен per-key throttling (`_next_allowed_request_by_key`) и cooldown (`TWELVEDATA_REQUEST_COOLDOWN_SECONDS` / по умолчанию равен TTL), и логика `if not _is_request_allowed -> throttled` чтобы не вызывать TwelveData пока действует локальный cooldown. 
- При `rate_limited`/`throttled` пытаемся использовать любой существующий кэш (даже старый) через `_get_cached_payload_any_age`; Yahoo вызывается только если подходящего кэша нет. 
- Добавлены диагностические поля в market health: `twelvedata_cache_hit`, `cache_age_seconds`, `next_allowed_request_at`, `final_provider_used`, а также возвращаются из `GET /api/debug/market-health`. 
- `/api/debug/twelvedata-health` теперь использует внутренний probe-cache на 10 минут (`_twelvedata_probe_cache`) и выполняет реальные пробные запросы только при `run_probe=true` или если cache устарел, чтобы избежать запросов на каждый refresh.

### Testing
- Выполнена компиляция: `python -m py_compile app/services/chart_data_service.py app/main.py` (успешно). 
- Прогнал тесты для chart API: `pytest -q tests/test_chart_api.py` (все тесты прошли — `10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaeff496f483319121f029b031b5e4)