### PR TITLE
Усилить требование причинно‑следственной логики в валидации LLM-описаний

### DIFF
--- a/app/services/idea_narrative_llm.py
+++ b/app/services/idea_narrative_llm.py
@@ -267,6 +267,21 @@ class IdeaNarrativeLLMService:
         if not any(token in joined for token in smart_money_any):
             return False
 
+        cause_effect_any = (
+            "потому что",
+            "из-за",
+            "в результате",
+            "поэтому",
+            "что привело",
+            "следствие",
+            "cause",
+            "effect",
+            "as a result",
+            "therefore",
+        )
+        if not any(token in joined for token in cause_effect_any):
+            return False
+
         if len(str(data.get("idea_thesis") or "")) < 220:
             return False
 
@@ -332,6 +347,8 @@ class IdeaNarrativeLLMService:
             "Не пиши шаблонный текст. Не используй одинаковые фразы для разных инструментов.\n"
             "Описание должно быть как комментарий профессионального трейдера, который смотрит на рынок "
             "глазами крупного игрока.\n\n"
+            "Логика текста должна быть строго причинно-следственной: "
+            "сначала факт/причина, затем реакция рынка, затем ожидаемое следствие и действие.\n\n"
 
             "Обязательно объясни:\n"
             "1. Что сейчас делает цена.\n"

--- a/tests/narrative/test_idea_narrative_llm.py
+++ b/tests/narrative/test_idea_narrative_llm.py
@@ -18,7 +18,11 @@ class _Resp:
 
 def _ok_content() -> str:
     return (
-        '{"headline":"EURUSD H1 long","summary":"Кратко","cause":"После снятия ликвидности причина ясна","confirmation":"Подтверждение",'
+        '{"idea_thesis":"После снятия sell-side ликвидности цена быстро вернулась в dealing range, потому что крупный покупатель защитил discount order block. '
+        'Это привело к локальному BOS вверх и снижению инициативы продавца, поэтому сценарий сместился в continuation, а не в разворот. '
+        'В результате повторный тест зоны рассматривается как рабочий entry только при сохранении реакции и объёма. '
+        'Если реакция ослабеет и структура сломается, сценарий отменяется.",'
+        '"headline":"EURUSD H1 long","summary":"Кратко","cause":"После снятия ликвидности причина ясна","confirmation":"Подтверждение",'
         '"risk":"Риск","invalidation":"Инвалидация","target_logic":"Логика цели",'
         '"update_explanation":"Что изменилось","short_text":"Коротко","full_text":"После sweep ликвидности сформирован BOS, крупный покупатель защищает order block, объём и дельта подтверждают реакцию.",'
         '"unified_narrative":"После sweep ликвидности под минимумом цена вернулась в диапазон, что показывает вход крупного покупателя. BOS подтверждает, что это скорее continuation после реакции, а не разворот. В зоне order block идёт набор позиции и защита уровня. Объём и дельта подтверждают импульс, дивергенция продавцов не усиливается. При сломе структуры сценарий отменяется.",'
@@ -86,6 +90,37 @@ def test_rejects_banned_phrase_and_retries(monkeypatch) -> None:
         '"risk":"Риск","invalidation":"Инвалидация","target_logic":"Логика цели",'
         '"update_explanation":"Что изменилось","short_text":"Коротко","full_text":"Сценарий строится вокруг зоны входа.",'
         '"unified_narrative":"Сценарий строится вокруг зоны входа.",'
+        '"summary_structured":{"signal":"BUY","situation":"Рынок у зоны","cause":"Причина","effect":"Эффект","action":"Действие","risk_note":"Риск"},'
+        '"trade_plan_structured":{"entry_trigger":"Триггер","entry_zone":"Зона","stop_loss":"SL","take_profit":"TP","invalidation":"Инвалидация"},'
+        '"market_structure_structured":{"bias":"бычий","structure":"структура","liquidity":"ликвидность","zone":"зона","confluence":"конфлюенс"}}'
+    )
+
+    def _post(*args, **kwargs):
+        calls["n"] += 1
+        content = invalid if calls["n"] == 1 else _ok_content()
+        return _Resp({"choices": [{"message": {"content": content}}]})
+
+    monkeypatch.setattr("requests.post", _post)
+    result = service.generate(event_type="idea_updated", facts={"symbol": "EURUSD"})
+
+    assert calls["n"] == 2
+    assert result.source == "llm"
+
+
+def test_rejects_missing_cause_effect_chain_and_retries(monkeypatch) -> None:
+    service = IdeaNarrativeLLMService()
+    service.api_key = "test"
+    calls = {"n": 0}
+
+    invalid = (
+        '{"headline":"EURUSD H1 long","summary":"Кратко","cause":"Причина","confirmation":"Подтверждение",'
+        '"risk":"Риск","invalidation":"Инвалидация","target_logic":"Логика цели","update_explanation":"Что изменилось",'
+        '"idea_thesis":"Крупный игрок отмечен в стакане, ликвидность снята, сформирован BOS и удерживается order block. '
+        'Сценарий описан для зоны спроса и импульса в continuation. Триггер подтверждается структурой, риск ограничен уровнем отмены. '
+        'Логика входа и цели построена по SMC-модели без лишних допущений.",'
+        '"short_text":"Коротко","full_text":"Крупный игрок защищает order block после sweep, виден BOS и контроль ликвидности.",'
+        '"unified_narrative":"Крупный участник защищает order block после sweep ликвидности, в структуре есть BOS и контроль зоны discount. '
+        'Импульс подтверждён и сценарий остаётся в continuation, пока зона не потеряна.",'
         '"summary_structured":{"signal":"BUY","situation":"Рынок у зоны","cause":"Причина","effect":"Эффект","action":"Действие","risk_note":"Риск"},'
         '"trade_plan_structured":{"entry_trigger":"Триггер","entry_zone":"Зона","stop_loss":"SL","take_profit":"TP","invalidation":"Инвалидация"},'
         '"market_structure_structured":{"bias":"бычий","structure":"структура","liquidity":"ликвидность","zone":"зона","confluence":"конфлюенс"}}'


### PR DESCRIPTION
### Motivation
- Сделать валидацию ответов Grok/OpenRouter строже, чтобы сайт лишь контролировал результат LLM и не публиковал шаблонные или неполные описания; ключевое требование — причинно‑следственная логика (причина → реакция рынка → следствие → действие).

### Description
- В `app/services/idea_narrative_llm.py` добавлена проверка наличия явных причинно‑следственных маркеров (например, "потому что", "в результате", "therefore") в `_quality_ok` перед признанием результата годным.
- В prompt для LLM (`_build_prompt`) уточнено требование строить текст в виде причинно‑следственной цепочки и сохранён акцент на взгляде крупного игрока.
- Обновлены тесты в `tests/narrative/test_idea_narrative_llm.py`: `ok`-фикстура теперь содержит поле `idea_thesis` с причинно‑следственным текстом и добавлен тест, который проверяет отклонение ответа без явной причинно‑следственной логики и успешный retry.

### Testing
- Запущено `pytest -q tests/narrative/test_idea_narrative_llm.py` и все тесты прошли (`5 passed`).
- Попытка запустить смежный тест `pytest -q tests/test_idea_update.py::test_build_narrative_facts_contains_smc_contract` была затруднена из‑за уже существующей синтаксической ошибки в проекте (`app/services/chart_snapshot_service.py` содержит `from **future** import annotations`), поэтому он не был выполнен в рамках этого изменения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ba003a5883319cfebb965dad6d82)