### PR TITLE
Исправление свечей, метрик proxy, полноэкранного календаря и изображений новостей

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -378,6 +378,7 @@ def api_signals():
         "ideas": signals,
         "archive": archive,
         "statistics": build_stats(),
+        "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
         "updated_at_utc": now_utc(),
     }
 
@@ -463,7 +464,7 @@ def api_debug_candles(symbol: str, tf: str, limit: int = 160):
         "interval": payload.get("interval"),
         "cache_status": payload.get("cache_status"),
         "warning_ru": payload.get("warning_ru"),
-        "attempts": payload.get("attempts"),
+        "raw_error": payload.get("raw_error"),
         "first": candles[0] if candles else None,
         "last": candles[-1] if candles else None,
     }
@@ -590,6 +591,8 @@ def build_signal(symbol: str) -> dict[str, Any]:
         "runtime_color": runtime_color,
         "source": price_data.get("source"),
         "data_status": price_data.get("data_status"),
+        "metric_status": "proxy",
+        "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
         "is_live_market_data": bool(price_data.get("is_live_market_data")),
         "source_symbol": to_twelvedata_symbol(symbol),
         "current_price": current_price,
@@ -734,6 +737,8 @@ def get_candles_with_markup(symbol: str, tf: str = "M15", limit: int = 160) -> d
         "cache_status": candles_payload.get("cache_status"),
         "source": "twelvedata_time_series",
         "data_status": "real" if candles else "unavailable",
+        "metric_status": "proxy",
+        "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
         "current_price": get_price(symbol).get("price"),
         "last_updated_utc": now_utc(),
         "candles": candles,
@@ -744,6 +749,7 @@ def get_candles_with_markup(symbol: str, tf: str = "M15", limit: int = 160) -> d
         "warning_ru": candles_payload.get("warning_ru"),
         "diagnostics": {
             "attempts": candles_payload.get("attempts"),
+            "raw_error": candles_payload.get("raw_error"),
             "cache_status": candles_payload.get("cache_status"),
             "provider": candles_payload.get("provider"),
         },
@@ -790,64 +796,6 @@ def parse_td_values(values: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return candles
 
 
-def fetch_stooq_fallback(symbol: str, tf: str, limit: int = 160) -> dict[str, Any] | None:
-    normalized = normalize_symbol(symbol)
-    if tf.upper() != "M15":
-        return None
-
-    mapping = {
-        "EURUSD": "eurusd",
-        "GBPUSD": "gbpusd",
-        "USDJPY": "usdjpy",
-        "XAUUSD": "xauusd",
-    }
-    stooq_symbol = mapping.get(normalized)
-    if not stooq_symbol:
-        return None
-
-    try:
-        response = requests.get(f"https://stooq.com/q/d/l/?s={stooq_symbol}&i=15", timeout=8)
-        response.raise_for_status()
-        rows = [line.strip() for line in response.text.splitlines() if line.strip()]
-        if len(rows) <= 1:
-            return None
-
-        candles: list[dict[str, Any]] = []
-        for row in rows[1:]:
-            parts = row.split(",")
-            if len(parts) < 6:
-                continue
-            dt = f"{parts[0]} {parts[1]}"
-            parsed = parse_td_datetime(dt)
-            candles.append(
-                {
-                    "time": int(parsed.timestamp()),
-                    "datetime": dt,
-                    "open": float(parts[2]),
-                    "high": float(parts[3]),
-                    "low": float(parts[4]),
-                    "close": float(parts[5]),
-                    "volume": float(parts[6]) if len(parts) > 6 and parts[6] else 0.0,
-                }
-            )
-
-        candles = candles[-limit:]
-        if not candles:
-            return None
-
-        return {
-            "candles": candles,
-            "warning_ru": "TwelveData временно недоступен, показаны реальные свечи из Stooq.",
-            "provider": "stooq_fallback",
-            "source_symbol": stooq_symbol,
-            "interval": "15m",
-            "cache_status": "live",
-            "attempts": 0,
-        }
-    except Exception:
-        return None
-
-
 def fetch_candles(symbol: str, tf: str = "M15", limit: int = 160) -> dict[str, Any]:
     normalized_symbol = normalize_symbol(symbol)
     source_symbol = to_twelvedata_symbol(normalized_symbol)
@@ -873,6 +821,7 @@ def fetch_candles(symbol: str, tf: str = "M15", limit: int = 160) -> dict[str, A
             "interval": interval,
             "cache_status": "empty",
             "attempts": 0,
+            "raw_error": "TWELVEDATA_API_KEY отсутствует.",
         }
 
     attempts = 0
@@ -912,6 +861,7 @@ def fetch_candles(symbol: str, tf: str = "M15", limit: int = 160) -> dict[str, A
                             "interval": interval,
                             "cache_status": "live",
                             "attempts": attempts,
+                            "raw_error": None,
                         }
                         set_cached_candles(cache_key, payload)
                         return payload
@@ -932,13 +882,8 @@ def fetch_candles(symbol: str, tf: str = "M15", limit: int = 160) -> dict[str, A
             "cache_status": "stale_fallback",
             "warning_ru": "TwelveData временно недоступен, показаны последние реальные свечи из кеша.",
             "attempts": attempts,
+            "raw_error": last_error,
         }
-
-    stooq_payload = fetch_stooq_fallback(normalized_symbol, tf, limit)
-    if stooq_payload:
-        stooq_payload["attempts"] = attempts
-        set_cached_candles(cache_key, stooq_payload)
-        return stooq_payload
 
     return {
         "candles": [],
@@ -948,6 +893,7 @@ def fetch_candles(symbol: str, tf: str = "M15", limit: int = 160) -> dict[str, A
         "interval": interval,
         "cache_status": "empty",
         "attempts": attempts,
+        "raw_error": last_error,
     }
 
 
@@ -1383,6 +1329,8 @@ def empty_signal(
         "full_text": "Нет текущей цены, идея не формируется.",
         "source": price_data.get("source"),
         "data_status": price_data.get("data_status"),
+        "metric_status": "unavailable",
+        "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
         "warning_ru": human_price_warning(price_data),
         "candles": m15,
         "chart_data": {"candles": m15},
@@ -1459,7 +1407,7 @@ def get_price(symbol: str) -> dict[str, Any]:
             "source_symbol": to_twelvedata_symbol(symbol),
             "price": price,
             "source": "twelvedata_rest_quote",
-            "data_status": "rest_fallback" if price is not None else "unavailable",
+            "data_status": "delayed" if price is not None else "unavailable",
             "is_live_market_data": False,
             "warning_ru": "Резервная цена: WebSocket сейчас не прислал live-тик, поэтому система взяла цену через TwelveData REST.",
             "raw": data,
@@ -1541,18 +1489,18 @@ def to_twelvedata_symbol(symbol: str) -> str:
 
 
 def to_td_interval(tf: str) -> str:
-    tf = str(tf or "").upper().strip()
-
-    mapping = {
+    tf = str(tf or "M15").upper().strip()
+    return {
+        "M1": "1min",
+        "M5": "5min",
         "M15": "15min",
+        "M30": "30min",
         "H1": "1h",
         "H4": "4h",
         "D1": "1day",
         "W1": "1week",
         "MN": "1month",
-    }
-
-    return mapping.get(tf, "15min")
+    }.get(tf, "15min")
 
 
 def parse_td_datetime(value: str) -> datetime:

--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -285,6 +285,26 @@ def extract_news_image(entry: dict) -> str | None:
     return None
 
 
+def extract_article_page_image(url: str) -> str | None:
+    try:
+        resp = requests.get(url, timeout=8, headers={"User-Agent": "Mozilla/5.0"})
+        if not resp.ok:
+            return None
+        html_text = resp.text
+        patterns = [
+            r'<meta[^>]+property=["\']og:image["\'][^>]+content=["\']([^"\']+)["\']',
+            r'<meta[^>]+name=["\']twitter:image["\'][^>]+content=["\']([^"\']+)["\']',
+            r'<meta[^>]+property=["\']og:image:secure_url["\'][^>]+content=["\']([^"\']+)["\']',
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, html_text, flags=re.I)
+            if match:
+                return html.unescape(match.group(1))
+    except Exception:
+        return None
+    return None
+
+
 def pick_fallback_news_image(title: str, summary: str, markets: list[str]) -> str:
     text = f"{title} {summary} {' '.join(markets)}".lower()
 
@@ -609,16 +629,30 @@ def _placeholder_svg_for_title(title: str) -> str:
     return f"/static/generated-news/{slug}.svg"
 
 
-def _resolve_news_image(title: str, summary: str, source: str, entry: dict, diagnostics: dict[str, Any]) -> tuple[str, str]:
-    cache_key = _source_hash(strip_html(title) or "news")
+def _resolve_news_image(
+    title: str,
+    summary: str,
+    source: str,
+    source_url: str | None,
+    entry: dict,
+    diagnostics: dict[str, Any],
+) -> tuple[str, str]:
+    cache_key = _source_hash(str(source_url or strip_html(title) or "news"))
     cached = IMAGE_CACHE.get(cache_key)
     if cached and time() - cached.get("ts", 0) < IMAGE_CACHE_TTL_SECONDS:
         return cached.get("url"), cached.get("source")
 
     source_image = extract_news_image(entry)
     if source_image and _looks_like_image_url(source_image):
-        IMAGE_CACHE[cache_key] = {"ts": time(), "url": source_image, "source": "source"}
-        return source_image, "source"
+        IMAGE_CACHE[cache_key] = {"ts": time(), "url": source_image, "source": "source_rss"}
+        return source_image, "source_rss"
+
+    if source_url:
+        source_page_image = extract_article_page_image(source_url)
+        if source_page_image and _looks_like_image_url(source_page_image):
+            IMAGE_CACHE[cache_key] = {"ts": time(), "url": source_page_image, "source": "source_page"}
+            return source_page_image, "source_page"
+
     web_query = f"{strip_html(title)} {strip_html(source)} market news"
     open_web_image = find_open_web_image(web_query)
     if open_web_image:
@@ -662,6 +696,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                 continue
             source_had_item = False
             for entry in entries:
+                source_url = str(entry.get("link") or "").strip() or None
                 try:
                     title = str(entry.get("title") or "Новость без заголовка").strip()
                     summary = str(entry.get("summary") or entry.get("description") or "").strip()
@@ -671,6 +706,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                         title=title,
                         summary=summary,
                         source=source_name,
+                        source_url=source_url,
                         entry=entry,
                         diagnostics=diagnostics,
                     )
@@ -695,7 +731,6 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     summary_ru = story["preview_ru"]
                     writer = "local_fallback"
                 source_had_item = True
-                source_url = str(entry.get("link") or "").strip() or None
                 items.append(
                     {
                         "title": title_ru,

--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -13,69 +13,43 @@
 
       body[data-page="calendar"] {
         min-height: 100vh;
+        overflow: hidden;
       }
 
       body[data-page="calendar"] .page-shell {
         width: 100%;
-        margin: 0;
+        max-width: none;
+        height: 100vh;
         padding: 0;
-        min-height: 100vh;
-        display: flex;
-        flex-direction: column;
-      }
-
-      body[data-page="calendar"] .site-header {
-        border-radius: 0;
-        border-left: 0;
-        border-right: 0;
-        border-top: 0;
         margin: 0;
-        padding: 16px 20px;
       }
 
       .calendar-fullscreen {
-        flex: 1;
-        min-height: calc(100vh - 90px);
-        z-index: 1;
+        position: fixed;
+        inset: 0;
         background: #020617;
         display: flex;
         flex-direction: column;
+        z-index: 1;
       }
 
       #economicCalendarWidget {
         flex: 1;
-        min-height: 0;
         width: 100%;
-        height: 100%;
-      }
-
-      #economicCalendarWidget > div,
-      #economicCalendarWidget iframe {
-        width: 100% !important;
-        height: 100% !important;
-        min-height: 100% !important;
+        min-height: 0;
       }
 
       .ecw-copyright {
+        flex: 0 0 auto;
         text-align: center;
+        padding: 6px;
         font-size: 12px;
-        padding: 6px 0;
-        color: rgba(255, 255, 255, 0.4);
+        background: #020617;
       }
     </style>
   </head>
   <body data-page="calendar">
     <div class="page-shell">
-      <header class="site-header">
-        <nav class="top-nav">
-          <a href="/">Главная</a>
-          <a href="/ideas">Идеи</a>
-          <a href="/news">Новости</a>
-          <a href="/calendar">Календарь</a>
-          <a href="/heatmap/page">Тепловая карта</a>
-        </nav>
-      </header>
-
       <div class="calendar-fullscreen">
         <div id="economicCalendarWidget"></div>
 
@@ -99,8 +73,5 @@
         </script>
       </div>
     </div>
-
-    <script src="/static/script.js"></script>
-    <script src="/static/nav.js"></script>
   </body>
 </html>

--- a/app/static/news.html
+++ b/app/static/news.html
@@ -82,14 +82,6 @@
         return list.map((item) => `<span class="news-chip">${escapeHtml(item)}</span>`).join("");
       }
 
-      function imageSourceLabel(item) {
-        const source = String(item.image_source || "").toLowerCase();
-        if (source === "source") return "Изображение из источника";
-        if (source === "web_search") return "Изображение по теме";
-        if (source === "generated") return "AI-иллюстрация";
-        return "";
-      }
-
       function imageHtml(item, big = false) {
         const wrapClass = big ? "news-image-wrap news-image-wrap--big" : "news-image-wrap";
         return `
@@ -107,15 +99,11 @@
       function renderExpanded(item) {
         const title = item.title_ru || item.title || "Новость без заголовка";
         const fullText = item.full_text_ru || item.long_story_ru || item.summary || "Описание недоступно.";
-        const imageLabel = imageSourceLabel(item);
         newsModalBody.innerHTML = `
           ${imageHtml(item, true)}
           <p class="news-card__eyebrow">Источник: ${escapeHtml(item.source || "Источник")} · ${formatDate(item.published_at)}</p>
           <h3 class="news-card__title">${escapeHtml(title)}</h3>
-          <div class="news-chip-row">
-            ${buildMarkets(item.markets || item.assets)}
-            ${imageLabel ? `<span class="news-chip">${escapeHtml(imageLabel)}</span>` : ""}
-          </div>
+          <div class="news-chip-row">${buildMarkets(item.markets || item.assets)}</div>
           <section class="news-modal__body"><p class="news-modal__story">${escapeHtml(fullText)}</p></section>
           <div class="news-card__footer">
             ${item.source_url ? `<a class="news-link-button" href="${escapeHtml(item.source_url)}" target="_blank" rel="noopener noreferrer">Открыть источник</a>` : '<span class="news-link-button news-link-button--disabled">Ссылка недоступна</span>'}
@@ -149,7 +137,6 @@
           const card = document.createElement("article");
           card.className = "news-card news-card--compact";
           card.setAttribute("tabindex", "0");
-          const imageLabel = imageSourceLabel(item);
           card.innerHTML = `
             ${imageHtml(item)}
             <div class="news-card__header news-card__header--stacked">
@@ -159,7 +146,7 @@
             <section class="news-detail-box"><h4>Коротко</h4><p class="news-card__text">${escapeHtml(item.preview_ru || item.summary || "Описание недоступно.")}</p></section>
             <div class="news-card__assets">
               <span class="news-label">Рынки под прицелом</span>
-              <div class="news-chip-row">${buildMarkets(item.markets)}${imageLabel ? `<span class="news-chip">${escapeHtml(imageLabel)}</span>` : ""}</div>
+              <div class="news-chip-row">${buildMarkets(item.markets)}</div>
             </div>
             <div class="news-card__footer">
               <button class="news-link-button" type="button">Читать разбор</button>


### PR DESCRIPTION
### Motivation
- Обеспечить использование только реальных OHLC-свечей от TwelveData без синтетики или случайных данных.\
- Ясно отделить прокси-метрики от реальных рыночных данных, чтобы фронтенд и пользователи не путали их с live-цена.\
- Сделать страницу календаря Tradays полноценной и читаемой (fullscreen) без боковых fallback-блоков.\
- Повысить качество показа изображений новостей, извлекая картинки со страницы статьи, когда RSS не содержит изображение.

### Description
- Перевёл получение свечей в `fetch_candles` на строгий real-only режим: используем только TwelveData + последний успешный кеш (`CANDLE_CACHE`), удалён Stooq fallback, добавлено поле диагностики `raw_error` в ответы.\
- Обновил преобразования символов и интервалов: `to_twelvedata_symbol` сохраняет `XAUUSD -> XAU/USD`, а `to_td_interval` поддерживает `M1/M5/M15/M30/H1/H4/D1/W1/MN` с дефолтом `15min`.\
- Добавил ясность метрик: в `api_signals`, `build_signal`, `get_candles_with_markup` и `empty_signal` появились поля `metric_status` и `metric_warning_ru` (техническое предупреждение о proxy), при этом `data_status` оставлен для состояния рыночных данных, а REST-quote fallback теперь маркируется как `delayed`.\
- Внёс правки в страницу календаря `app/static/calendar.html`, убрал лишние элементы и оформил контейнер под полный экран, оставив точный Tradays widget snippet и авторский блок.\
- Улучшил pipeline изображений новостей в `app/services/news_service.py`: добавлен `extract_article_page_image` (парсинг `og:image` / `twitter:image` / `og:image:secure_url`), обновлён `_resolve_news_image` с приоритетом RSS → source page → web search → generated → placeholder и кешированием по `source_url`, а значения `image_source` теперь включают `source_rss` / `source_page` / `web_search` / `generated` / `placeholder`.\
- Минимальные фронтенд-правки в `app/static/news.html`, чтобы не показывать пользователю технические метки источника картинки и оставить аккуратный modal с одним длинным текстом и изображением (fallback-градиент при ошибке загрузки сохранён).

### Testing
- Запустил `python -m py_compile app/main.py app/services/news_service.py`, компиляция прошла успешно.\
- Выполнил smoke-проверки в окружении: `to_twelvedata_symbol('XAUUSD')` вернул `XAU/USD` и `to_td_interval('M30')` вернул `30min`, оба теста успешны.\
- Вызов `api_debug_candles('GBPUSD','M15')` вернул ожидаемый контракт полей (включая `raw_error`), тест выполнен успешно; в текущем окружении без валидного `TWELVEDATA_API_KEY` количество свечей равно 0, что ожидаемо при отсутствии доступа к TwelveData.\
- Вызов `api_canonical_chart('GBPUSD','M15')` и связанные проверки контрактов прошли (endpoint стабилен), однако реальные свечи в CI-шелле пусты из-за отсутствия TwelveData-ключа, поведение соответствует требований: не генерируем фейковые свечи.\
- Проверка `/api/signals` показала наличие `metric_status`/`metric_warning_ru` в полезной нагрузке, тест успешен.\
- Вызов `fetch_public_news(limit=1)` возвратил `image_url` и `image_source` = `source_page` в моём прогоне, проверка успешна и демонстрирует извлечение картинки со страницы источника.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f9373d7083318ad90e64f5929609)