### PR TITLE
Привязать market-health и идеи к CanonicalMarketService (Finnhub→TwelveData→Yahoo) и добавить debug-поля

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import logging
+import os
 from pathlib import Path
 
 import asyncio
@@ -209,39 +210,41 @@ async def twelvedata_health_debug(run_probe: bool = False) -> dict:
 
 @app.get("/api/debug/market-health")
 async def market_health_debug(symbol: str = "EURUSD", timeframe: str = "H1", limit: int = 120) -> dict:
-    try:
-        payload = await asyncio.to_thread(chart_data_service.get_chart, symbol, timeframe, limit)
-    except TypeError:
-        payload = await asyncio.to_thread(chart_data_service.get_chart, symbol, timeframe)
-    candles = payload.get("candles") if isinstance(payload, dict) and isinstance(payload.get("candles"), list) else []
-    meta = payload.get("meta") if isinstance(payload, dict) and isinstance(payload.get("meta"), dict) else {}
-    health = chart_data_service.get_last_market_health()
-    provider_used = health.get("provider_used") or health.get("final_provider_used") or payload.get("source") or "unknown"
-    final_provider_used = health.get("final_provider_used") or provider_used
-    source_symbol = health.get("source_symbol")
-    if not source_symbol:
-        source_symbol = _td_symbol(str(symbol).upper().replace("/", "").strip()) if "twelvedata" in str(provider_used) else str(symbol).upper().replace("/", "").strip()
+    normalized_symbol = str(symbol).upper().replace("/", "").strip()
+    normalized_timeframe = str(timeframe or "H1").upper().strip()
+    requested_limit = max(1, int(limit or 1))
+    payload = await asyncio.to_thread(canonical_market_service.get_candles, normalized_symbol, normalized_timeframe, requested_limit)
+    candles = payload.get("candles") if isinstance(payload.get("candles"), list) else []
+    diagnostics = payload.get("diagnostics") if isinstance(payload.get("diagnostics"), dict) else {}
+    final_provider_used = diagnostics.get("final_provider_used") or payload.get("provider") or "unknown"
+    provider_used = final_provider_used
+    source_symbol = payload.get("source_symbol") or normalized_symbol
+    app_commit = os.getenv("RENDER_GIT_COMMIT") or os.getenv("APP_COMMIT") or os.getenv("GIT_COMMIT") or "unknown"
+    finnhub_api_key = getattr(canonical_market_service.finnhub_provider, "api_key", "") or ""
+    finnhub_error = diagnostics.get("finnhub_error")
     return {
+        "app_commit": app_commit,
+        "build_version": app.version,
         "provider_used": provider_used,
-        "twelvedata_cache_hit": bool(health.get("twelvedata_cache_hit", health.get("cache_hit"))),
-        "cache_hit": bool(health.get("cache_hit")),
-        "cache_age_seconds": health.get("cache_age_seconds"),
-        "next_allowed_request_at": health.get("next_allowed_request_at"),
-        "primary_provider": health.get("primary_provider") or "twelvedata",
-        "primary_error": health.get("primary_error"),
-        "fallback_attempted": bool(health.get("fallback_attempted")),
-        "fallback_provider": health.get("fallback_provider"),
-        "fallback_error": health.get("fallback_error"),
+        "finnhub_configured": bool(finnhub_api_key),
+        "finnhub_attempted": bool(finnhub_error is not None or provider_used in {"finnhub", "twelvedata", "yahoo"}),
+        "finnhub_error": finnhub_error,
+        "cache_hit": bool(diagnostics.get("cache_hit")),
+        "primary_provider": "finnhub",
+        "primary_error": finnhub_error if provider_used != "finnhub" else None,
+        "fallback_attempted": provider_used != "finnhub",
+        "fallback_provider": "twelvedata",
+        "fallback_error": diagnostics.get("twelvedata_error") if provider_used == "yahoo" else None,
         "final_provider_used": final_provider_used,
-        "request_succeeded": bool(health.get("request_succeeded") or len(candles) > 0),
-        "candles_count": int(health.get("candles_count") or len(candles)),
-        "error": health.get("error"),
+        "request_succeeded": bool(len(candles) > 0),
+        "candles_count": len(candles),
+        "error": payload.get("error"),
         "source_symbol": source_symbol,
-        "symbol": str(symbol).upper().replace("/", "").strip(),
-        "timeframe": str(timeframe or "H1").upper().strip(),
-        "requested_limit": max(1, int(limit or 1)),
+        "symbol": normalized_symbol,
+        "timeframe": normalized_timeframe,
+        "requested_limit": requested_limit,
         "status": payload.get("status"),
-        "meta_provider": meta.get("provider"),
+        "meta_provider": payload.get("provider"),
     }
 
 

--- a/app/services/chart_data_service.py
+++ b/app/services/chart_data_service.py
@@ -11,6 +11,7 @@ from typing import Any
 import requests
 
 from app.core.env import get_twelvedata_api_key
+from app.services.market_service_registry import get_canonical_market_service
 from app.services.yahoo_market_data_service import YahooMarketDataService
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class ChartDataService:
         self.timeout_seconds = float(os.getenv("TWELVEDATA_TIMEOUT", str(DEFAULT_CHART_TIMEOUT_SECONDS)))
         self.output_size = int(os.getenv("TWELVEDATA_OUTPUTSIZE", str(DEFAULT_CHART_LIMIT)))
         self.yahoo_service = YahooMarketDataService()
+        self.canonical_market_service = get_canonical_market_service()
         self._cache_ttl_seconds = max(600.0, float(os.getenv("TWELVEDATA_CHART_CACHE_TTL_SECONDS", "600")))
         self._stale_success_ttl_seconds = max(self._cache_ttl_seconds, float(os.getenv("TWELVEDATA_STALE_CACHE_TTL_SECONDS", "900")))
         self._request_cooldown_seconds = max(
@@ -61,240 +63,67 @@ class ChartDataService:
         }
 
     def get_chart(self, symbol: str, timeframe: str, limit: int | None = None) -> dict[str, Any]:
-        logger.info("chart_request_started symbol=%s tf=%s", symbol, timeframe)
+        return self._get_chart_from_canonical(symbol=symbol, timeframe=timeframe, limit=limit)
 
+    def _get_chart_from_canonical(self, *, symbol: str, timeframe: str, limit: int | None = None) -> dict[str, Any]:
         normalized_symbol = self._normalize_symbol(symbol)
         normalized_tf = self._normalize_timeframe(timeframe)
-        provider_symbol = self._format_twelvedata_symbol(normalized_symbol)
-        provider_interval = TIMEFRAME_MAPPING.get(normalized_tf)
         requested_limit = max(1, min(int(limit or self.output_size), 5000))
-
-        logger.info(
-            "chart_request_mapped requested_symbol=%s requested_tf=%s mapped_symbol=%s mapped_tf=%s provider_symbol=%s provider_interval=%s",
-            symbol,
-            timeframe,
-            normalized_symbol,
-            normalized_tf,
-            provider_symbol,
-            provider_interval,
+        provider_payload = self.canonical_market_service.get_candles(normalized_symbol, normalized_tf, requested_limit)
+        diagnostics = provider_payload.get("diagnostics") if isinstance(provider_payload.get("diagnostics"), dict) else {}
+        raw_candles = provider_payload.get("candles") if isinstance(provider_payload.get("candles"), list) else []
+        candles = self._normalize_candles(raw_candles)
+        provider = str(provider_payload.get("provider") or "none")
+        finnhub_error = diagnostics.get("finnhub_error")
+        twelvedata_error = diagnostics.get("twelvedata_error")
+        final_provider_used = diagnostics.get("final_provider_used") or provider
+        error = provider_payload.get("error")
+        finnhub_attempted = bool(finnhub_error is not None or provider in {"finnhub", "twelvedata", "yahoo"})
+        self._set_market_health(
+            primary_provider="finnhub",
+            primary_error=finnhub_error if provider != "finnhub" else None,
+            fallback_attempted=provider != "finnhub",
+            fallback_provider="twelvedata",
+            fallback_error=twelvedata_error if provider == "yahoo" else None,
+            final_provider_used=final_provider_used,
+            request_succeeded=bool(candles),
+            candles_count=len(candles),
+            error=str(error) if error else None,
+            source_symbol=str(provider_payload.get("source_symbol") or normalized_symbol),
+            provider_used=final_provider_used,
+            cache_hit=bool(diagnostics.get("cache_hit")),
+            cache_age_seconds=None,
+            next_allowed_request_at=None,
         )
-        cache_key = self._cache_key(normalized_symbol, normalized_tf)
-        cached_fresh = self._get_cached_payload(cache_key=cache_key, limit=requested_limit, max_age_seconds=self._cache_ttl_seconds)
-        if cached_fresh is not None:
-            cache_age_seconds = self._cache_age_seconds(cache_key)
-            self._set_market_health(
-                primary_provider="twelvedata",
-                primary_error=None,
-                fallback_attempted=False,
-                fallback_provider="yahoo_finance",
-                fallback_error=None,
-                final_provider_used="twelvedata_cached",
-                request_succeeded=True,
-                candles_count=len(cached_fresh.get("candles") or []),
-                error=None,
-                source_symbol=provider_symbol,
-                provider_used="twelvedata_cached",
-                cache_hit=True,
-                cache_age_seconds=cache_age_seconds,
-                next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
-            )
-            return cached_fresh
+        self._last_market_health["finnhub_configured"] = bool(getattr(self.canonical_market_service.finnhub_provider, "api_key", ""))
+        self._last_market_health["finnhub_attempted"] = finnhub_attempted
+        self._last_market_health["finnhub_error"] = finnhub_error
 
-        if normalized_tf not in TIMEFRAME_MAPPING:
-            logger.warning("twelvedata_failed symbol=%s tf=%s reason=unsupported_timeframe", normalized_symbol, normalized_tf)
-            payload = self.build_unavailable_payload(
+        if not candles:
+            return self.build_unavailable_payload(
                 symbol=normalized_symbol,
                 timeframe=normalized_tf,
-                message_ru="Неподдерживаемый таймфрейм для свечного графика.",
+                message_ru=f"Свечные данные недоступны: {error or diagnostics.get('provider_error') or 'unknown_error'}.",
                 reason="fetch_error",
             )
-            self._set_market_health(
-                primary_provider="twelvedata",
-                primary_error="unsupported_timeframe",
-                fallback_attempted=False,
-                fallback_provider="yahoo_finance",
-                fallback_error=None,
-                final_provider_used="twelvedata",
-                request_succeeded=False,
-                candles_count=0,
-                error="unsupported_timeframe",
-                source_symbol=provider_symbol,
-                provider_used="twelvedata",
-                cache_hit=False,
-                cache_age_seconds=None,
-                next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
-            )
-            return payload
 
-        if not self.api_key:
-            logger.warning("twelvedata_failed symbol=%s tf=%s reason=missing_api_key", normalized_symbol, normalized_tf)
-            return self._fallback_to_yahoo(
-                symbol=normalized_symbol,
-                timeframe=normalized_tf,
-                limit=requested_limit,
-                twelvedata_error="missing_api_key",
-                twelvedata_payload=self.build_unavailable_payload(
-                    symbol=normalized_symbol,
-                    timeframe=normalized_tf,
-                    message_ru="Свечной API не настроен: отсутствует TWELVEDATA_API_KEY.",
-                    reason="fetch_error",
-                ),
-                provider_symbol=provider_symbol,
-                cache_key=cache_key,
-            )
-
-        if not self._is_request_allowed(cache_key):
-            return self._fallback_to_yahoo(
-                symbol=normalized_symbol,
-                timeframe=normalized_tf,
-                limit=requested_limit,
-                twelvedata_error="throttled",
-                twelvedata_payload=self.build_unavailable_payload(
-                    symbol=normalized_symbol,
-                    timeframe=normalized_tf,
-                    message_ru="Запрос к Twelve Data отложен: действует локальный throttling.",
-                    reason="rate_limited",
-                ),
-                provider_symbol=provider_symbol,
-                cache_key=cache_key,
-            )
-
-        params = {
-            "symbol": provider_symbol,
-            "interval": provider_interval,
-            "outputsize": requested_limit,
-            "apikey": self.api_key,
-            "format": "JSON",
-        }
-        logger.info(
-            "twelvedata_chart_request_symbol_sent requested_symbol=%s provider_symbol=%s",
-            normalized_symbol,
-            provider_symbol,
-        )
-
-        try:
-            response = requests.get(self.api_url, params=params, timeout=self.timeout_seconds)
-            response.raise_for_status()
-            payload = response.json()
-        except requests.RequestException as exc:
-            self._set_next_allowed_request(cache_key)
-            logger.warning("twelvedata_failed symbol=%s tf=%s reason=request_exception error=%s", normalized_symbol, normalized_tf, exc)
-            return self._fallback_to_yahoo(
-                symbol=normalized_symbol,
-                timeframe=normalized_tf,
-                limit=requested_limit,
-                twelvedata_error="fetch_error",
-                twelvedata_payload=self.build_unavailable_payload(
-                    symbol=normalized_symbol,
-                    timeframe=normalized_tf,
-                    message_ru="Не удалось загрузить реальные свечные данные из Twelve Data.",
-                    reason="fetch_error",
-                ),
-                provider_symbol=provider_symbol,
-                cache_key=cache_key,
-            )
-        except ValueError:
-            self._set_next_allowed_request(cache_key)
-            logger.warning("twelvedata_failed symbol=%s tf=%s reason=invalid_json", normalized_symbol, normalized_tf)
-            return self._fallback_to_yahoo(
-                symbol=normalized_symbol,
-                timeframe=normalized_tf,
-                limit=requested_limit,
-                twelvedata_error="fetch_error",
-                twelvedata_payload=self.build_unavailable_payload(
-                    symbol=normalized_symbol,
-                    timeframe=normalized_tf,
-                    message_ru="Свечной API вернул некорректный ответ.",
-                    reason="fetch_error",
-                ),
-                provider_symbol=provider_symbol,
-                cache_key=cache_key,
-            )
-
-        payload, candles = self.normalize_provider_payload(payload)
-        provider_status = str(payload.get("status") or "").lower()
-        logger.info(
-            "twelvedata_payload_normalized symbol=%s tf=%s provider_status=%s candle_count=%s keys=%s",
-            normalized_symbol,
-            normalized_tf,
-            provider_status or "unknown",
-            len(candles),
-            sorted(payload.keys()),
-        )
-        if not candles:
-            if provider_status == "error":
-                logger.warning(
-                    "twelvedata_failed symbol=%s tf=%s reason=api_error code=%s message=%s",
-                    normalized_symbol,
-                    normalized_tf,
-                    payload.get("code"),
-                    payload.get("message"),
-                )
-                reason = "rate_limited" if str(payload.get("code")) == "429" else "fetch_error"
-                self._set_next_allowed_request(cache_key)
-                return self._fallback_to_yahoo(
-                    symbol=normalized_symbol,
-                    timeframe=normalized_tf,
-                    limit=requested_limit,
-                    twelvedata_error=reason,
-                    twelvedata_payload=self.build_unavailable_payload(
-                        symbol=normalized_symbol,
-                        timeframe=normalized_tf,
-                        message_ru=f"Twelve Data недоступен: {payload.get('message') or 'неизвестная ошибка'}.",
-                        reason=reason,
-                    ),
-                    provider_symbol=provider_symbol,
-                    cache_key=cache_key,
-                )
-            logger.warning("twelvedata_failed symbol=%s tf=%s reason=empty_candles", normalized_symbol, normalized_tf)
-            self._set_next_allowed_request(cache_key)
-            return self._fallback_to_yahoo(
-                symbol=normalized_symbol,
-                timeframe=normalized_tf,
-                limit=requested_limit,
-                twelvedata_error="no_data",
-                twelvedata_payload=self.build_unavailable_payload(
-                    symbol=normalized_symbol,
-                    timeframe=normalized_tf,
-                    message_ru="Свечной API не вернул candles/values для выбранной идеи.",
-                    reason="no_data",
-                ),
-                provider_symbol=provider_symbol,
-                cache_key=cache_key,
-            )
-
-        logger.info("twelvedata_success symbol=%s tf=%s candles=%s", normalized_symbol, normalized_tf, len(candles))
-        self._set_market_health(
-            primary_provider="twelvedata",
-            primary_error=None,
-            fallback_attempted=False,
-            fallback_provider="yahoo_finance",
-            fallback_error=None,
-            final_provider_used="twelvedata",
-            request_succeeded=True,
-            candles_count=len(candles),
-            error=None,
-            source_symbol=provider_symbol,
-            provider_used="twelvedata",
-            cache_hit=False,
-            cache_age_seconds=0.0,
-            next_allowed_request_at=self._get_next_allowed_request_at(cache_key),
-        )
-        response_payload = {
+        source = "yahoo_finance" if provider == "yahoo" else provider
+        return {
             "symbol": normalized_symbol,
             "timeframe": normalized_tf,
-            "source": "twelvedata",
+            "source": source,
             "status": "ok",
-            "message_ru": None,
+            "message_ru": None if provider != "yahoo" else "Live candles недоступны, использован Yahoo fallback.",
             "candles": candles,
             "meta": {
-                "provider": "Twelve Data",
-                "interval": provider_interval,
-                "outputsize": min(len(candles), requested_limit),
+                "provider": provider.upper(),
+                "outputsize": len(candles),
+                "finnhub_attempted": finnhub_attempted,
+                "finnhub_error": finnhub_error,
+                "twelvedata_error": twelvedata_error,
+                "final_provider_used": final_provider_used,
             },
         }
-        self._store_cached_payload(cache_key=cache_key, payload=response_payload)
-        return response_payload
 
     def get_last_market_health(self) -> dict[str, Any]:
         return dict(self._last_market_health)


### PR DESCRIPTION
### Motivation
- В проде `/api/debug/market-health` показывал старую цепочку с primary_provider=twelvedata, поэтому диагностика не отражала интеграцию Finnhub. 
- Нужно, чтобы и debug-эндпоинт, и API идей использовали один и тот же выбор провайдера и возвращали явные поля для диагностики Finnhub.

### Description
- `ChartDataService.get_chart()` теперь делегирует получение свечей в `CanonicalMarketService.get_candles()` и убран legacy direct TwelveData-only путь из рабочего потока (файл: `app/services/chart_data_service.py`).
- `/api/debug/market-health` теперь вызывает `canonical_market_service.get_candles(...)` и возвращает диагностические поля `app_commit`, `build_version`, `finnhub_configured`, `finnhub_attempted`, `finnhub_error` и `final_provider_used` (файл: `app/main.py`).
- Диагностика и поведение следуют приоритету провайдеров `finnhub -> twelvedata -> yahoo` как в `CanonicalMarketService` и в новых ответах `ChartDataService`/debug.
- `FINNHUB_API_KEY` читается из окружения через `os.getenv("FINNHUB_API_KEY")` в провайдере Finnhub (см. `app/services/market_providers.py`).

### Testing
- Запущены интеграционные тесты `pytest -q tests/api/test_ideas_api.py`, все тесты прошли (`16 passed`).
- Выполнен локальный запрос через `TestClient` к `/api/debug/market-health`, который вернул новые поля (`app_commit`, `build_version`, `finnhub_configured`, `finnhub_attempted`, `finnhub_error`, `final_provider_used`) и подтвердил поведение fallback; запрос вернулся с `200`.
- Изменения сохранены и проверены в кодовой базе, готово к деплою; для подтверждения реального прод-выпуска используйте поле `app_commit` в debug-ответе и сравните с Render deploy logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77df9db08331990f20dffa019459)