### PR TITLE
Enhance news cards with images and richer explanations safely

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import html
+import re
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
 from time import time
@@ -218,6 +220,118 @@ PUBLIC_RSS_SOURCES = [
 ]
 
 
+def strip_html(value: str) -> str:
+    decoded = html.unescape(str(value or ""))
+    without_script = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", decoded, flags=re.IGNORECASE | re.DOTALL)
+    without_tags = re.sub(r"<[^>]+>", " ", without_script)
+    normalized = re.sub(r"\s+", " ", without_tags).strip()
+    return normalized
+
+
+def extract_news_image(entry: dict) -> str | None:
+    def _pick_url(value: Any) -> str | None:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    media_content = entry.get("media_content") or []
+    if isinstance(media_content, list):
+        for item in media_content:
+            if isinstance(item, dict):
+                candidate = _pick_url(item.get("url"))
+                if candidate:
+                    return candidate
+
+    media_thumbnail = entry.get("media_thumbnail") or []
+    if isinstance(media_thumbnail, list):
+        for item in media_thumbnail:
+            if isinstance(item, dict):
+                candidate = _pick_url(item.get("url"))
+                if candidate:
+                    return candidate
+
+    for key in ("links", "enclosures"):
+        rows = entry.get(key) or []
+        if isinstance(rows, list):
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                mime = str(row.get("type") or row.get("title") or "").lower()
+                href = _pick_url(row.get("href") or row.get("url"))
+                if href and ("image/" in mime or any(href.lower().endswith(ext) for ext in [".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg"])):
+                    return href
+
+    summary_html = str(entry.get("summary") or entry.get("description") or "")
+    image_match = re.search(r'<img[^>]+src=["\']([^"\']+)["\']', summary_html, flags=re.IGNORECASE)
+    if image_match:
+        return image_match.group(1).strip()
+    return None
+
+
+def pick_fallback_news_image(title: str, summary: str, markets: list[str]) -> str:
+    text = f"{title} {summary} {' '.join(markets)}".lower()
+
+    if "xau" in text or "gold" in text or "золото" in text:
+        return "/static/news-placeholders/gold.svg"
+    if "oil" in text or "brent" in text or "energy" in text or "нефть" in text:
+        return "/static/news-placeholders/energy.svg"
+    if "stocks" in text or "nasdaq" in text or "s&p" in text or "equities" in text or "акции" in text:
+        return "/static/news-placeholders/stocks.svg"
+    if "usd" in text or "fed" in text or "dollar" in text or "фрс" in text or "доллар" in text:
+        return "/static/news-placeholders/usd.svg"
+
+    return "/static/news-placeholders/default.svg"
+
+
+def build_long_news_story(title: str, source_summary: str, markets: list[str], tone: str) -> dict[str, str]:
+    clean_title = strip_html(title).strip()
+    clean_summary = strip_html(source_summary).strip()
+
+    what_happened = (
+        f"Что случилось: {clean_title}. "
+        f"{clean_summary[:450] if clean_summary else 'Источник сообщил о событии, которое рынок может учитывать в текущем фундаментальном фоне.'}"
+    )
+
+    why_it_matters = (
+        "Почему это важно: такие новости влияют на ожидания по ставкам, инфляции, доллару, золоту и аппетиту к риску. "
+        "Рынок обычно сначала делает резкое лицо, потом открывает календарь, потом вспоминает про ФРС."
+    )
+
+    markets_text = ", ".join(markets or ["USD", "EURUSD", "GBPUSD", "XAUUSD"])
+
+    what_next = (
+        f"К чему может привести: в фокусе {markets_text}. "
+        "Если новость усиливает ожидания жёсткой политики центробанков, доллар может получить поддержку, "
+        "а золото и риск-активы — давление. Если фон мягче, рынок может снова включить режим «риск-он»."
+    )
+
+    humor = (
+        "Комментарий в популярном стиле и с лёгким юмором: рынок сейчас как трейдер перед NFP — уверенно кивает, "
+        "но держит палец рядом с кнопкой закрытия позиции."
+    )
+
+    if tone == "dovish":
+        humor = (
+            "Комментарий в популярном стиле и с лёгким юмором: рынок услышал более мягкий тон и будто снял галстук, "
+            "но терминал всё равно не закрывает."
+        )
+    elif tone in {"hawkish", "risk_off"}:
+        humor = (
+            "Комментарий в популярном стиле и с лёгким юмором: при жёстком фоне рынок становится серьёзным, "
+            "как чат трейдеров за минуту до публикации CPI."
+        )
+
+    long_story = f"{what_happened}\n\n{why_it_matters}\n\n{what_next}\n\n{humor}"
+
+    return {
+        "what_happened_ru": what_happened,
+        "why_it_matters_ru": why_it_matters,
+        "what_next_ru": what_next,
+        "grok_style_comment_ru": humor,
+        "long_story_ru": long_story,
+    }
+
+
 def build_market_explanation(title: str, summary: str) -> dict[str, Any]:
     text = f"{title} {summary}".lower()
 
@@ -255,12 +369,9 @@ def build_market_explanation(title: str, summary: str) -> dict[str, Any]:
 
     summary_ru = (
         "Что случилось: "
-        + title.strip()
-        + "\n\n"
-        + "Почему это важно: эта новость может повлиять на ожидания по ставкам, доллар, золото и общий аппетит к риску. "
-        + "Рынок, как обычно, сначала пугается, потом делает вид, что всё было очевидно.\n\n"
-        + "К чему может привести: "
-        + impact
+        + strip_html(title).strip()
+        + ". "
+        + (strip_html(summary).strip()[:260] if summary else "Источник опубликовал обновление по рынку.")
     )
 
     return {
@@ -290,10 +401,31 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
             feed = feedparser.parse(response.content)
             entries = getattr(feed, "entries", [])[: max(limit, 12)]
             for entry in entries:
-                title = str(entry.get("title") or "Новость без заголовка").strip()
-                summary = str(entry.get("summary") or entry.get("description") or "").strip()
-                enriched = build_market_explanation(title=title, summary=summary)
-                published_raw = entry.get("published") or entry.get("updated") or now_utc.isoformat()
+                try:
+                    title = str(entry.get("title") or "Новость без заголовка").strip()
+                    summary = str(entry.get("summary") or entry.get("description") or "").strip()
+                    enriched = build_market_explanation(title=title, summary=summary)
+                    published_raw = entry.get("published") or entry.get("updated") or now_utc.isoformat()
+                    image_url = extract_news_image(entry)
+                    fallback_image = pick_fallback_news_image(title=title, summary=summary, markets=enriched["markets"])
+                    safe_image_url = image_url or fallback_image
+                    image_alt = f"{strip_html(title)[:110] or 'Иллюстрация новости'} — иллюстрация новости"
+                    story = build_long_news_story(title=title, source_summary=summary, markets=enriched["markets"], tone=enriched["tone"])
+                except Exception:
+                    title = str(entry.get("title") or "Новость без заголовка").strip()
+                    summary = str(entry.get("summary") or entry.get("description") or "").strip()
+                    published_raw = entry.get("published") or entry.get("updated") or now_utc.isoformat()
+                    enriched = build_market_explanation(title=title, summary=summary)
+                    safe_image_url = pick_fallback_news_image(title=title, summary=summary, markets=enriched["markets"])
+                    image_alt = "Иллюстрация новости"
+                    basic_summary = strip_html(summary)[:350] or "Источник сообщил о событии, детали уточняются."
+                    story = {
+                        "what_happened_ru": f"Что случилось: {strip_html(title)}. {basic_summary}",
+                        "why_it_matters_ru": "Почему это важно: рынок пересматривает ожидания по ставкам и риску.",
+                        "what_next_ru": f"К чему может привести: внимание на {', '.join(enriched['markets'])}.",
+                        "grok_style_comment_ru": "Комментарий в популярном стиле и с лёгким юмором: волатильность любит внезапные сюжеты.",
+                        "long_story_ru": f"Что случилось: {strip_html(title)}. {basic_summary}",
+                    }
                 items.append(
                     {
                         "title": title,
@@ -304,6 +436,13 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                         "impact": enriched["impact"],
                         "markets": enriched["markets"],
                         "tone": enriched["tone"],
+                        "image_url": safe_image_url,
+                        "image_alt": image_alt,
+                        "what_happened_ru": story["what_happened_ru"],
+                        "why_it_matters_ru": story["why_it_matters_ru"],
+                        "what_next_ru": story["what_next_ru"],
+                        "grok_style_comment_ru": story["grok_style_comment_ru"],
+                        "long_story_ru": story["long_story_ru"],
                     }
                 )
         except Exception:

--- a/app/static/news-placeholders/default.svg
+++ b/app/static/news-placeholders/default.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Market Pulse">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#061224"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <circle cx="220" cy="170" r="140" fill="#ffd84d" fill-opacity="0.2"/>
+  <circle cx="980" cy="150" r="120" fill="#45caff" fill-opacity="0.22"/>
+  <text x="72" y="560" fill="#ffffff" font-family="Inter,Arial,sans-serif" font-size="84" font-weight="800">Market Pulse</text>
+</svg>

--- a/app/static/news-placeholders/energy.svg
+++ b/app/static/news-placeholders/energy.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Энергия и нефть">
+  <defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#ef4444"/><stop offset="100%" stop-color="#1f2937"/></linearGradient></defs>
+  <rect width="1200" height="675" fill="url(#g)"/>
+  <text x="72" y="300" fill="#fee2e2" font-family="Inter,Arial,sans-serif" font-size="70" font-weight="800">ENERGY / OIL</text>
+  <text x="72" y="395" fill="#fca5a5" font-family="Inter,Arial,sans-serif" font-size="40">Нефть, инфляция и волатильность</text>
+</svg>

--- a/app/static/news-placeholders/gold.svg
+++ b/app/static/news-placeholders/gold.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Золото">
+  <defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#111827"/></linearGradient></defs>
+  <rect width="1200" height="675" fill="url(#g)"/>
+  <text x="72" y="300" fill="#fff7d6" font-family="Inter,Arial,sans-serif" font-size="72" font-weight="800">XAU / GOLD</text>
+  <text x="72" y="395" fill="#fde68a" font-family="Inter,Arial,sans-serif" font-size="40">Золото и защитные активы</text>
+</svg>

--- a/app/static/news-placeholders/stocks.svg
+++ b/app/static/news-placeholders/stocks.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Акции">
+  <defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#22c55e"/><stop offset="100%" stop-color="#052e16"/></linearGradient></defs>
+  <rect width="1200" height="675" fill="url(#g)"/>
+  <text x="72" y="300" fill="#dcfce7" font-family="Inter,Arial,sans-serif" font-size="70" font-weight="800">STOCK MARKET</text>
+  <text x="72" y="395" fill="#86efac" font-family="Inter,Arial,sans-serif" font-size="40">Индексы, риск-он и риск-офф</text>
+</svg>

--- a/app/static/news-placeholders/usd.svg
+++ b/app/static/news-placeholders/usd.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="USD и ФРС">
+  <defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#0ea5e9"/><stop offset="100%" stop-color="#0f172a"/></linearGradient></defs>
+  <rect width="1200" height="675" fill="url(#g)"/>
+  <text x="72" y="300" fill="#e2e8f0" font-family="Inter,Arial,sans-serif" font-size="70" font-weight="800">USD / FED WATCH</text>
+  <text x="72" y="400" fill="#93c5fd" font-family="Inter,Arial,sans-serif" font-size="40">Ставки, инфляция и доллар</text>
+</svg>

--- a/app/static/news.html
+++ b/app/static/news.html
@@ -98,7 +98,16 @@
         items.forEach((item) => {
           const card = document.createElement("article");
           card.className = "news-card";
+          const longStory = item.long_story_ru || item.summary || "Описание недоступно.";
           card.innerHTML = `
+            <div class="news-card__image-wrap news-image-wrap">
+              <img
+                src="${escapeHtml(item.image_url || "")}"
+                alt="${escapeHtml(item.image_alt || item.title || "Иллюстрация новости")}"
+                loading="lazy"
+                onerror="this.closest('.news-image-wrap').classList.add('is-fallback'); this.remove();"
+              />
+            </div>
             <div class="news-card__header news-card__header--stacked">
               <p class="news-card__eyebrow">${escapeHtml(item.source || "Источник")}</p>
               <h3 class="news-card__title">${escapeHtml(item.title || "Новость без заголовка")}</h3>
@@ -108,8 +117,12 @@
               </div>
             </div>
             <section class="news-detail-box">
-              <h4>Разбор</h4>
-              <p class="news-card__text">${escapeHtml(item.summary || "Описание недоступно.").replace(/\n/g, "<br/>")}</p>
+              <h4>Коротко</h4>
+              <p class="news-card__text">${escapeHtml(item.summary || "Описание недоступно.")}</p>
+            </section>
+            <section class="news-detail-box">
+              <h4>Подробно (в популярном стиле, с лёгким юмором)</h4>
+              <p class="news-card__story">${escapeHtml(longStory)}</p>
             </section>
             <section class="news-detail-box news-detail-box--impact">
               <h4>Рыночный эффект</h4>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1057,6 +1057,48 @@ a { color: inherit; }
   flex: 1 1 240px;
 }
 
+.news-card__image-wrap,
+.news-image-wrap {
+  position: relative;
+  overflow: hidden;
+  min-height: 210px;
+  border-radius: 20px;
+  margin-bottom: 16px;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255,216,77,.35), transparent 30%),
+    radial-gradient(circle at 85% 15%, rgba(69,202,255,.32), transparent 34%),
+    linear-gradient(135deg, rgba(124,60,255,.95), rgba(6,18,36,.98));
+  border: 1px solid rgba(255,255,255,.16);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 18px 45px rgba(0,0,0,.28);
+}
+
+.news-card__image-wrap img,
+.news-image-wrap img {
+  width: 100%;
+  height: 240px;
+  object-fit: cover;
+  display: block;
+}
+
+.news-card__image-wrap.is-fallback::after,
+.news-image-wrap.is-fallback::after {
+  content: "Market Pulse";
+  position: absolute;
+  inset: auto 18px 18px 18px;
+  color: #fff;
+  font-weight: 950;
+  font-size: 28px;
+  letter-spacing: -.04em;
+  text-shadow: 0 8px 26px rgba(0,0,0,.45);
+}
+
+.news-card__story {
+  white-space: pre-line;
+  color: rgba(244,248,255,.88);
+  line-height: 1.7;
+  font-size: 15px;
+}
+
 @media (max-width: 900px) {
   .news-card__compact-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Сделать страницу новостей более информативной и визуально привлекательной, добавив изображения в карточки и расширённые русские разборы в популярном стиле с лёгким юмором. 
- Сохранить существующий контракт `GET /api/news` и не ломать текущую архитектуру или страницу `ideas`. 
- Обеспечить надёжность: падение парсинга изображений или генерации текста не должно приводить к крашу ответа API.

### Description
- Добавлены безопасные хелперы в `app/services/news_service.py`: `strip_html`, `extract_news_image`, `pick_fallback_news_image` и `build_long_news_story`, а также интегрированы в поток сборки новостей для детерминированной генерации текста и извлечения изображений. 
- Расширен формат ответов паблик-ленты (не удаляя старые поля) — добавлены `image_url`, `image_alt`, `long_story_ru`, `grok_style_comment_ru`, `what_happened_ru`, `why_it_matters_ru`, `what_next_ru` и гарантии fallback при ошибках парсинга. 
- Добавлены локальные SVG-плейсхолдеры в `app/static/news-placeholders/` (`usd.svg`, `gold.svg`, `stocks.svg`, `energy.svg`, `default.svg`) и логика их выбора в `pick_fallback_news_image`. 
- Обновлён фронтенд `app/static/news.html` для отображения изображения в карточке, добавлен `onerror`-fallback для `<img>` и блок детального рассказа, и добавлены стили в `app/static/styles.css` для профессиональной верстки image-card и случая fallback.

### Testing
- Успешно скомпилированы модули проверкой: `python -m py_compile app/services/news_service.py app/main.py`. 
- Попытка локального smoke-теста `fetch_public_news` завершилась ошибкой запуска в данном окружении из‑за отсутствующего пакета `feedparser`, поэтому интеграционный вызов RSS не выполнялся (зависимость отсутствует в CI/окружении). 
- При ошибках парсинга изображения/построения текста логика использует детерминированные fallback-значения, что защищает `/api/news` от падений (покрыто кодом обработки исключений в `fetch_public_news`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c92575a48331952a54a58622ebc6)