### PR TITLE
Исправить видимость графика в модалке идей (без изменений логики)

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -359,6 +359,12 @@
       box-shadow: none;
     }
 
+    .ideas-modal__content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
     .modal-head,
     .ideas-modal__header {
       display: flex;
@@ -424,6 +430,22 @@
       gap: 0;
     }
 
+    .ideas-modal__top {
+      flex: 0 0 auto;
+      max-height: 45vh;
+      overflow-y: auto;
+      min-height: 0;
+      padding-right: 4px;
+    }
+
+    .ideas-modal__bottom {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
     .chart-wrap {
       margin: 12px 0 0;
       border: 1px solid rgba(95,145,203,.42);
@@ -484,7 +506,14 @@
 
     .ideas-modal__chart {
       flex: 1;
-      min-height: 0;
+      min-height: 300px;
+      width: 100%;
+    }
+
+    .ideas-modal__chart canvas,
+    .ideas-modal__chart svg {
+      width: 100% !important;
+      height: 100% !important;
     }
 
     .chart-note {
@@ -579,6 +608,12 @@
       .hero { flex-direction: column; }
       .grid, .stats, .modal-grid, .legend-grid, .ideas-archive__list { grid-template-columns: 1fr; }
       .chart { height: 390px; }
+    }
+
+    @media (max-width: 768px) {
+      .ideas-modal__top {
+        max-height: 50vh;
+      }
     }
   </style>
 </head>
@@ -903,42 +938,45 @@
       modalSubtitle.textContent = pickText(idea);
 
       modalContent.innerHTML = `
-        <div class="modal-grid">
-          <div class="level entry">ENTRY<br>${formatValue(idea.entry || idea.entry_price || idea.entry_zone)}</div>
-          <div class="level sl">SL<br>${formatValue(idea.stop_loss || idea.stopLoss || idea.sl)}</div>
-          <div class="level tp">TP<br>${formatValue(idea.take_profit || idea.takeProfit || idea.tp)}</div>
-          <div class="level rr">Confidence<br>${numberOrDash(idea.final_confidence ?? idea.confidence)}%</div>
+        <div class="ideas-modal__top">
+          <div class="modal-grid">
+            <div class="level entry">ENTRY<br>${formatValue(idea.entry || idea.entry_price || idea.entry_zone)}</div>
+            <div class="level sl">SL<br>${formatValue(idea.stop_loss || idea.stopLoss || idea.sl)}</div>
+            <div class="level tp">TP<br>${formatValue(idea.take_profit || idea.takeProfit || idea.tp)}</div>
+            <div class="level rr">Confidence<br>${numberOrDash(idea.final_confidence ?? idea.confidence)}%</div>
+          </div>
+
+          <div class="modal-section-title">Основная идея</div>
+          <div class="box modal-text">${escapeHtml(pickText(idea))}</div>
+          ${renderFundamentalContext(idea)}
+          <div class="status-reason">${escapeHtml(statusReason)}</div>
+
+          <div class="modal-section-title">График и разметка</div>
+          <div class="legend-grid">
+              <div class="legend-item" style="color:var(--yellow)">ENTRY — точка входа</div>
+              <div class="legend-item" style="color:var(--red)">SL — отмена идеи</div>
+              <div class="legend-item" style="color:var(--green)">TP — цель идеи</div>
+              <div class="legend-item" style="color:var(--violet)">OB — ордерблок</div>
+              <div class="legend-item" style="color:#ff4d6d">Breaker — пробитый OB</div>
+              <div class="legend-item" style="color:var(--orange)">FVG — имбаланс</div>
+              <div class="legend-item" style="color:var(--blue)">Liquidity — ликвидность</div>
+              <div class="legend-item" style="color:var(--pattern)">Pattern — графический паттерн</div>
+          </div>
         </div>
 
-        <div class="modal-section-title">Основная идея</div>
-        <div class="box modal-text">${escapeHtml(pickText(idea))}</div>
-        ${renderFundamentalContext(idea)}
-        <div class="status-reason">${escapeHtml(statusReason)}</div>
+        <div class="ideas-modal__bottom">
+          <div class="chart-wrap">
+            <div class="chart-toolbar">
+              <button class="tf-btn" data-tf="M15">M15</button>
+              <button class="tf-btn" data-tf="H1">H1</button>
+              <button class="tf-btn" data-tf="H4">H4</button>
+            </div>
 
-        <div class="modal-section-title">График и разметка</div>
+            <div id="ideaChart" class="chart ideas-modal__chart"></div>
 
-        <div class="chart-wrap">
-          <div class="chart-toolbar">
-            <button class="tf-btn" data-tf="M15">M15</button>
-            <button class="tf-btn" data-tf="H1">H1</button>
-            <button class="tf-btn" data-tf="H4">H4</button>
-          </div>
-
-          <div class="legend-grid">
-            <div class="legend-item" style="color:var(--yellow)">ENTRY — точка входа</div>
-            <div class="legend-item" style="color:var(--red)">SL — отмена идеи</div>
-            <div class="legend-item" style="color:var(--green)">TP — цель идеи</div>
-            <div class="legend-item" style="color:var(--violet)">OB — ордерблок</div>
-            <div class="legend-item" style="color:#ff4d6d">Breaker — пробитый OB</div>
-            <div class="legend-item" style="color:var(--orange)">FVG — имбаланс</div>
-            <div class="legend-item" style="color:var(--blue)">Liquidity — ликвидность</div>
-            <div class="legend-item" style="color:var(--pattern)">Pattern — графический паттерн</div>
-          </div>
-
-          <div id="ideaChart" class="chart ideas-modal__chart"></div>
-
-          <div class="chart-note" id="chartNote">
-            Разметка строится только по реальным свечам. Фейковые свечи отключены.
+            <div class="chart-note" id="chartNote">
+              Разметка строится только по реальным свечам. Фейковые свечи отключены.
+            </div>
           </div>
         </div>
       `;


### PR DESCRIPTION
### Motivation
- Исправить поведение модального окна идей: текстовые блоки не должны выталкивать график за пределы экрана, модалка должна занимать весь экран, а график — доступную нижнюю часть.

### Description
- Добавлен вертикальный flex-контейнер `ideas-modal__content` и переработана внутренняя структура на два блока: `ideas-modal__top` (инфо, скролл) и `ideas-modal__bottom` (график). 
- Ограничена высота верхнего блока через `max-height: 45vh` с прокруткой и мобильной корректировкой `max-height: 50vh` для `@media (max-width: 768px)`.
- Нижний блок и контейнер графика сделаны растягиваемыми (`flex: 1`, `min-height: 300px`, `width: 100%`), а `canvas`/`svg` внутри принудительно установлены в `width: 100%` и `height: 100%` для корректной отрисовки чарта.
- Сохранены имена классов/идентификаторов, используемых JS-рендерером (`chart`, `ideas-modal__chart`, `#ideaChart`), логика сигналов/свечей/разметки не изменялась.

### Testing
- Выполнен поиск в файле `app/static/ideas.html` для подтверждения присутствия новых блоков и стилей (`rg`), проверка успешна.
- Запуск `pytest tests/api/test_ideas_api.py` завершился ошибкой на этапе сбора тестов из-за `ImportError: cannot import name 'canonical_market_service' from 'app.main'`, ошибка не связана с внесёнными изменениями в CSS/HTML и тест не прошёл.
- Попытка визуальной проверки через Playwright: скачивание браузеров (`npx playwright install chromium`) прошло успешно, но выполнение Node-скрипта со `playwright` не удалось из-за отсутствия Node-пакета `playwright`, поэтому полноценный автоматический скриншот не был получен.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f104e354d0833196c4d9988309cfbd)