### PR TITLE
Добавить навигацию на полноэкранной странице календаря

### DIFF
--- a/app/static/calendar.html
+++ b/app/static/calendar.html
@@ -14,6 +14,47 @@
       body[data-page="calendar"] {
         min-height: 100vh;
         overflow: hidden;
+        background: #020617;
+      }
+
+      .calendar-top-nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 52px;
+        z-index: 50;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 14px;
+        background: rgba(2, 8, 23, 0.92);
+        border-bottom: 1px solid rgba(95, 156, 230, 0.28);
+        backdrop-filter: blur(10px);
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+
+      .calendar-top-nav a {
+        color: #dbeeff;
+        text-decoration: none;
+        font-weight: 800;
+        font-size: 13px;
+        padding: 8px 12px;
+        border-radius: 999px;
+        border: 1px solid rgba(95, 156, 230, 0.28);
+        background: rgba(10, 31, 58, 0.75);
+      }
+
+      .calendar-top-nav a:hover,
+      .calendar-top-nav a.is-active {
+        color: #ffffff;
+        border-color: rgba(69, 202, 255, 0.75);
+        background: linear-gradient(
+          135deg,
+          rgba(28, 80, 150, 0.95),
+          rgba(10, 31, 58, 0.95)
+        );
       }
 
       body[data-page="calendar"] .page-shell {
@@ -26,7 +67,10 @@
 
       .calendar-fullscreen {
         position: fixed;
-        inset: 0;
+        top: 52px;
+        left: 0;
+        right: 0;
+        bottom: 0;
         background: #020617;
         display: flex;
         flex-direction: column;
@@ -50,6 +94,14 @@
   </head>
   <body data-page="calendar">
     <div class="page-shell">
+      <nav class="calendar-top-nav">
+        <a href="/">Главная</a>
+        <a href="/ideas">Идеи</a>
+        <a href="/news">Новости</a>
+        <a class="is-active" href="/calendar">Календарь</a>
+        <a href="/heatmap/page">Тепловая карта</a>
+      </nav>
+
       <div class="calendar-fullscreen">
         <div id="economicCalendarWidget"></div>
 


### PR DESCRIPTION
### Motivation
- Восстановить верхнюю навигацию на странице `/calendar` без нарушения полноэкранного вида виджета Tradays.

### Description
- Добавлена разметка навигации в `app/static/calendar.html` перед `.calendar-fullscreen` с ссылками `Главная`, `Идеи`, `Новости`, `Календарь` (active) и `Тепловая карта`.
- Внутренний `<style>` в том же файле обновлён: добавлен тёмный фон страницы, стили `.calendar-top-nav` (фиксированная позиция, высота `52px`, кнопки, hover/active) и мобильная горизонтальная прокрутка (`overflow-x: auto; white-space: nowrap;`).
- Изменён стиль `.calendar-fullscreen` чтобы начинаться с `top: 52px` и занимать оставшееся пространство экрана, при этом `#economicCalendarWidget` оставлен с `flex: 1; width: 100%; min-height: 0;` для корректного заполнения области.
- Скрипт и контейнер виджета Tradays не удалялись и остались без изменений.

### Testing
- Выполнен `git diff -- app/static/calendar.html` для проверки дельты и он прошёл успешно.
- Файл добавлен и зафиксирован через `git commit -m "Add navigation to fullscreen calendar safely"` и коммит прошёл успешно.
- Содержимое файла проверено командой `nl -ba app/static/calendar.html` для подтверждения вставки навигации и стилей, проверка выполнена успешно.
- Проверка наличия `playwright` через Python (`importlib.util.find_spec('playwright')`) вернула `False`, поэтому автоматические визуальные скриншоты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1021be5e083319f1a15883b7a5978)