### PR TITLE
Добавить блок версии и краткий changelog внизу главной страницы

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -72,5 +72,16 @@
 
     <script src="/static/landing.js"></script>
     <script src="/static/nav.js"></script>
+    <div class="app-version-block">
+      <div class="app-version-line">
+        Версия: <span id="appVersion">v1.0.0</span>
+      </div>
+
+      <div class="app-changelog">
+        <div>• Добавлен календарь с реальными событиями</div>
+        <div>• Улучшена работа новостей и изображений</div>
+        <div>• Исправлено получение реальных свечей</div>
+      </div>
+    </div>
   </body>
 </html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2028,6 +2028,28 @@ a { color: inherit; }
   50% { box-shadow: 0 0 20px rgba(139, 92, 246, 0.35), inset 0 0 20px rgba(76, 201, 240, 0.2); }
 }
 
+.app-version-block {
+  margin-top: 40px;
+  padding: 12px 16px;
+  font-size: 11px;
+  opacity: 0.6;
+  color: rgba(200, 220, 255, 0.6);
+  text-align: center;
+}
+
+.app-version-line {
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.app-changelog div {
+  margin: 2px 0;
+}
+
+.app-version-block:hover {
+  opacity: 0.85;
+}
+
 @media (max-width: 860px) {
   .calendar-guide-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Показать текущую версию и краткую историю изменений внизу главной страницы в малозаметном стиле, не меняя маршруты, логику бекенда и страницу «Идеи». 

### Description
- Добавлен HTML-блок перед закрывающим `</body>` в `app/static/index.html` с `id="appVersion"` и кратким списком изменений, а также добавлены ненавязчивые стили в `app/static/styles.css` для компактного отображения. 

### Testing
- Подтверждено с помощью `git diff`/`git status`, изменения ограничены `app/static/index.html` и `app/static/styles.css`, выполнен `git commit` и проверены файлы через `nl`/просмотр, все операции выполнены успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10877ea648331add0e16cf654b395)