### PR TITLE
Добавить юмористические строки к тексту событий календаря

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -41,7 +41,7 @@
           <div class="panel-heading compact">
             <div>
               <p class="section-kicker">События</p>
-              <h2>События и ожидаемое влияние</h2>
+              <h2>События и ожидаемое влияние (с долей рыночного юмора)</h2>
             </div>
             <span class="panel-meta" id="calendarState">Ожидание загрузки...</span>
           </div>

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -147,16 +147,42 @@ function getCalendarTimeLabel(event) {
 }
 
 function getCalendarMainText(event, fallbackImpact) {
-  if (event?.full_text_ru) return String(event.full_text_ru);
+  if (event?.full_text_ru) {
+    return `${String(event.full_text_ru).trim()} ${getCalendarHumorLine(event, fallbackImpact)}`.trim();
+  }
   const parts = [
     event?.description_ru,
     event?.why_important_ru,
     event?.market_impact_ru || fallbackImpact.effect,
     event?.humor_ru || fallbackImpact.humor,
+    getCalendarHumorLine(event, fallbackImpact),
   ]
     .map((part) => String(part || '').trim())
     .filter(Boolean);
   return parts.join(' ') || 'Описание события пока обновляется.';
+}
+
+function getCalendarHumorLine(event, fallbackImpact) {
+  const title = String(event?.title || '').toLowerCase();
+  const impact = String(event?.impact || event?.importance || '').toLowerCase();
+  const currency = String(event?.currency || '').toUpperCase();
+
+  if (title.includes('cpi') || title.includes('инфляц') || title.includes('pce')) {
+    return 'Инфляция в кадре: трейдеры снова гадают, кто первым моргнёт — рынок или здравый смысл.';
+  }
+  if (title.includes('nfp') || title.includes('занятост') || title.includes('безработ')) {
+    return 'Релиз по рынку труда: волатильность приходит без приглашения и сразу садится за главный стол.';
+  }
+  if (title.includes('ставк') || title.includes('rate') || title.includes('fomc') || title.includes('ecb')) {
+    return 'День ставок: одно предложение регулятора, и графики начинают кардио быстрее трейдера.';
+  }
+  if (impact.includes('high') || impact.includes('выс')) {
+    return 'Высокая важность: кофе покрепче, риск-менеджмент ещё крепче.';
+  }
+  if (currency) {
+    return `Сегодня в центре внимания ${currency}: рынок обещал «спокойно», но мы ему не верим.`;
+  }
+  return fallbackImpact?.humor || 'Спокойно, это просто новости... наверное.';
 }
 
 function setCalendarState(state, message) {


### PR DESCRIPTION
### Motivation
- Сделать подачу текстов в экономическом календаре более живой и с юмором, не меняя фактических данных и API-контракты.

### Description
- Добавлена функция `getCalendarHumorLine` в `app/static/script.js`, которая возвращает контекстные шутливые строки по типу события (инфляция, ставки, занятость, высокая важность, валюта). 
- Изменён рендер основного текста события в `getCalendarMainText`, чтобы аккуратно добавлять юмористическую строку и при наличии `full_text_ru` тоже дополнять её юмором. 
- Обновлён заголовок секции календаря в `app/static/calendar.html` на `События и ожидаемое влияние (с долей рыночного юмора)`. 
- Изменения ограничены фронтендом и не подменяют рыночные данные, только изменяют стиль отображения.

### Testing
- Выполнена компиляция с помощью `python -m compileall app/static/script.js app/main.py`, которая завершилась успешно. 
- Запуск `pytest -q tests/test_chart_api.py` упал на существующей ошибке импорта (`cannot import name 'canonical_market_service' from 'app.main'`), ошибка не связана с внесёнными фронтенд-изменениями.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e1e66dd0833194fa779bf656e025)