### PR TITLE
Встроить виджет Tradays на страницу /calendar

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -41,109 +41,47 @@
           <div class="panel-heading compact">
             <div>
               <p class="section-kicker">Живой календарь</p>
-              <h2>Экономические события в реальном времени</h2>
+              <h2>Экономический календарь Tradays</h2>
               <p class="section-text">
-                Данные берутся из Tradays: время выхода, важность, фактические значения, прогнозы и предыдущие показатели.
+                Здесь отображаются реальные события, время выхода, важность, прогноз, факт и предыдущее значение.
               </p>
             </div>
           </div>
 
-          <div class="calendar-explainer">
-            <p>
-              <strong>Как читать календарь без паники:</strong> высокая важность — это когда рынок внезапно вспоминает, что он
-              живой. На таких событиях спреды, свечи и настроение трейдера иногда расширяются одновременно.
-            </p>
-            <p>
-              <strong>Факт выше прогноза:</strong> валюта страны часто получает поддержку. Но рынок — существо капризное: иногда
-              покупает слухи, продаёт факт и делает вид, что «так и было задумано».
-            </p>
-            <p>
-              <strong>Факт ниже прогноза:</strong> слабые данные могут давить на валюту, особенно когда меняются ожидания по
-              ставкам. Центробанк смотрит на цифры, рынок смотрит на центробанк, трейдер смотрит на обоих и пьёт кофе с
-              уважением.
-            </p>
-          </div>
-
           <div class="calendar-guide-grid">
             <article class="calendar-guide-card">
-              <h3>Высокая важность</h3>
-              <p>Публикации, на которых волатильность может включить режим «турбо» за пару секунд.</p>
+              <strong>Высокая важность</strong>
+              <p>Это момент, когда рынок может внезапно вспомнить, что он живой. На таких релизах свечи иногда бегают быстрее трейдера за кофе.</p>
             </article>
             <article class="calendar-guide-card">
-              <h3>Факт / Прогноз / Предыдущее</h3>
-              <p>Сравнивайте не одну цифру, а три: рынок торгует отклонение от ожиданий и контекст.</p>
+              <strong>Факт против прогноза</strong>
+              <p>Если факт сильно отличается от прогноза, валюты могут дернуться резко. Рынок любит сюрпризы примерно как кот любит ванну.</p>
             </article>
             <article class="calendar-guide-card">
-              <h3>Уже вышло</h3>
-              <p>Смотрите, как цена отреагировала в первые минуты и где формируется новый баланс.</p>
-            </article>
-            <article class="calendar-guide-card">
-              <h3>Ожидается</h3>
-              <p>До релиза полезно проверить риск, ликвидность и план: «что делаю при сюрпризе».</p>
-            </article>
-            <article class="calendar-guide-card">
-              <h3>На что смотреть после релиза</h3>
-              <p>Реакция облигаций, индекс доллара и комментарии регулятора часто важнее самой первой свечи.</p>
+              <strong>После релиза</strong>
+              <p>Не только цифра важна, но и реакция цены. Иногда данные хорошие, а рынок продаёт — потому что ожидал ещё лучше.</p>
             </article>
           </div>
 
-          <div class="tradays-widget-wrap" id="tradaysWidgetWrap">
-            <div id="economicCalendarWidget"></div>
-            <div class="ecw-copyright">
-              <a
-                href="https://www.mql5.com/?utm_source=calendar.widget&utm_medium=link&utm_term=economic.calendar&utm_content=visit.mql5.calendar&utm_campaign=202.calendar.widget"
-                rel="noopener nofollow"
-                target="_blank"
-                >MQL5 Algo Trading Community</a
-              >
+          <div class="tradays-widget-wrap">
+            <div id="economicCalendarWidget">
+              <iframe
+                title="Экономический календарь Tradays"
+                src="https://www.tradays.com/ru/economic-calendar/widget?mode=2&dateFormat=DMY"
+                width="100%"
+                height="650"
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade"
+                style="border:0"
+              ></iframe>
             </div>
           </div>
-          <p class="tradays-fallback" id="tradaysFallback" hidden>
-            Tradays временно не загрузился. Попробуйте обновить страницу. Хорошая новость: если календарь не грузится, рынок
-            всё равно найдёт способ удивить.
-          </p>
+          <script async src="https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15"></script>
         </section>
       </main>
     </div>
 
     <script src="/static/script.js"></script>
     <script src="/static/nav.js"></script>
-    <script>
-      (function () {
-        const widgetHost = document.getElementById('economicCalendarWidget');
-        const fallback = document.getElementById('tradaysFallback');
-        if (!widgetHost || !fallback) return;
-
-        let loaded = false;
-        const widgetScript = document.createElement('script');
-        widgetScript.async = true;
-        widgetScript.type = 'text/javascript';
-        widgetScript.dataset.type = 'calendar-widget';
-        widgetScript.src = 'https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15';
-        widgetScript.textContent = JSON.stringify({
-          width: '100%',
-          height: 540,
-          mode: 2,
-          lang: 'ru',
-          dateformat: 'DMY',
-          theme: 1,
-        });
-
-        widgetScript.onload = function () {
-          loaded = true;
-          fallback.hidden = true;
-        };
-        widgetScript.onerror = function () {
-          fallback.hidden = false;
-        };
-
-        widgetHost.appendChild(widgetScript);
-        window.setTimeout(function () {
-          if (!loaded && widgetHost.children.length <= 1) {
-            fallback.hidden = false;
-          }
-        }, 5000);
-      })();
-    </script>
   </body>
 </html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1880,9 +1880,7 @@ a { color: inherit; }
 }
 
 .calendar-widget-panel {
-  border-color: rgba(108, 169, 255, 0.3);
-  background: linear-gradient(155deg, rgba(8, 23, 44, 0.92), rgba(28, 17, 54, 0.88));
-  box-shadow: 0 18px 45px rgba(8, 20, 40, 0.42), inset 0 1px 0 rgba(160, 222, 255, 0.1);
+  overflow: hidden;
 }
 
 .calendar-explainer {
@@ -1904,41 +1902,41 @@ a { color: inherit; }
 
 .calendar-guide-grid {
   display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  margin-bottom: 18px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
 }
 
 .calendar-guide-card {
-  border-radius: 14px;
-  border: 1px solid rgba(118, 191, 255, 0.28);
-  padding: 14px;
-  background: linear-gradient(155deg, rgba(10, 27, 48, 0.86), rgba(25, 14, 50, 0.78));
-  box-shadow: 0 10px 26px rgba(5, 14, 30, 0.3), inset 0 0 22px rgba(76, 201, 240, 0.07);
+  padding: 16px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(18,43,78,.92), rgba(6,18,36,.96));
+  border: 1px solid rgba(95,156,230,.35);
+  box-shadow: 0 16px 42px rgba(0,0,0,.28);
 }
 
-.calendar-guide-card h3 {
-  margin: 0 0 8px;
-  font-size: 1rem;
-  color: #c9e7ff;
+.calendar-guide-card strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #f4f8ff;
 }
 
 .calendar-guide-card p {
   margin: 0;
-  color: var(--muted);
-  line-height: 1.55;
+  color: rgba(220,235,255,.78);
+  line-height: 1.6;
 }
 
 .tradays-widget-wrap {
-  border-radius: 16px;
-  border: 1px solid rgba(122, 193, 255, 0.28);
-  background: linear-gradient(145deg, rgba(7, 18, 32, 0.92), rgba(12, 26, 46, 0.9));
-  padding: 12px;
-  box-shadow: 0 0 26px rgba(76, 201, 240, 0.12);
+  min-height: 650px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(3,14,28,.88);
+  border: 1px solid rgba(95,156,230,.35);
 }
 
 .tradays-widget-wrap #economicCalendarWidget {
-  min-height: 420px;
+  min-height: 650px;
 }
 
 .tradays-fallback {
@@ -2030,16 +2028,8 @@ a { color: inherit; }
   50% { box-shadow: 0 0 20px rgba(139, 92, 246, 0.35), inset 0 0 20px rgba(76, 201, 240, 0.2); }
 }
 
-@media (max-width: 720px) {
-  .calendar-explainer {
-    padding: 14px;
-  }
-
-  .tradays-widget-wrap {
-    padding: 8px;
-  }
-
-  .tradays-widget-wrap #economicCalendarWidget {
-    min-height: 360px;
+@media (max-width: 860px) {
+  .calendar-guide-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Заменить образовательные резервные карточки на странице `/calendar` реальным виджетом экономического календаря Tradays, чтобы основным контентом были живые события от поставщика.
- Сохранить существующую навигацию, маршруты и API, не ломая текущую архитектуру и страницу `/ideas`.

### Description
- На `app/static/calendar.html` заменён основной видимый блок календаря: добавлена секция с заголовком «Экономический календарь Tradays», три юмористические guide-карточки и контейнер с реальным embed (iframe) на `https://www.tradays.com/ru/economic-calendar/widget?mode=2&dateFormat=DMY` и подключён официальный скрипт `widget.js?v=15`.
- Удалена старая inline-логика динамической подгрузки/фолбэка, которая показывала «Показан образовательный календарь...», чтобы резервный контент не был главным на странице; при этом маршруты и API (`/calendar/events`, `/api/calendar`) оставлены нетронутыми.
- Обновлены стили в `app/static/styles.css` для обёрток: `.calendar-widget-panel`, `.calendar-guide-grid`, `.calendar-guide-card`, `.calendar-guide-card strong`, `.calendar-guide-card p`, `.tradays-widget-wrap` и адаптивное правило `@media (max-width: 860px)` согласно требованиям.
- Изменения локализованы в HTML/CSS страницы календаря и не затрагивают `app/static/ideas.html` или другие маршруты.

### Testing
- Проверен наличий вставки и классов с помощью поиска `rg` по `app/static` (поиск селекторов и URL виджета) — успешно обнаружены новые блоки и embed.
- Проверен официальный источник виджета командой `curl -L -s https://www.tradays.com/ru/widget` для подтверждения параметров внедрения — успешно выполнено.
- Прогон `git status` и коммит изменений подтверждён (`Embed Tradays calendar widget safely`) — успешно выполнено.
- Автоматических unit-тестов не запускалось; визуальная интеграция проверялась статически командами выше и правками в HTML/CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e2444ed0833183b79c00f1f297fb)