### PR TITLE
Заменить календарь на полноэкранный виджет Tradays

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -6,14 +6,9 @@
     <title>Экономический календарь</title>
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
-  <body data-page="calendar">
-    <div class="page-shell">
-      <header class="site-header calendar-hero">
-        <div>
-          <p class="eyebrow">Календарь</p>
-          <h1>Экономический календарь</h1>
-          <p class="lead">Страница календаря сохранена в меню и продолжает использовать текущий API-контракт.</p>
-        </div>
+  <body data-page="calendar" class="calendar-page">
+    <div class="page-shell calendar-shell-nav">
+      <header class="site-header calendar-hero calendar-nav-header">
         <nav class="top-nav">
           <a href="/">Главная</a>
           <a href="/ideas">Идеи</a>
@@ -22,63 +17,29 @@
           <a href="/heatmap/page">Тепловая карта</a>
         </nav>
       </header>
+    </div>
 
-      <main class="content-stack">
-        <section class="panel">
-          <div class="panel-heading compact">
-            <div>
-              <p class="section-kicker">Навигатор</p>
-              <h2>Как читать влияние новостей</h2>
-              <p class="section-text">
-                Для каждого события мы показываем: <strong>что выходит</strong>, <strong>какие активы обычно реагируют</strong>,
-                <strong>тип реакции</strong> и <strong>короткий комментарий в стиле Grok</strong> (юмористическая подача, без выдумывания данных).
-              </p>
-            </div>
-          </div>
-        </section>
+    <div class="calendar-fullscreen">
+      <div id="economicCalendarWidget"></div>
 
-        <section class="panel calendar-widget-panel">
-          <div class="panel-heading compact">
-            <div>
-              <p class="section-kicker">Живой календарь</p>
-              <h2>Экономический календарь Tradays</h2>
-              <p class="section-text">
-                Здесь отображаются реальные события, время выхода, важность, прогноз, факт и предыдущее значение.
-              </p>
-            </div>
-          </div>
+      <div class="ecw-copyright">
+        <a
+          href="https://www.mql5.com/?utm_source=calendar.widget&utm_medium=link&utm_term=economic.calendar&utm_content=visit.mql5.calendar&utm_campaign=202.calendar.widget"
+          rel="noopener nofollow"
+          target="_blank"
+        >
+          MQL5 Algo Trading Community
+        </a>
+      </div>
 
-          <div class="calendar-guide-grid">
-            <article class="calendar-guide-card">
-              <strong>Высокая важность</strong>
-              <p>Это момент, когда рынок может внезапно вспомнить, что он живой. На таких релизах свечи иногда бегают быстрее трейдера за кофе.</p>
-            </article>
-            <article class="calendar-guide-card">
-              <strong>Факт против прогноза</strong>
-              <p>Если факт сильно отличается от прогноза, валюты могут дернуться резко. Рынок любит сюрпризы примерно как кот любит ванну.</p>
-            </article>
-            <article class="calendar-guide-card">
-              <strong>После релиза</strong>
-              <p>Не только цифра важна, но и реакция цены. Иногда данные хорошие, а рынок продаёт — потому что ожидал ещё лучше.</p>
-            </article>
-          </div>
-
-          <div class="tradays-widget-wrap">
-            <div id="economicCalendarWidget">
-              <iframe
-                title="Экономический календарь Tradays"
-                src="https://www.tradays.com/ru/economic-calendar/widget?mode=2&dateFormat=DMY"
-                width="100%"
-                height="650"
-                loading="lazy"
-                referrerpolicy="no-referrer-when-downgrade"
-                style="border:0"
-              ></iframe>
-            </div>
-          </div>
-          <script async src="https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15"></script>
-        </section>
-      </main>
+      <script
+        async
+        type="text/javascript"
+        data-type="calendar-widget"
+        src="https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15"
+      >
+        {"width":"100%","height":"100%","mode":"2","fw":"html","theme":1}
+      </script>
     </div>
 
     <script src="/static/script.js"></script>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -15,6 +15,10 @@
 }
 
 * { box-sizing: border-box; }
+html,
+body {
+  height: 100%;
+}
 html { scroll-behavior: smooth; }
 body {
   margin: 0;
@@ -1881,6 +1885,46 @@ a { color: inherit; }
 
 .calendar-widget-panel {
   overflow: hidden;
+}
+
+.calendar-page .calendar-shell-nav {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  padding-top: 16px;
+}
+
+.calendar-page .calendar-nav-header {
+  padding: 16px;
+  border-radius: 18px;
+}
+
+.calendar-page .calendar-nav-header .top-nav {
+  justify-content: center;
+}
+
+.calendar-fullscreen {
+  position: fixed;
+  inset: 0;
+  top: 92px;
+  z-index: 1;
+  background: #020617;
+  display: flex;
+  flex-direction: column;
+}
+
+#economicCalendarWidget {
+  flex: 1;
+  min-height: 0;
+}
+
+.ecw-copyright {
+  text-align: center;
+  font-size: 12px;
+  padding: 6px 0;
+  color: rgba(255, 255, 255, 0.4);
 }
 
 .calendar-explainer {


### PR DESCRIPTION
### Motivation
- Упростить страницу календаря и показать только официальный виджет Tradays в полноэкранном режиме для более чистого и знакомого интерфейса экономических событий.
- Сохранить существующую навигацию и маршрут, избегая изменения бекенд-логики или других страниц.

### Description
- Полностью удалена старая видимая разметка календаря и справочные блоки в `app/static/calendar.html`, оставлена только верхняя навигация и новый блок `calendar-fullscreen` с `#economicCalendarWidget` и официальным скриптом виджета.
- Добавлены CSS-правила в `app/static/styles.css` для поддержки `html, body { height: 100%; }`, фиксирования навигации сверху и размещения `.calendar-fullscreen` на весь доступный viewport с безопасным отступом сверху (`top: 92px`) чтобы навигация не перекрывала виджет.
- Обеспечено, что контейнер виджета растягивается (`flex: 1; min-height: 0;`) и добавлен небольшой стиль для копирайта виджета; изменены только два файла: `app/static/calendar.html` и `app/static/styles.css`.
- Архитектура, маршруты и другие страницы (включая `app/static/ideas.html`) не затронуты.

### Testing
- Выполнен `git diff --check` и проблем форматирования не найдено (успешно).
- Проверено, что изменены только `app/static/calendar.html` и `app/static/styles.css` и что в итоговом diff отображается только удаление старого контента и добавление виджета (успешно).
- Локальные команды `git status --short` и просмотр diff-файлов подтверждают внесённые изменения (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ebd570348331907562a7b112d8f6)