### PR TITLE
Добавить панель статистики идей справа в шапке

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -51,6 +51,13 @@
       margin-bottom: 22px;
     }
 
+    .ideas-page-header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 420px;
+      gap: 24px;
+      align-items: start;
+    }
+
     h1 {
       margin: 0 0 8px;
       font-size: clamp(30px, 3.2vw, 46px);
@@ -82,6 +89,71 @@
       gap: 12px;
       flex-wrap: wrap;
       margin: 22px 0;
+    }
+
+    .ideas-performance-panel {
+      margin-top: 18px;
+      padding: 14px;
+      border-radius: 18px;
+      background:
+        radial-gradient(circle at 20% 0%, rgba(49,245,157,.18), transparent 35%),
+        linear-gradient(145deg, rgba(13,42,76,.92), rgba(5,18,34,.96));
+      border: 1px solid rgba(95,156,230,.35);
+      box-shadow: 0 18px 45px rgba(0,0,0,.28);
+    }
+
+    .ideas-performance-panel__title {
+      margin-bottom: 10px;
+      color: rgba(219,238,255,.9);
+      font-size: 12px;
+      font-weight: 950;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+    }
+
+    .ideas-performance-grid {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 8px;
+    }
+
+    .ideas-performance-item {
+      min-height: 54px;
+      padding: 8px 10px;
+      border-radius: 14px;
+      background: rgba(3,14,28,.72);
+      border: 1px solid rgba(95,156,230,.25);
+    }
+
+    .ideas-performance-item span {
+      display: block;
+      margin-bottom: 4px;
+      color: rgba(185,214,248,.72);
+      font-size: 10px;
+      font-weight: 900;
+      text-transform: uppercase;
+    }
+
+    .ideas-performance-item strong {
+      color: #f4f8ff;
+      font-size: 20px;
+      font-weight: 950;
+    }
+
+    .ideas-performance-item--tp strong {
+      color: #31f59d;
+    }
+
+    .ideas-performance-item--sl strong {
+      color: #ff5f7a;
+    }
+
+    .ideas-performance-item--expired strong {
+      color: #ffd84d;
+    }
+
+    .ideas-performance-item--winrate strong {
+      color: #45caff;
     }
 
     .stats,
@@ -610,6 +682,22 @@
       .legend-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     }
 
+    @media (max-width: 1180px) {
+      .ideas-page-header {
+        grid-template-columns: 1fr;
+      }
+
+      .ideas-performance-panel {
+        margin-top: 10px;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .ideas-performance-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
     @media (max-width: 760px) {
       .page { padding: 22px 14px 44px; }
       .hero { flex-direction: column; }
@@ -627,27 +715,57 @@
 
 <body>
   <main class="page">
-    <header class="hero">
-      <div>
-        <h1>AI-идеи по рынку</h1>
-        <div class="subtitle">
-          Entry / SL / TP фиксируются. График строится только по реальным свечам backend. Фейковые свечи отключены.
+    <header class="ideas-page-header">
+      <div class="ideas-page-header__main">
+        <div class="hero">
+          <div>
+            <h1>AI-идеи по рынку</h1>
+            <div class="subtitle">
+              Entry / SL / TP фиксируются. График строится только по реальным свечам backend. Фейковые свечи отключены.
+            </div>
+          </div>
+          <a class="home-link" href="/">На главную</a>
         </div>
-      </div>
-      <a class="home-link" href="/">На главную</a>
-    </header>
 
-    <section class="controls">
-      <select id="pairFilter"><option value="ALL">Все пары</option></select>
-      <select id="signalFilter">
-        <option value="ALL">Все сигналы</option>
-        <option value="BUY">BUY</option>
-        <option value="SELL">SELL</option>
-        <option value="WAIT">WAIT</option>
-        <option value="CLOSED">Архив</option>
-      </select>
-      <button id="refreshBtn">Обновить</button>
-    </section>
+        <section class="controls">
+          <select id="pairFilter"><option value="ALL">Все пары</option></select>
+          <select id="signalFilter">
+            <option value="ALL">Все сигналы</option>
+            <option value="BUY">BUY</option>
+            <option value="SELL">SELL</option>
+            <option value="WAIT">WAIT</option>
+            <option value="CLOSED">Архив</option>
+          </select>
+          <button id="refreshBtn">Обновить</button>
+        </section>
+      </div>
+
+      <aside class="ideas-performance-panel">
+        <div class="ideas-performance-panel__title">Статистика идей</div>
+        <div class="ideas-performance-grid">
+          <div class="ideas-performance-item ideas-performance-item--tp">
+            <span>Плюс</span>
+            <strong id="ideasTpCount">0</strong>
+          </div>
+          <div class="ideas-performance-item ideas-performance-item--sl">
+            <span>Минус</span>
+            <strong id="ideasSlCount">0</strong>
+          </div>
+          <div class="ideas-performance-item ideas-performance-item--expired">
+            <span>Не отработали</span>
+            <strong id="ideasExpiredCount">0</strong>
+          </div>
+          <div class="ideas-performance-item">
+            <span>Закрыто</span>
+            <strong id="ideasClosedCount">0</strong>
+          </div>
+          <div class="ideas-performance-item ideas-performance-item--winrate">
+            <span>Winrate</span>
+            <strong id="ideasWinrate">0%</strong>
+          </div>
+        </div>
+      </aside>
+    </header>
 
     <section class="stats ideas-stats">
       <div class="stat ideas-stat-card"><div class="stat-label ideas-stat-card__label">BUY</div><div class="stat-value ideas-stat-card__value" id="buyCount">0</div></div>
@@ -880,6 +998,40 @@
       document.getElementById("waitCount").textContent = wait;
       document.getElementById("closedCount").textContent = archive.length;
       document.getElementById("totalCount").textContent = active.length + archive.length;
+      updateIdeasPerformanceStats(archive);
+    }
+
+    function updateIdeasPerformanceStats(archiveItems) {
+      const archive = Array.isArray(archiveItems) ? archiveItems : [];
+
+      const tp = archive.filter((item) =>
+        String(item.result || item.status || "").toUpperCase().includes("TP") ||
+        String(item.close_reason || "").includes("take_profit")
+      ).length;
+
+      const sl = archive.filter((item) =>
+        String(item.result || item.status || "").toUpperCase().includes("SL") ||
+        String(item.close_reason || "").includes("stop_loss")
+      ).length;
+
+      const expired = archive.filter((item) =>
+        String(item.result || item.status || "").toUpperCase().includes("EXPIRED") ||
+        String(item.close_reason || "").includes("expired")
+      ).length;
+
+      const closed = tp + sl + expired;
+      const winrate = tp + sl > 0 ? Math.round((tp / (tp + sl)) * 100) : 0;
+
+      const setText = (id, value) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = String(value);
+      };
+
+      setText("ideasTpCount", tp);
+      setText("ideasSlCount", sl);
+      setText("ideasExpiredCount", expired);
+      setText("ideasClosedCount", closed);
+      setText("ideasWinrate", `${winrate}%`);
     }
 
     function renderCard(idea) {


### PR DESCRIPTION
### Motivation
- Добавить компактный блок производительности идей в правой части верхней зоны страницы, чтобы отображать итоги из архива (Плюс/Минус/Не отработали/Закрыто/Winrate) без изменения существующей логики и маршрутов.

### Description
- В `app/static/ideas.html` обернул верхнюю часть в контейнер `ideas-page-header` с двухколоночным grid и сохранил существующий блок заголовка/фильтров внутри `ideas-page-header__main`.
- Добавил разметку `aside.ideas-performance-panel` с элементами и `id` для `ideasTpCount`, `ideasSlCount`, `ideasExpiredCount`, `ideasClosedCount`, `ideasWinrate` и соответствующие стили и адаптивное поведение.
- Реализовал безопасную JS-функцию `updateIdeasPerformanceStats(archiveItems)` и вызов `updateIdeasPerformanceStats(archive)` из существующей `updateStats()` для заполнения значений на основе уже загруженного архива без новых API-вызовов.
- Изменения ограничены одним файлом и не трогают API, рендер графика, генерацию сигналов или существующие ID/классы карт.

### Testing
- Выполнены статические проверки наличия вставленных идентификаторов и классов командой `rg -n "ideas-page-header|ideas-performance|updateIdeasPerformanceStats|section class=\"controls\"" app/static/ideas.html`, которые подтвердили добавление кода; команда вернула ожидаемые совпадения (успех).
- Проверен diff через `git diff -- app/static/ideas.html` и изменения зафиксированы коммитом с сообщением `Add ideas performance stats panel safely` (успешно).
- В репозитории нет автоматизированных unit-тестов для фронтенда; никаких дополнительных автоматических тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10c93ee9083318d3dba7c17de621b)