### PR TITLE
fix(ideas): синхронизировать SVG-разметку с панорамированием модального графика

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -448,6 +448,7 @@
       activeIdea: null,
       chart: null,
       series: null,
+      overlaySyncCleanup: null,
       currentTf: "M15",
     };
 
@@ -688,6 +689,10 @@
 
     function closeModal() {
       modalBackdrop.classList.remove("open");
+      if (typeof state.overlaySyncCleanup === "function") {
+        state.overlaySyncCleanup();
+        state.overlaySyncCleanup = null;
+      }
       if (state.chart) {
         state.chart.remove();
         state.chart = null;
@@ -701,6 +706,10 @@
       if (!container) return;
 
       if (state.chart) {
+        if (typeof state.overlaySyncCleanup === "function") {
+          state.overlaySyncCleanup();
+          state.overlaySyncCleanup = null;
+        }
         state.chart.remove();
         state.chart = null;
         state.series = null;
@@ -766,9 +775,44 @@
       state.chart = chart;
       state.series = series;
 
-      requestAnimationFrame(() => {
-        addIdeaOverlay(container, chart, series, candles, idea);
-      });
+      const redrawOverlay = () => addIdeaOverlay(container, chart, series, candles, idea);
+
+      state.overlaySyncCleanup = bindOverlayToChart(container, chart, redrawOverlay);
+      requestAnimationFrame(redrawOverlay);
+    }
+
+    function bindOverlayToChart(container, chart, redrawOverlay) {
+      if (!container || !chart || typeof redrawOverlay !== "function") return null;
+
+      let rafId = null;
+      const requestRedraw = () => {
+        if (rafId !== null) cancelAnimationFrame(rafId);
+        rafId = requestAnimationFrame(() => {
+          rafId = null;
+          redrawOverlay();
+        });
+      };
+
+      const handleRangeChange = () => requestRedraw();
+      chart.timeScale().subscribeVisibleLogicalRangeChange(handleRangeChange);
+
+      const handleWindowResize = () => {
+        chart.applyOptions({
+          width: container.clientWidth,
+          height: container.clientHeight,
+        });
+        requestRedraw();
+      };
+      window.addEventListener("resize", handleWindowResize);
+
+      return () => {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId);
+          rafId = null;
+        }
+        chart.timeScale().unsubscribeVisibleLogicalRangeChange(handleRangeChange);
+        window.removeEventListener("resize", handleWindowResize);
+      };
     }
 
     function addCleanTradeLevels(series, idea) {


### PR DESCRIPTION
### Motivation
- В модальном окне идеи SVG-оверлей (OB/FVG/ликвидность/паттерны) отрисовывался только один раз и не двигался вместе с графиком при панорамировании или изменении размера, что приводило к неверной визуализации аналитической разметки.

### Description
- Изменён файл `app/static/ideas.html`: добавлено поле состояния `overlaySyncCleanup` для управления жизненным циклом синхронизации оверлея и корректного cleanup при закрытии модалки или повторном рендере.
- Добавлена функция `bindOverlayToChart(container, chart, redrawOverlay)` которая подписывается на `chart.timeScale().subscribeVisibleLogicalRangeChange(...)` и на `window.resize`, и запускает перерисовку оверлея через `requestAnimationFrame` с простым дебаунсом.
- При инициализации чарта теперь используется `bindOverlayToChart(...)`, вызывается первичная отрисовка через `requestAnimationFrame`, и обеспечивается отмена подписок и ожидающих RAF при закрытии модалки и перед повторной инициализацией чарта.
- Сохранена совместимость с существующими функциями рисования оверлея — `addIdeaOverlay(...)` осталась точкой отрисовки, теперь вызывается из привязки к событиям чарта.

### Testing
- Запуск `pytest -q tests/api/test_ideas_api.py` завершился ошибкой на этапе импорта с сообщением `ImportError: cannot import name 'canonical_market_service' from 'app.main'`, что указывает на проблему окружения/импорта в тестовой среде и не относится к изменению фронтенда; тесты выполнения изменений фронтенда в CI не запускались успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0aec344288331b705c19731d18bf4)