### PR TITLE
Растянуть экономический календарь на всю страницу

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -35,7 +35,7 @@
 
       .calendar-fullscreen {
         flex: 1;
-        min-height: 0;
+        min-height: calc(100vh - 90px);
         z-index: 1;
         background: #020617;
         display: flex;
@@ -45,6 +45,15 @@
       #economicCalendarWidget {
         flex: 1;
         min-height: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #economicCalendarWidget > div,
+      #economicCalendarWidget iframe {
+        width: 100% !important;
+        height: 100% !important;
+        min-height: 100% !important;
       }
 
       .ecw-copyright {


### PR DESCRIPTION
### Motivation
- Пользователь сообщил, что виджет календаря отображается только в верхней части страницы, поэтому нужно, чтобы календарь занимал всё доступное пространство под шапкой.

### Description
- Обновлены стили в `app/static/calendar.html`: изменено правило для `.calendar-fullscreen` на `min-height: calc(100vh - 90px)`, добавлены правила для `#economicCalendarWidget` (`width: 100%; height: 100%`) и для вложенных `div`/`iframe`, чтобы встроенный виджет растягивался по ширине и высоте и занимал всю область контейнера.

### Testing
- Автоматические тесты не запускались; изменение ограничено клиентским CSS и не затрагивает API или серверную логику, поэтому регрессий на бэкенд не ожидается.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f53e17a88331919f25950a16e0e5)