### PR TITLE
Добавить страницу новостей и `GET /api/news` с фундаментальными объяснениями

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.services.htf_context_filter import HtfContextFilter
+from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 
 
@@ -114,6 +115,19 @@ def api_archive():
 @app.get("/api/stats")
 def api_stats():
     return build_stats()
+
+
+@app.get("/api/news")
+def api_news(limit: int = 12):
+    safe_limit = min(max(limit, 1), 30)
+    try:
+        return fetch_public_news(limit=safe_limit)
+    except Exception:
+        return {
+            "items": [],
+            "updated_at_utc": now_utc(),
+            "warning": "Новости временно недоступны. Источники не ответили.",
+        }
 
 
 @app.get("/api/live-price/{symbol}")

--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
+from time import time
+from typing import Any
 
+import feedparser
+import requests
 from app.schemas.contracts import NewsIngestRequest, NewsItemResponse, NewsListResponse
 from app.services.storage.json_storage import JsonStorage
 from backend.news_provider import MarketNewsProvider
@@ -196,3 +200,132 @@ class NewsService:
     @staticmethod
     def _digest(value: str) -> str:
         return sha1(value.encode("utf-8")).hexdigest()[:12]
+
+
+RSS_TIMEOUT_SECONDS = 8
+NEWS_CACHE: dict[str, Any] = {
+    "updated_at": None,
+    "payload": None,
+}
+NEWS_CACHE_TTL_SECONDS = 900
+PUBLIC_RSS_SOURCES = [
+    {"name": "Reuters Markets", "url": "https://www.reutersagency.com/feed/?taxonomy=best-sectors&post_type=best"},
+    {"name": "CNBC Markets", "url": "https://www.cnbc.com/id/100003114/device/rss/rss.html"},
+    {"name": "MarketWatch", "url": "https://feeds.content.dowjones.io/public/rss/mw_marketpulse"},
+    {"name": "Yahoo Finance", "url": "https://finance.yahoo.com/news/rssindex"},
+    {"name": "FXStreet", "url": "https://www.fxstreet.com/rss/news"},
+    {"name": "Investing.com", "url": "https://www.investing.com/rss/news_285.rss"},
+]
+
+
+def build_market_explanation(title: str, summary: str) -> dict[str, Any]:
+    text = f"{title} {summary}".lower()
+
+    markets: list[str] = []
+    tone = "neutral"
+    impact_parts: list[str] = []
+
+    if any(x in text for x in ["fed", "federal reserve", "powell", "rate", "inflation", "cpi", "pce", "fomc"]):
+        markets += ["USD", "XAUUSD", "EURUSD", "GBPUSD"]
+        tone = "hawkish" if any(x in text for x in ["higher", "hot", "sticky", "above forecast"]) else "neutral"
+        impact_parts.append("Фокус на ставках ФРС: доллар может реагировать сильнее остальных валют, а золото — нервничать.")
+
+    if any(x in text for x in ["risk", "stocks", "equities", "nasdaq", "s&p", "wall street"]):
+        markets += ["USD", "XAUUSD"]
+        if tone == "neutral":
+            tone = "risk_off" if any(x in text for x in ["selloff", "drop", "fall", "fear"]) else "risk_on"
+        impact_parts.append("Риск-сентимент влияет на спрос на доллар и золото.")
+
+    if any(x in text for x in ["oil", "brent", "crude", "energy"]):
+        markets += ["USD", "XAUUSD"]
+        impact_parts.append("Нефть влияет на инфляционные ожидания, а значит — на ожидания по ставкам.")
+
+    if any(x in text for x in ["ecb", "euro", "eurozone", "lagarde"]):
+        markets += ["EURUSD"]
+        tone = "dovish" if any(x in text for x in ["cut", "slowdown", "weak"]) else tone
+        impact_parts.append("Новости по ЕЦБ могут двигать EURUSD.")
+
+    if any(x in text for x in ["boe", "pound", "sterling", "uk", "bank of england"]):
+        markets += ["GBPUSD"]
+        impact_parts.append("Новости по Банку Англии и Британии важны для GBPUSD.")
+
+    markets = list(dict.fromkeys(markets)) or ["USD", "EURUSD", "GBPUSD", "XAUUSD"]
+
+    impact = " ".join(impact_parts) or "Новость формирует общий фундаментальный фон: рынок оценивает ставки, инфляцию и аппетит к риску."
+
+    summary_ru = (
+        "Что случилось: "
+        + title.strip()
+        + "\n\n"
+        + "Почему это важно: эта новость может повлиять на ожидания по ставкам, доллар, золото и общий аппетит к риску. "
+        + "Рынок, как обычно, сначала пугается, потом делает вид, что всё было очевидно.\n\n"
+        + "К чему может привести: "
+        + impact
+    )
+
+    return {
+        "summary": summary_ru,
+        "impact": impact,
+        "markets": markets,
+        "tone": tone,
+    }
+
+
+def fetch_public_news(limit: int = 12) -> dict[str, Any]:
+    now_utc = datetime.now(timezone.utc)
+    now_ts = time()
+    cached_at = NEWS_CACHE.get("updated_at")
+    cached_payload = NEWS_CACHE.get("payload")
+
+    if isinstance(cached_at, float) and cached_payload and now_ts - cached_at < NEWS_CACHE_TTL_SECONDS:
+        return cached_payload
+
+    items: list[dict[str, Any]] = []
+    failed_sources = 0
+
+    for source in PUBLIC_RSS_SOURCES:
+        try:
+            response = requests.get(source["url"], timeout=RSS_TIMEOUT_SECONDS, headers={"User-Agent": "Mozilla/5.0"})
+            response.raise_for_status()
+            feed = feedparser.parse(response.content)
+            entries = getattr(feed, "entries", [])[: max(limit, 12)]
+            for entry in entries:
+                title = str(entry.get("title") or "Новость без заголовка").strip()
+                summary = str(entry.get("summary") or entry.get("description") or "").strip()
+                enriched = build_market_explanation(title=title, summary=summary)
+                published_raw = entry.get("published") or entry.get("updated") or now_utc.isoformat()
+                items.append(
+                    {
+                        "title": title,
+                        "source": source["name"],
+                        "url": entry.get("link"),
+                        "published_at": str(published_raw),
+                        "summary": enriched["summary"],
+                        "impact": enriched["impact"],
+                        "markets": enriched["markets"],
+                        "tone": enriched["tone"],
+                    }
+                )
+        except Exception:
+            failed_sources += 1
+            continue
+
+    deduped: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items:
+        key = f'{item.get("title", "")}|{item.get("url", "")}'
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+
+    payload: dict[str, Any] = {
+        "items": deduped[:limit],
+        "updated_at_utc": now_utc.isoformat(),
+    }
+    if failed_sources == len(PUBLIC_RSS_SOURCES):
+        payload["warning"] = "Новости временно недоступны. Источники не ответили."
+
+    NEWS_CACHE["updated_at"] = now_ts
+    NEWS_CACHE["payload"] = payload
+    return payload

--- a/app/static/news.html
+++ b/app/static/news.html
@@ -31,14 +31,14 @@
           <div class="panel-heading compact news-panel__heading">
             <div>
               <p class="section-kicker">Поток новостей</p>
-              <h2>Интеллектуальная лента новостей</h2>
+              <h2>Фундаментальные новости простым языком</h2>
               <p class="section-text">
-                Лента показывает ограниченное число самых свежих новостей в более компактном формате, чтобы быстрее оценивать фон рынка.
+                Объясняем, что произошло, почему это важно и как это может повлиять на USD, золото и риск-сентимент.
               </p>
             </div>
             <div class="news-panel__meta">
               <span class="panel-meta" id="newsUpdatedAt">Обновление: —</span>
-              <span class="panel-meta">На странице отображаются только последние 12 новостей</span>
+              <button class="news-link-button" id="refreshNewsButton" type="button">Обновить</button>
             </div>
           </div>
           <div class="news-list" id="newsList"></div>
@@ -46,6 +46,105 @@
       </main>
     </div>
 
-    <script src="/static/script.js"></script>
+    <script>
+      const newsList = document.getElementById("newsList");
+      const newsUpdatedAt = document.getElementById("newsUpdatedAt");
+      const refreshButton = document.getElementById("refreshNewsButton");
+
+      function escapeHtml(value) {
+        return String(value || "")
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
+
+      function formatDate(value) {
+        if (!value) return "—";
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return value;
+        return date.toLocaleString("ru-RU", { timeZone: "UTC" }) + " UTC";
+      }
+
+      function buildMarkets(markets) {
+        const list = Array.isArray(markets) ? markets : [];
+        if (!list.length) return '<span class="news-chip news-chip--muted">Нет меток</span>';
+        return list.map((item) => `<span class="news-chip">${escapeHtml(item)}</span>`).join("");
+      }
+
+      function renderState(title, text) {
+        newsList.innerHTML = `
+          <article class="news-card news-card--empty">
+            <p class="news-card__title">${escapeHtml(title)}</p>
+            <p class="news-card__text">${escapeHtml(text)}</p>
+          </article>
+        `;
+      }
+
+      function renderNews(payload) {
+        const items = Array.isArray(payload?.items) ? payload.items : [];
+        newsUpdatedAt.textContent = `Обновление: ${formatDate(payload?.updated_at_utc)}`;
+
+        if (!items.length) {
+          renderState(
+            "Свежих новостей пока нет",
+            payload?.warning || "Источники молчат. Рынок, похоже, делает глубокий вдох перед новым движением."
+          );
+          return;
+        }
+
+        newsList.innerHTML = "";
+        items.forEach((item) => {
+          const card = document.createElement("article");
+          card.className = "news-card";
+          card.innerHTML = `
+            <div class="news-card__header news-card__header--stacked">
+              <p class="news-card__eyebrow">${escapeHtml(item.source || "Источник")}</p>
+              <h3 class="news-card__title">${escapeHtml(item.title || "Новость без заголовка")}</h3>
+              <div class="news-chip-row">
+                <span class="news-chip">${escapeHtml(item.tone || "neutral")}</span>
+                <span class="news-chip">${formatDate(item.published_at)}</span>
+              </div>
+            </div>
+            <section class="news-detail-box">
+              <h4>Разбор</h4>
+              <p class="news-card__text">${escapeHtml(item.summary || "Описание недоступно.").replace(/\n/g, "<br/>")}</p>
+            </section>
+            <section class="news-detail-box news-detail-box--impact">
+              <h4>Рыночный эффект</h4>
+              <p class="news-card__text">${escapeHtml(item.impact || "Фон нейтральный.")}</p>
+            </section>
+            <div class="news-card__assets">
+              <span class="news-label">Рынки под прицелом</span>
+              <div class="news-chip-row">${buildMarkets(item.markets)}</div>
+            </div>
+            <div class="news-card__footer">
+              ${
+                item.url
+                  ? `<a class="news-link-button" href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer">Читать источник</a>`
+                  : '<span class="news-link-button news-link-button--disabled">Ссылка недоступна</span>'
+              }
+            </div>
+          `;
+          newsList.appendChild(card);
+        });
+      }
+
+      async function loadNews() {
+        renderState("Загрузка...", "Собираем новости из открытых RSS-источников.");
+        try {
+          const response = await fetch("/api/news", { cache: "no-store" });
+          const payload = await response.json();
+          renderNews(payload);
+        } catch (error) {
+          newsUpdatedAt.textContent = "Обновление: ошибка загрузки";
+          renderState("Новости временно недоступны", "Не удалось получить данные. Попробуйте обновить позже.");
+        }
+      }
+
+      refreshButton.addEventListener("click", loadNews);
+      loadNews();
+    </script>
   </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ scikit-learn==1.5.2
 ta==0.11.0
 python-dotenv==1.0.1
 websocket-client==1.8.0
+feedparser==6.0.11


### PR DESCRIPTION
### Motivation
- Добавить страницу "Новости" с краткими объяснениями важных рыночных событий в понятной, лёгкой Grok-like подаче на русском языке и обеспечить доступ к ним через стабильный backend-эндпоинт.
- Собрать новости из нескольких публичных RSS-источников и не допустить падения API при недоступности внешних фидов.

### Description
- Добавлен backend-эндпоинт `GET /api/news` в `app/main.py`, который вызывает `fetch_public_news(limit)` и возвращает безопасный fallback при ошибках.
- Реализована функция `fetch_public_news` и вспомогательная логика в `app/services/news_service.py` включая публичные RSS-источники, in-memory кэш `NEWS_CACHE` с TTL и детерминированную функцию `build_market_explanation(...)` для генерации объяснений/оценок влияния на рынки (USD, золото, пары и риск-сентимент).
- Обновлена фронтенд-страница `app/static/news.html` для загрузки `/api/news`, рендеринга карточек с заголовком, источником, датой, `tone`, списком рынков, объяснением и ссылкой на источник, а также добавлена кнопка «Обновить» и дружелюбные состояния загрузки/ошибки.
- Добавлена зависимость `feedparser==6.0.11` в `requirements.txt` и использованы только серверные запросы к внешним фидам (без ключей в фронтенде).

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile app/main.py app/services/news_service.py` — успешно.
- Установлена зависимость `feedparser` и выполнён локальный smoke-тест `from app.services.news_service import fetch_public_news; fetch_public_news(limit=3)` для проверки структуры ответа — успешно и вернул ожидаемую структуру (`items`, `updated_at_utc`).
- Попытка UI smoke-теста через Selenium для снятия скриншота не прошла из-за отсутствия Chrome/Chromium в окружении (ограничение среды), но фронтенд-логика проверялась вручную через скрипт загрузки JSON и обработку ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bff33cf48331a733d5c25d3120a7)