### PR TITLE
Упростить страницу «Календарь»: встроить виджет Tradays

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -3,95 +3,40 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Экономический календарь</title>
-    <link rel="stylesheet" href="/static/styles.css" />
+    <title>Календарь</title>
     <style>
       html,
       body {
-        height: 100%;
-      }
-
-      body[data-page="calendar"] {
-        min-height: 100vh;
-      }
-
-      body[data-page="calendar"] .page-shell {
+        margin: 0;
         width: 100%;
-        margin: 0;
-        padding: 0;
-        min-height: 100vh;
-        display: flex;
-        flex-direction: column;
-      }
-
-      body[data-page="calendar"] .site-header {
-        border-radius: 0;
-        border-left: 0;
-        border-right: 0;
-        border-top: 0;
-        margin: 0;
-        padding: 16px 20px;
-      }
-
-      .calendar-fullscreen {
-        flex: 1;
-        min-height: 0;
-        z-index: 1;
+        height: 100%;
         background: #020617;
-        display: flex;
-        flex-direction: column;
       }
 
       #economicCalendarWidget {
-        flex: 1;
-        min-height: 0;
+        width: 100%;
+        height: calc(100% - 28px);
       }
 
       .ecw-copyright {
-        text-align: center;
+        height: 28px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         font-size: 12px;
-        padding: 6px 0;
-        color: rgba(255, 255, 255, 0.4);
+      }
+
+      .ecw-copyright a {
+        color: rgba(255, 255, 255, 0.55);
+        text-decoration: none;
       }
     </style>
   </head>
-  <body data-page="calendar">
-    <div class="page-shell">
-      <header class="site-header">
-        <nav class="top-nav">
-          <a href="/">Главная</a>
-          <a href="/ideas">Идеи</a>
-          <a href="/news">Новости</a>
-          <a href="/calendar">Календарь</a>
-          <a href="/heatmap/page">Тепловая карта</a>
-        </nav>
-      </header>
-
-      <div class="calendar-fullscreen">
-        <div id="economicCalendarWidget"></div>
-
-        <div class="ecw-copyright">
-          <a
-            href="https://www.mql5.com/?utm_source=calendar.widget&utm_medium=link&utm_term=economic.calendar&utm_content=visit.mql5.calendar&utm_campaign=202.calendar.widget"
-            rel="noopener nofollow"
-            target="_blank"
-          >
-            MQL5 Algo Trading Community
-          </a>
-        </div>
-
-        <script
-          async
-          type="text/javascript"
-          data-type="calendar-widget"
-          src="https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15"
-        >
-          {"width":"100%","height":"100%","mode":"2","fw":"html","theme":1}
-        </script>
-      </div>
-    </div>
-
-    <script src="/static/script.js"></script>
-    <script src="/static/nav.js"></script>
+  <body>
+    <div id="economicCalendarWidget"></div>
+    <div class="ecw-copyright"><a href="https://www.mql5.com/?utm_source=calendar.widget&utm_medium=link&utm_term=economic.calendar&utm_content=visit.mql5.calendar&utm_campaign=202.calendar.widget" rel="noopener nofollow" target="_blank">MQL5 Algo Trading Community</a></div>
+    <script async type="text/javascript" data-type="calendar-widget" src="https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15">
+      {"width":"100%","height":"100%","mode":"2","fw":"html","theme":1}
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Страница календаря должна отображать только внешний экономический виджет по запросу — убрать лишние блоки интерфейса и обвязку страницы.
- Сделать страницу минималистичной и независимой от общих скриптов/шаблонов, чтобы она показывала только внешний виджет Tradays/MQL5.

### Description
- Заменён файл `app/static/calendar.html` на упрощённую страницу, в которой оставлены только `div#economicCalendarWidget`, копирайт MQL5 и подключение скрипта виджета Tradays. 
- Удалены навигация, заголовок/обёртки страницы и подключения общих скриптов/стилей, добавлены минимальные встроенные стили и обновлён `<title>`.
- Виджет и его параметры оставлены как в запросе: скрипт `https://www.tradays.com/c/js/widgets/calendar/widget.js?v=15` с телом конфигурации `{"width":"100%","height":"100%","mode":"2","fw":"html","theme":1}`.

### Testing
- Запуск `python -m compileall app` был выполнен и завершился с ошибкой из-за существующей синтаксической ошибки в `app/services/chart_snapshot_service.py`, не связанной с изменением HTML, поэтому сборка не прошла полностью.
- Изменение страницы HTML не запускало дополнительных автоматизированных тестов и не затрагивает серверный Python-код напрямую.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f2e8a35483318b0228e095566197)