### PR TITLE
Встраивание виджета Tradays на страницу календаря с юмористическим гайдом

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -37,20 +37,113 @@
           </div>
         </section>
 
-        <section class="panel calendar-events-panel">
+        <section class="panel calendar-widget-panel">
           <div class="panel-heading compact">
             <div>
-              <p class="section-kicker">События</p>
-              <h2>События и ожидаемое влияние</h2>
+              <p class="section-kicker">Живой календарь</p>
+              <h2>Экономические события в реальном времени</h2>
+              <p class="section-text">
+                Данные берутся из Tradays: время выхода, важность, фактические значения, прогнозы и предыдущие показатели.
+              </p>
             </div>
-            <span class="panel-meta" id="calendarState">Ожидание загрузки...</span>
           </div>
-          <ul class="data-list" id="calendarList"></ul>
+
+          <div class="calendar-explainer">
+            <p>
+              <strong>Как читать календарь без паники:</strong> высокая важность — это когда рынок внезапно вспоминает, что он
+              живой. На таких событиях спреды, свечи и настроение трейдера иногда расширяются одновременно.
+            </p>
+            <p>
+              <strong>Факт выше прогноза:</strong> валюта страны часто получает поддержку. Но рынок — существо капризное: иногда
+              покупает слухи, продаёт факт и делает вид, что «так и было задумано».
+            </p>
+            <p>
+              <strong>Факт ниже прогноза:</strong> слабые данные могут давить на валюту, особенно когда меняются ожидания по
+              ставкам. Центробанк смотрит на цифры, рынок смотрит на центробанк, трейдер смотрит на обоих и пьёт кофе с
+              уважением.
+            </p>
+          </div>
+
+          <div class="calendar-guide-grid">
+            <article class="calendar-guide-card">
+              <h3>Высокая важность</h3>
+              <p>Публикации, на которых волатильность может включить режим «турбо» за пару секунд.</p>
+            </article>
+            <article class="calendar-guide-card">
+              <h3>Факт / Прогноз / Предыдущее</h3>
+              <p>Сравнивайте не одну цифру, а три: рынок торгует отклонение от ожиданий и контекст.</p>
+            </article>
+            <article class="calendar-guide-card">
+              <h3>Уже вышло</h3>
+              <p>Смотрите, как цена отреагировала в первые минуты и где формируется новый баланс.</p>
+            </article>
+            <article class="calendar-guide-card">
+              <h3>Ожидается</h3>
+              <p>До релиза полезно проверить риск, ликвидность и план: «что делаю при сюрпризе».</p>
+            </article>
+            <article class="calendar-guide-card">
+              <h3>На что смотреть после релиза</h3>
+              <p>Реакция облигаций, индекс доллара и комментарии регулятора часто важнее самой первой свечи.</p>
+            </article>
+          </div>
+
+          <div class="tradays-widget-wrap" id="tradaysWidgetWrap">
+            <div id="economicCalendarWidget"></div>
+            <div class="ecw-copyright">
+              <a
+                href="https://www.mql5.com/?utm_source=calendar.widget&utm_medium=link&utm_term=economic.calendar&utm_content=visit.mql5.calendar&utm_campaign=202.calendar.widget"
+                rel="noopener nofollow"
+                target="_blank"
+                >MQL5 Algo Trading Community</a
+              >
+            </div>
+          </div>
+          <p class="tradays-fallback" id="tradaysFallback" hidden>
+            Tradays временно не загрузился. Попробуйте обновить страницу. Хорошая новость: если календарь не грузится, рынок
+            всё равно найдёт способ удивить.
+          </p>
         </section>
       </main>
     </div>
 
     <script src="/static/script.js"></script>
     <script src="/static/nav.js"></script>
+    <script>
+      (function () {
+        const widgetHost = document.getElementById('economicCalendarWidget');
+        const fallback = document.getElementById('tradaysFallback');
+        if (!widgetHost || !fallback) return;
+
+        let loaded = false;
+        const widgetScript = document.createElement('script');
+        widgetScript.async = true;
+        widgetScript.type = 'text/javascript';
+        widgetScript.dataset.type = 'calendar-widget';
+        widgetScript.src = 'https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15';
+        widgetScript.textContent = JSON.stringify({
+          width: '100%',
+          height: 540,
+          mode: 2,
+          lang: 'ru',
+          dateformat: 'DMY',
+          theme: 1,
+        });
+
+        widgetScript.onload = function () {
+          loaded = true;
+          fallback.hidden = true;
+        };
+        widgetScript.onerror = function () {
+          fallback.hidden = false;
+        };
+
+        widgetHost.appendChild(widgetScript);
+        window.setTimeout(function () {
+          if (!loaded && widgetHost.children.length <= 1) {
+            fallback.hidden = false;
+          }
+        }, 5000);
+      })();
+    </script>
   </body>
 </html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1863,6 +1863,77 @@ a { color: inherit; }
   border-color: rgba(108, 169, 255, 0.26);
 }
 
+.calendar-widget-panel {
+  border-color: rgba(108, 169, 255, 0.3);
+  background: linear-gradient(155deg, rgba(8, 23, 44, 0.92), rgba(28, 17, 54, 0.88));
+  box-shadow: 0 18px 45px rgba(8, 20, 40, 0.42), inset 0 1px 0 rgba(160, 222, 255, 0.1);
+}
+
+.calendar-explainer {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 18px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(117, 177, 255, 0.28);
+  background: linear-gradient(145deg, rgba(11, 30, 52, 0.78), rgba(17, 22, 46, 0.72));
+  backdrop-filter: blur(8px);
+}
+
+.calendar-explainer p {
+  margin: 0;
+  color: #dde8ff;
+  line-height: 1.6;
+}
+
+.calendar-guide-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  margin-bottom: 18px;
+}
+
+.calendar-guide-card {
+  border-radius: 14px;
+  border: 1px solid rgba(118, 191, 255, 0.28);
+  padding: 14px;
+  background: linear-gradient(155deg, rgba(10, 27, 48, 0.86), rgba(25, 14, 50, 0.78));
+  box-shadow: 0 10px 26px rgba(5, 14, 30, 0.3), inset 0 0 22px rgba(76, 201, 240, 0.07);
+}
+
+.calendar-guide-card h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: #c9e7ff;
+}
+
+.calendar-guide-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.tradays-widget-wrap {
+  border-radius: 16px;
+  border: 1px solid rgba(122, 193, 255, 0.28);
+  background: linear-gradient(145deg, rgba(7, 18, 32, 0.92), rgba(12, 26, 46, 0.9));
+  padding: 12px;
+  box-shadow: 0 0 26px rgba(76, 201, 240, 0.12);
+}
+
+.tradays-widget-wrap #economicCalendarWidget {
+  min-height: 420px;
+}
+
+.tradays-fallback {
+  margin: 12px 0 0;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px dashed rgba(251, 191, 36, 0.45);
+  background: rgba(54, 39, 10, 0.26);
+  color: #fde68a;
+}
+
 .calendar-state {
   padding: 8px 12px;
   border-radius: 999px;
@@ -1941,4 +2012,18 @@ a { color: inherit; }
 @keyframes quotePulse {
   0%, 100% { box-shadow: 0 0 14px rgba(76, 201, 240, 0.2), inset 0 0 14px rgba(139, 92, 246, 0.1); }
   50% { box-shadow: 0 0 20px rgba(139, 92, 246, 0.35), inset 0 0 20px rgba(76, 201, 240, 0.2); }
+}
+
+@media (max-width: 720px) {
+  .calendar-explainer {
+    padding: 14px;
+  }
+
+  .tradays-widget-wrap {
+    padding: 8px;
+  }
+
+  .tradays-widget-wrap #economicCalendarWidget {
+    min-height: 360px;
+  }
 }


### PR DESCRIPTION
### Motivation
- Заменить сломанный/резервный список событий на реальный виджет экономического календаря Tradays, не изобретая времена релизов.
- Дать пользователю полезные и юмористические инструкции по чтению событий, не меняя исходные данные календаря.
- Выполнить минимальные безопасные изменения, сохранив маршруты, существующие API и страницу `ideas`.

### Description
- В `app/static/calendar.html` заменён старый список событий на секцию `calendar-widget-panel` с объяснительным текстом, карточками-гайдами и контейнером для официального виджета Tradays; добавлен инлайновый скрипт, который вставляет официальный скрипт виджета с конфигом на `ru` (`data-type=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0dfc90d4083319e51010d8c97f1b3)