### PR TITLE
Автоархивация идей при достижении TP/SL по реальной цене

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -534,23 +534,33 @@ def build_signal(symbol: str) -> dict[str, Any]:
             "htf_reason": decision.reason,
         }
 
+    auto_close_allowed = is_real_market_price_available(price_data)
     runtime_status, runtime_text, runtime_color, close_result = get_runtime_status(
         price=current_price,
         entry=safe_float(trade.get("entry")),
         sl=safe_float(trade.get("sl")),
         tp=safe_float(trade.get("tp")),
         signal=trade.get("signal"),
+        allow_close=auto_close_allowed,
     )
 
-    if close_result in {"TP", "SL"}:
+    auto_close_eval = evaluate_trade_result_by_price(trade=trade, current_price=current_price)
+
+    if auto_close_allowed and auto_close_eval.get("is_closed"):
+        close_result = auto_close_eval.get("result")
         archived = {
             **trade,
             "current_price": current_price,
             "result": close_result,
-            "runtime_status": runtime_status,
-            "runtime_text": runtime_text,
+            "status": "CLOSED_TP" if close_result == "TP" else "CLOSED_SL",
+            "runtime_status": "CLOSED_TP" if close_result == "TP" else "CLOSED_SL",
+            "runtime_text": auto_close_eval.get("reason_ru"),
             "runtime_color": runtime_color,
+            "close_reason": auto_close_eval.get("close_reason"),
+            "close_reason_ru": auto_close_eval.get("reason_ru"),
             "closed_at": now_utc(),
+            "closed_price": current_price,
+            "is_archived": True,
         }
 
         move_to_archive(archived)
@@ -559,6 +569,10 @@ def build_signal(symbol: str) -> dict[str, Any]:
         save_json(ACTIVE_FILE, active)
 
         trade = archived
+        runtime_status = str(archived.get("runtime_status") or runtime_status)
+        runtime_text = str(archived.get("runtime_text") or runtime_text)
+    elif not auto_close_allowed and trade.get("signal") in {"BUY", "SELL"}:
+        trade["auto_close_skipped_ru"] = "Автозакрытие пропущено: нет реальной рыночной цены."
 
     summary = build_summary(
         symbol=symbol,
@@ -614,6 +628,7 @@ def build_signal(symbol: str) -> dict[str, Any]:
         "full_text": summary,
         "compact_summary": summary,
         "warning_ru": human_price_warning(price_data),
+        "auto_close_skipped_ru": trade.get("auto_close_skipped_ru"),
         "setup_quality": "HTF_CONTEXT_REAL_CANDLES_ONLY",
         "risk_filter": "MN_W1_D1_H4_H1_M15_ALIGNMENT",
         "trade_permission": decision.allowed and runtime_status == "ACTIVE",
@@ -1213,17 +1228,84 @@ def build_market_structure(
     }
 
 
-def get_runtime_status(price, entry, sl, tp, signal):
+def evaluate_trade_result_by_price(trade: dict[str, Any], current_price: float | None) -> dict[str, Any]:
+    if current_price is None:
+        return {
+            "is_closed": False,
+            "result": None,
+            "reason_ru": "Нет реальной текущей цены — идея не закрывается автоматически.",
+        }
+
+    signal = str(trade.get("signal") or trade.get("final_signal") or "").upper()
+    entry = safe_float(trade.get("entry") or trade.get("entry_price"))
+    sl = safe_float(trade.get("sl") or trade.get("stop_loss"))
+    tp = safe_float(trade.get("tp") or trade.get("take_profit"))
+
+    if signal not in {"BUY", "SELL"}:
+        return {"is_closed": False, "result": None, "reason_ru": "Идея не является BUY/SELL."}
+
+    if entry is None or sl is None or tp is None:
+        return {
+            "is_closed": False,
+            "result": None,
+            "reason_ru": "Недостаточно уровней Entry/SL/TP для автоматического закрытия.",
+        }
+
+    if signal == "BUY":
+        if current_price >= tp:
+            return {
+                "is_closed": True,
+                "result": "TP",
+                "close_reason": "take_profit_hit",
+                "reason_ru": "TP достигнут по реальной рыночной цене.",
+            }
+        if current_price <= sl:
+            return {
+                "is_closed": True,
+                "result": "SL",
+                "close_reason": "stop_loss_hit",
+                "reason_ru": "SL достигнут по реальной рыночной цене.",
+            }
+
+    if signal == "SELL":
+        if current_price <= tp:
+            return {
+                "is_closed": True,
+                "result": "TP",
+                "close_reason": "take_profit_hit",
+                "reason_ru": "TP достигнут по реальной рыночной цене.",
+            }
+        if current_price >= sl:
+            return {
+                "is_closed": True,
+                "result": "SL",
+                "close_reason": "stop_loss_hit",
+                "reason_ru": "SL достигнут по реальной рыночной цене.",
+            }
+
+    return {
+        "is_closed": False,
+        "result": None,
+        "reason_ru": "Цена ещё не достигла TP или SL.",
+    }
+
+
+def is_real_market_price_available(price_data: dict[str, Any]) -> bool:
+    status = str(price_data.get("data_status") or "").lower()
+    return status in {"real", "delayed"} or bool(price_data.get("is_live_market_data") is True)
+
+
+def get_runtime_status(price, entry, sl, tp, signal, allow_close: bool = True):
     if price is None or entry is None:
         return "WAIT", "Нет текущей цены.", "violet", None
 
-    if signal == "BUY":
+    if allow_close and signal == "BUY":
         if tp is not None and price >= tp:
             return "CLOSED_TP", "TP достигнут. Идея закрыта в плюс и перенесена в архив.", "blue", "TP"
         if sl is not None and price <= sl:
             return "CLOSED_SL", "SL достигнут. Идея закрыта в минус и перенесена в архив.", "red", "SL"
 
-    if signal == "SELL":
+    if allow_close and signal == "SELL":
         if tp is not None and price <= tp:
             return "CLOSED_TP", "TP достигнут. Идея закрыта в плюс и перенесена в архив.", "blue", "TP"
         if sl is not None and price >= sl:
@@ -1426,7 +1508,10 @@ def get_price(symbol: str) -> dict[str, Any]:
 def move_to_archive(trade: dict[str, Any]) -> None:
     archive = load_json(ARCHIVE_FILE)
 
-    if any(x.get("id") == trade.get("id") and x.get("result") == trade.get("result") for x in archive):
+    existing_index = next((idx for idx, item in enumerate(archive) if item.get("id") == trade.get("id")), None)
+    if existing_index is not None:
+        archive[existing_index] = {**archive[existing_index], **trade}
+        save_json(ARCHIVE_FILE, archive)
         return
 
     archive.append(trade)

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -274,6 +274,13 @@
       line-height: 1.55;
     }
 
+    .archive-meta {
+      margin-top: 8px;
+      font-size: 12px;
+      color: #95afca;
+      line-height: 1.5;
+    }
+
     .levels,
     .modal-grid {
       display: grid;
@@ -804,7 +811,9 @@
     function isArchivedIdea(idea) {
       const status = String(idea?.status || "").toLowerCase();
       const isClosedByStatus = ["tp_hit", "sl_hit", "archived", "closed", "expired"].some((x) => status.includes(x));
-      return isClosedByStatus || isIdeaExpired(idea);
+      const result = String(idea?.result || "").toUpperCase();
+      const isClosedByResult = ["TP", "SL", "EXPIRED"].includes(result);
+      return Boolean(idea?.is_archived) || isClosedByStatus || isClosedByResult || isIdeaExpired(idea);
     }
 
     function renderArchive(archivedIdeas) {
@@ -847,6 +856,7 @@
       const summary = pickText(idea);
       const statusView = resolveIdeaStatusView(idea);
       const statusReason = buildIdeaStatusReason(idea, statusView);
+      const closeMeta = buildCloseMeta(idea);
 
       card.className = "card";
       card.dataset.ideaId = id;
@@ -872,6 +882,7 @@
           <span class="badge ${statusView.badgeClass}">${escapeHtml(statusView.icon + " " + statusView.label)}</span>
         </div>
         <div class="status-reason">${escapeHtml(statusReason)}</div>
+        ${closeMeta}
 
         <div class="levels">
           <div class="level entry">ENTRY<br>${formatValue(idea.entry || idea.entry_price || idea.entry_zone)}</div>
@@ -1680,23 +1691,32 @@
 
     function resolveIdeaStatusView(idea) {
       const rawStatus = String(idea.status || "").trim().toLowerCase();
+      const result = String(idea.result || "").trim().toUpperCase();
       const entryDeviationPct = toNumber(idea.entry_deviation_pct ?? idea.entryDeviationPct);
       const hasMissedEntry = Number.isFinite(entryDeviationPct) && entryDeviationPct > 0.35;
 
-      if (rawStatus === "tp_hit") {
+      if (rawStatus === "closed_tp" || rawStatus === "tp_hit" || result === "TP") {
         return {
-          code: "tp_hit",
+          code: "closed_tp",
           label: "Завершена (TP достигнут)",
           icon: "🎯",
           badgeClass: "badge-status-tp",
         };
       }
-      if (rawStatus === "sl_hit") {
+      if (rawStatus === "closed_sl" || rawStatus === "sl_hit" || result === "SL") {
         return {
-          code: "sl_hit",
+          code: "closed_sl",
           label: "Завершена (SL сработал)",
           icon: "🛑",
           badgeClass: "badge-status-sl",
+        };
+      }
+      if (rawStatus === "expired" || result === "EXPIRED") {
+        return {
+          code: "expired",
+          label: "Истекла по времени",
+          icon: "⌛",
+          badgeClass: "badge-status-wait",
         };
       }
       if (["active", "triggered"].includes(rawStatus) && hasMissedEntry) {
@@ -1737,16 +1757,43 @@
       const fallbackReason = String(idea.meaningful_update_reason || idea.update_summary || "").trim();
       if (fallbackReason) return fallbackReason;
 
-      if (statusView.code === "tp_hit") {
+      if (statusView.code === "tp_hit" || statusView.code === "closed_tp") {
         return "Цена достигла целевой зоны ликвидности (TP), поэтому идея закрыта с выполнением сценария.";
       }
-      if (statusView.code === "sl_hit") {
+      if (statusView.code === "sl_hit" || statusView.code === "closed_sl") {
         return "Рынок нарушил уровень инвалидации (SL), сценарий потерял актуальность и идея закрыта.";
+      }
+      if (statusView.code === "expired") {
+        return "Идея истекла по времени и закрыта без фиксации TP/SL результата.";
       }
       if (statusView.label.includes("момент упущен")) {
         return "Сигнал остаётся направленным, но цена уже заметно ушла от оптимальной точки входа. Лучше ждать новый откат или переразметку.";
       }
       return "Сценарий остаётся в работе: ждём подтверждение структуры и соблюдаем ограничения по риску.";
+    }
+
+    function buildCloseMeta(idea) {
+      if (!isArchivedIdea(idea)) return "";
+      const result = String(idea.result || "").toUpperCase();
+      const resultClass = result === "TP" ? "badge-status-tp" : result === "SL" ? "badge-status-sl" : "badge-status-wait";
+      const closedPrice = formatValue(idea.closed_price ?? idea.current_price);
+      const closedAt = formatDateTime(idea.closed_at);
+      const closeReason = String(idea.close_reason_ru || idea.runtime_text || "").trim() || "Причина закрытия не указана.";
+      return `
+        <div class="archive-meta">
+          <div><span class="badge ${resultClass}">${escapeHtml(result || "CLOSED")}</span></div>
+          <div>Цена закрытия: ${escapeHtml(closedPrice)}</div>
+          <div>Время закрытия: ${escapeHtml(closedAt)}</div>
+          <div>Причина: ${escapeHtml(closeReason)}</div>
+        </div>
+      `;
+    }
+
+    function formatDateTime(value) {
+      if (!value) return "—";
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return String(value);
+      return date.toLocaleString("ru-RU", { hour12: false });
     }
 
     function toNumber(value) {

--- a/tests/test_auto_archive_logic.py
+++ b/tests/test_auto_archive_logic.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app import main
+
+
+def test_evaluate_trade_result_by_price_buy_and_sell() -> None:
+    buy_trade = {"signal": "BUY", "entry": 1.1, "sl": 1.09, "tp": 1.12}
+    sell_trade = {"signal": "SELL", "entry": 1.1, "sl": 1.11, "tp": 1.08}
+
+    buy_tp = main.evaluate_trade_result_by_price(buy_trade, 1.1201)
+    buy_sl = main.evaluate_trade_result_by_price(buy_trade, 1.0899)
+    sell_tp = main.evaluate_trade_result_by_price(sell_trade, 1.0799)
+    sell_sl = main.evaluate_trade_result_by_price(sell_trade, 1.1101)
+
+    assert buy_tp["is_closed"] is True and buy_tp["result"] == "TP"
+    assert buy_sl["is_closed"] is True and buy_sl["result"] == "SL"
+    assert sell_tp["is_closed"] is True and sell_tp["result"] == "TP"
+    assert sell_sl["is_closed"] is True and sell_sl["result"] == "SL"
+
+
+def test_evaluate_trade_result_by_price_skips_when_price_missing_or_wait() -> None:
+    wait_trade = {"signal": "WAIT", "entry": 1.1, "sl": 1.09, "tp": 1.12}
+    no_price = main.evaluate_trade_result_by_price(wait_trade, None)
+    wait_result = main.evaluate_trade_result_by_price(wait_trade, 1.12)
+
+    assert no_price["is_closed"] is False
+    assert "не закрывается автоматически" in no_price["reason_ru"].lower()
+    assert wait_result["is_closed"] is False
+    assert "не является buy/sell" in wait_result["reason_ru"].lower()
+
+
+def test_move_to_archive_updates_existing_by_id(tmp_path: Path, monkeypatch) -> None:
+    archive_file = tmp_path / "archive.json"
+    monkeypatch.setattr(main, "ARCHIVE_FILE", archive_file)
+
+    first = {"id": "EURUSD-BUY", "result": "TP", "status": "CLOSED_TP"}
+    second = {"id": "EURUSD-BUY", "result": "SL", "status": "CLOSED_SL", "closed_price": 1.1}
+
+    main.move_to_archive(first)
+    main.move_to_archive(second)
+
+    archive = main.load_json(archive_file)
+    assert len(archive) == 1
+    assert archive[0]["id"] == "EURUSD-BUY"
+    assert archive[0]["result"] == "SL"
+    assert archive[0]["closed_price"] == 1.1
+
+
+def test_is_real_market_price_available_accepts_real_delayed_or_live() -> None:
+    assert main.is_real_market_price_available({"data_status": "real"}) is True
+    assert main.is_real_market_price_available({"data_status": "delayed"}) is True
+    assert main.is_real_market_price_available({"data_status": "unavailable", "is_live_market_data": True}) is True
+    assert main.is_real_market_price_available({"data_status": "unavailable", "is_live_market_data": False}) is False


### PR DESCRIPTION
### Motivation
- Автоматически переводить активные идеи в архив только когда реальная рыночная цена подтверждает выполнение TP/SL, а не по времени или прокси-метрике.
- Исключить ложные автозакрытия при отсутствии live/real/delayed котировки и избежать дублирования записей в архиве.

### Description
- Добавлена функция `evaluate_trade_result_by_price(trade, current_price)` для детерминированной оценки результата сделки по реальной цене (TP/SL) с русскими сообщениями причин закрытия.
- Добавлен helper `is_real_market_price_available(price_data)` и использован как gate в `build_signal(...)`, чтобы автозакрытие происходило только при `data_status` в `{"real","delayed"}` или при `is_live_market_data == True`.
- Интегрировано безопасное автоперенесение в `build_signal`: при фактическом TP/SL идея удаляется из active, добавляется в архив с сохранением полей и дополнительными метаданными `status`, `result`, `close_reason`, `close_reason_ru`, `closed_at`, `closed_price`, `is_archived`; при отсутствии реальной цены добавляется `auto_close_skipped_ru` и идея остаётся активной.
- Обновлён `move_to_archive(...)` для upsert по `id` (обновление существующей записи вместо дублирования).
- Обновлён фронтенд в `app/static/ideas.html` для корректного распознавания и отображения архивных карт: учитывается `is_archived` и `result`, показываются бейдж результата, цена/время/причина закрытия и сохранены старые фильтры/визуальная дифференциация.
- Добавлены юнит-тесты в `tests/test_auto_archive_logic.py` для `evaluate_trade_result_by_price`, `is_real_market_price_available` и поведения `move_to_archive` при обновлении записи.

### Testing
- Запущено `pytest -q tests/test_auto_archive_logic.py`, все тесты прошли: 4 passed (с предупреждениями о deprecation от FastAPI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1049c99248331bcf10a1a9c16d8c0)