### PR TITLE
Автоактивация top-nav через новый `nav.js`

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -18,7 +18,7 @@
           <a href="/">Главная</a>
           <a href="/ideas">Идеи</a>
           <a href="/news">Новости</a>
-          <a class="is-active" href="/calendar">Календарь</a>
+          <a href="/calendar">Календарь</a>
           <a href="/heatmap/page">Тепловая карта</a>
         </nav>
       </header>
@@ -51,5 +51,6 @@
     </div>
 
     <script src="/static/script.js"></script>
+    <script src="/static/nav.js"></script>
   </body>
 </html>

--- a/app/static/heatmap.html
+++ b/app/static/heatmap.html
@@ -19,7 +19,7 @@
           <a href="/ideas">Идеи</a>
           <a href="/news">Новости</a>
           <a href="/calendar">Календарь</a>
-          <a class="is-active" href="/heatmap/page">Тепловая карта</a>
+          <a href="/heatmap/page">Тепловая карта</a>
         </nav>
       </header>
 
@@ -37,5 +37,6 @@
     </div>
 
     <script src="/static/script.js"></script>
+    <script src="/static/nav.js"></script>
   </body>
 </html>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -18,7 +18,7 @@
           </p>
         </div>
         <nav class="top-nav">
-          <a class="is-active" href="/">Главная</a>
+          <a href="/">Главная</a>
           <a href="/ideas">Идеи</a>
           <a href="/news">Новости</a>
           <a href="/calendar">Календарь</a>
@@ -71,5 +71,6 @@
     </div>
 
     <script src="/static/landing.js"></script>
+    <script src="/static/nav.js"></script>
   </body>
 </html>

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -1,0 +1,18 @@
+(function activateTopNav() {
+  const nav = document.querySelector('.top-nav');
+  if (!nav) return;
+
+  const currentPath = window.location.pathname.replace(/\/+$/, '') || '/';
+  const normalize = (path) => (path || '/').replace(/\/+$/, '') || '/';
+
+  nav.querySelectorAll('a[href]').forEach((link) => {
+    const linkPath = normalize(link.getAttribute('href'));
+    const isActive = linkPath === currentPath;
+    link.classList.toggle('is-active', isActive);
+    if (isActive) {
+      link.setAttribute('aria-current', 'page');
+    } else {
+      link.removeAttribute('aria-current');
+    }
+  });
+})();

--- a/app/static/news.html
+++ b/app/static/news.html
@@ -20,7 +20,7 @@
         <nav class="top-nav">
           <a href="/">Главная</a>
           <a href="/ideas">Идеи</a>
-          <a class="is-active" href="/news">Новости</a>
+          <a href="/news">Новости</a>
           <a href="/calendar">Календарь</a>
           <a href="/heatmap/page">Тепловая карта</a>
         </nav>
@@ -146,5 +146,6 @@
       refreshButton.addEventListener("click", loadNews);
       loadNews();
     </script>
+    <script src="/static/nav.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Уменьшить вероятность merge-конфликтов при параллельных правках страниц путём удаления ручной установки `class="is-active"` в каждом HTML-файле и централизовать логику подсветки активной ссылки.

### Description
- Убран ручной `class="is-active"` из навигации в `app/static/index.html`, `app/static/news.html`, `app/static/calendar.html` и `app/static/heatmap.html`.
- Добавлен новый скрипт `app/static/nav.js`, который по `window.location.pathname` нормализует пути и автоматически добавляет/удаляет `is-active` и `aria-current` для ссылок навигации.
- Подключено `<script src="/static/nav.js"></script>` на всех перечисленных страницах, чтобы поведение было единообразным и не требовало ручных изменений в HTML.
- Изменения ограничены статическими файлами интерфейса и не меняют API-контракты или серверную логику.

### Testing
- Запущен `pytest -q`, сбор тестов прерван на этапе collection из-за отсутствующей зависимости `feedparser` и существующей синтаксической ошибки в `app/services/chart_snapshot_service.py`, поэтому автоматические тесты не завершились успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c8900e98833183c9150221e954e8)