### PR TITLE
Добавить реальную тепловую карту валют (без фейковых данных)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,35 @@ BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "static"
 
 SYMBOLS = ["EURUSD", "GBPUSD", "USDJPY", "XAUUSD"]
+HEATMAP_CURRENCIES = ["USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD", "NZD"]
+HEATMAP_PAIRS = [
+    "EURUSD",
+    "GBPUSD",
+    "USDJPY",
+    "USDCHF",
+    "USDCAD",
+    "AUDUSD",
+    "NZDUSD",
+    "EURGBP",
+    "EURJPY",
+    "EURCHF",
+    "EURCAD",
+    "EURAUD",
+    "EURNZD",
+    "GBPJPY",
+    "GBPCHF",
+    "GBPCAD",
+    "GBPAUD",
+    "GBPNZD",
+    "AUDJPY",
+    "AUDCAD",
+    "AUDNZD",
+    "NZDJPY",
+    "NZDCAD",
+    "CADJPY",
+    "CADCHF",
+    "CHFJPY",
+]
 
 TWELVEDATA_API_KEY = os.getenv("TWELVEDATA_API_KEY", "").strip()
 TRADING_ECONOMICS_KEY = os.getenv("TRADING_ECONOMICS_KEY", "").strip()
@@ -366,6 +395,11 @@ def api_calendar():
 @app.get("/heatmap/page", include_in_schema=False)
 def heatmap_page():
     return FileResponse(STATIC_DIR / "heatmap.html")
+
+
+@app.get("/api/heatmap")
+def api_heatmap():
+    return build_currency_heatmap()
 
 
 @app.get("/api/signals")
@@ -1503,6 +1537,140 @@ def get_price(symbol: str) -> dict[str, Any]:
             "data_status": "unavailable",
             "warning_ru": str(exc),
         }
+
+
+def _fetch_twelvedata_previous_close(symbol: str) -> float | None:
+    if not TWELVEDATA_API_KEY:
+        return None
+    try:
+        response = requests.get(
+            "https://api.twelvedata.com/time_series",
+            params={
+                "symbol": to_twelvedata_symbol(symbol),
+                "interval": "1day",
+                "outputsize": 2,
+                "apikey": TWELVEDATA_API_KEY,
+            },
+            timeout=8,
+        )
+        data = response.json()
+        values = data.get("values")
+        if not isinstance(values, list) or len(values) < 2:
+            return None
+        return first_float(values[1].get("close"))
+    except Exception:
+        return None
+
+
+def _fetch_heatmap_pair(symbol: str) -> dict[str, Any]:
+    pair = normalize_symbol(symbol)
+    base = pair[:3]
+    quote = pair[3:]
+    row = {
+        "symbol": pair,
+        "base": base,
+        "quote": quote,
+        "price": None,
+        "change_pct": None,
+        "data_status": "unavailable",
+    }
+
+    if len(pair) != 6:
+        return row
+    if not TWELVEDATA_API_KEY:
+        return row
+
+    try:
+        response = requests.get(
+            "https://api.twelvedata.com/quote",
+            params={"symbol": to_twelvedata_symbol(pair), "apikey": TWELVEDATA_API_KEY},
+            timeout=8,
+        )
+        data = response.json()
+        if data.get("status") == "error":
+            return row
+
+        current_price = first_float(data.get("close"), data.get("price"))
+        previous_close = first_float(data.get("previous_close"))
+        if previous_close is None:
+            previous_close = _fetch_twelvedata_previous_close(pair)
+
+        if current_price is None or previous_close in (None, 0):
+            return row
+
+        change_pct = ((current_price - previous_close) / previous_close) * 100
+        row["price"] = round(float(current_price), 6)
+        row["change_pct"] = round(float(change_pct), 4)
+        row["data_status"] = "delayed"
+        return row
+    except Exception:
+        return row
+
+
+def build_currency_heatmap() -> dict[str, Any]:
+    currencies = HEATMAP_CURRENCIES.copy()
+    pair_rows: list[dict[str, Any]] = []
+    strength_totals: dict[str, float] = {currency: 0.0 for currency in currencies}
+    strength_counts: dict[str, int] = {currency: 0 for currency in currencies}
+    real_pairs_count = 0
+    unavailable_pairs_count = 0
+
+    for symbol in HEATMAP_PAIRS:
+        row = _fetch_heatmap_pair(symbol)
+        pair_rows.append(row)
+        if row.get("change_pct") is None:
+            unavailable_pairs_count += 1
+            continue
+
+        real_pairs_count += 1
+        change_pct = float(row["change_pct"])
+        base = str(row.get("base") or "")
+        quote = str(row.get("quote") or "")
+
+        if base in strength_totals:
+            strength_totals[base] += change_pct
+            strength_counts[base] += 1
+        if quote in strength_totals:
+            strength_totals[quote] -= change_pct
+            strength_counts[quote] += 1
+
+    if real_pairs_count == 0:
+        return {
+            "currencies": currencies,
+            "pairs": [],
+            "strength": [],
+            "warning": "Реальные FX-данные временно недоступны. Тепловая карта не строится без котировок.",
+            "updated_at_utc": now_utc(),
+            "diagnostics": {
+                "real_pairs_count": 0,
+                "unavailable_pairs_count": len(HEATMAP_PAIRS),
+                "provider": "twelvedata",
+            },
+        }
+
+    strength: list[dict[str, Any]] = []
+    for currency in currencies:
+        count = strength_counts[currency]
+        if count <= 0:
+            continue
+        score = strength_totals[currency] / count
+        strength.append({"currency": currency, "score": round(score, 4)})
+
+    strength.sort(key=lambda item: item["score"], reverse=True)
+    for idx, item in enumerate(strength, start=1):
+        item["rank"] = idx
+
+    return {
+        "currencies": currencies,
+        "pairs": pair_rows,
+        "strength": strength,
+        "updated_at_utc": now_utc(),
+        "diagnostics": {
+            "real_pairs_count": real_pairs_count,
+            "unavailable_pairs_count": unavailable_pairs_count,
+            "provider": "twelvedata",
+        },
+    }
 
 
 def move_to_archive(trade: dict[str, Any]) -> None:

--- a/app/static/heatmap.html
+++ b/app/static/heatmap.html
@@ -3,16 +3,36 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Currency Heatmap</title>
+    <title>Тепловая карта валют</title>
     <link rel="stylesheet" href="/static/styles.css" />
+    <style>
+      .heatmap-page { display: grid; gap: 16px; }
+      .currency-strength-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 8px; }
+      .currency-strength-item { display: flex; justify-content: space-between; padding: 10px 12px; border-radius: 10px; background: rgba(255,255,255,0.04); }
+      .heatmap-grid-wrap { overflow-x: auto; }
+      .heatmap-grid { display: grid; gap: 6px; min-width: 760px; }
+      .heatmap-cell { min-height: 74px; border-radius: 10px; padding: 8px; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
+      .heatmap-cell--positive { background: rgba(26, 160, 83, var(--cell-intensity, 0.22)); border-color: rgba(26, 160, 83, 0.5); }
+      .heatmap-cell--negative { background: rgba(204, 55, 55, var(--cell-intensity, 0.22)); border-color: rgba(204, 55, 55, 0.5); }
+      .heatmap-cell--neutral { background: rgba(124, 132, 153, 0.28); }
+      .heatmap-head { font-size: 12px; color: #a9b1c7; text-align: center; }
+      .heatmap-side { font-size: 12px; color: #a9b1c7; display: flex; align-items: center; justify-content: center; }
+      .heatmap-pair { font-weight: 700; font-size: 13px; }
+      .heatmap-change { font-size: 12px; opacity: 0.9; margin-top: 4px; }
+      .heatmap-empty { opacity: 0.4; }
+      .pair-table { width: 100%; border-collapse: collapse; }
+      .pair-table th, .pair-table td { text-align: left; padding: 8px; border-bottom: 1px solid rgba(255,255,255,0.08); }
+      .warn-box { border-radius: 10px; padding: 12px; background: rgba(204,55,55,0.16); border: 1px solid rgba(204,55,55,0.35); }
+      .explain-box { border-radius: 10px; padding: 12px; background: rgba(61,108,206,0.16); border: 1px solid rgba(61,108,206,0.35); }
+    </style>
   </head>
   <body data-page="heatmap">
-    <div class="page-shell">
+    <div class="page-shell heatmap-page">
       <header class="site-header">
         <div>
           <p class="eyebrow">Тепловая карта</p>
-          <h1>Тепловая карта валют</h1>
-          <p class="lead">Раздел сохранён как отдельная страница и получает данные по существующему маршруту heatmap.</p>
+          <h1>Тепловая карта валют FX</h1>
+          <p class="lead">Реальные изменения валютных пар и сила/слабость основных валют.</p>
         </div>
         <nav class="top-nav">
           <a href="/">Главная</a>
@@ -24,19 +44,188 @@
       </header>
 
       <main class="content-stack">
+        <section class="panel explain-box">
+          <strong>Как читать карту:</strong>
+          <div>Зелёная ячейка означает, что базовая валюта пары сильнее котируемой. Красная — слабее. Чем ярче цвет, тем сильнее движение.</div>
+        </section>
+
+        <section class="panel" id="warningBox" hidden></section>
+
         <section class="panel">
           <div class="panel-heading compact">
-            <div>
-              <p class="section-kicker">Тепловая карта FX</p>
-              <h2>Движение валютных пар</h2>
-            </div>
+            <h2>Рейтинг силы валют</h2>
+            <span id="updatedAt">Обновление: —</span>
           </div>
-          <ul class="data-list" id="heatmapList"></ul>
+          <ul class="currency-strength-list" id="strengthList"></ul>
+        </section>
+
+        <section class="panel">
+          <div class="panel-heading compact">
+            <h2>Матрица тепловой карты</h2>
+          </div>
+          <div class="heatmap-grid-wrap">
+            <div class="heatmap-grid" id="heatmapGrid"></div>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-heading compact">
+            <h2>Пары и изменения</h2>
+          </div>
+          <table class="pair-table">
+            <thead>
+              <tr><th>Пара</th><th>Цена</th><th>Изм., %</th><th>Статус</th></tr>
+            </thead>
+            <tbody id="pairTableBody"></tbody>
+          </table>
         </section>
       </main>
     </div>
 
-    <script src="/static/script.js"></script>
+    <script>
+      const warningBox = document.getElementById('warningBox');
+      const strengthList = document.getElementById('strengthList');
+      const heatmapGrid = document.getElementById('heatmapGrid');
+      const pairTableBody = document.getElementById('pairTableBody');
+      const updatedAt = document.getElementById('updatedAt');
+
+      function intensityByChange(change) {
+        const value = Math.abs(change);
+        if (value < 0.1) return 0.20;
+        if (value <= 0.4) return 0.38;
+        return 0.55;
+      }
+
+      function cellClass(change) {
+        if (change > 0.02) return 'heatmap-cell heatmap-cell--positive';
+        if (change < -0.02) return 'heatmap-cell heatmap-cell--negative';
+        return 'heatmap-cell heatmap-cell--neutral';
+      }
+
+      function renderStrength(strength) {
+        strengthList.innerHTML = '';
+        if (!Array.isArray(strength) || strength.length === 0) {
+          strengthList.innerHTML = '<li class="currency-strength-item">Нет данных по силе валют.</li>';
+          return;
+        }
+        strength.forEach((item) => {
+          const li = document.createElement('li');
+          li.className = 'currency-strength-item';
+          li.innerHTML = `<span>#${item.rank} ${item.currency}</span><strong>${Number(item.score).toFixed(4)}%</strong>`;
+          strengthList.appendChild(li);
+        });
+      }
+
+      function renderGrid(currencies, pairs) {
+        heatmapGrid.innerHTML = '';
+        const list = Array.isArray(currencies) ? currencies : [];
+        const bySymbol = new Map((pairs || []).map((p) => [p.symbol, p]));
+        heatmapGrid.style.gridTemplateColumns = `80px repeat(${list.length}, minmax(82px, 1fr))`;
+
+        const blank = document.createElement('div');
+        blank.className = 'heatmap-head';
+        heatmapGrid.appendChild(blank);
+
+        list.forEach((quote) => {
+          const head = document.createElement('div');
+          head.className = 'heatmap-head';
+          head.textContent = quote;
+          heatmapGrid.appendChild(head);
+        });
+
+        list.forEach((base) => {
+          const side = document.createElement('div');
+          side.className = 'heatmap-side';
+          side.textContent = base;
+          heatmapGrid.appendChild(side);
+
+          list.forEach((quote) => {
+            const cell = document.createElement('div');
+            if (base === quote) {
+              cell.className = 'heatmap-cell heatmap-cell--neutral heatmap-empty';
+              cell.textContent = '—';
+              heatmapGrid.appendChild(cell);
+              return;
+            }
+
+            const direct = `${base}${quote}`;
+            const inverse = `${quote}${base}`;
+            let pair = bySymbol.get(direct);
+            let change = null;
+            let symbol = direct;
+
+            if (pair && typeof pair.change_pct === 'number') {
+              change = pair.change_pct;
+            } else {
+              const inv = bySymbol.get(inverse);
+              if (inv && typeof inv.change_pct === 'number') {
+                pair = inv;
+                change = -inv.change_pct;
+                symbol = direct;
+              }
+            }
+
+            if (change === null) {
+              cell.className = 'heatmap-cell heatmap-cell--neutral heatmap-empty';
+              cell.innerHTML = `<div class="heatmap-pair">${symbol}</div><div class="heatmap-change">нет данных</div>`;
+              heatmapGrid.appendChild(cell);
+              return;
+            }
+
+            cell.className = cellClass(change);
+            cell.style.setProperty('--cell-intensity', String(intensityByChange(change)));
+            cell.innerHTML = `<div class="heatmap-pair">${symbol}</div><div class="heatmap-change">${change >= 0 ? '+' : ''}${change.toFixed(3)}%</div>`;
+            heatmapGrid.appendChild(cell);
+          });
+        });
+      }
+
+      function renderPairs(pairs) {
+        pairTableBody.innerHTML = '';
+        const list = Array.isArray(pairs) ? pairs : [];
+        if (!list.length) {
+          pairTableBody.innerHTML = '<tr><td colspan="4">Реальные пары временно недоступны.</td></tr>';
+          return;
+        }
+
+        list.forEach((pair) => {
+          const tr = document.createElement('tr');
+          const change = typeof pair.change_pct === 'number' ? `${pair.change_pct >= 0 ? '+' : ''}${pair.change_pct.toFixed(3)}%` : '—';
+          const price = typeof pair.price === 'number' ? pair.price.toFixed(6) : '—';
+          tr.innerHTML = `<td>${pair.symbol}</td><td>${price}</td><td>${change}</td><td>${pair.data_status || 'unavailable'}</td>`;
+          pairTableBody.appendChild(tr);
+        });
+      }
+
+      async function loadHeatmap() {
+        try {
+          const response = await fetch('/api/heatmap');
+          const data = await response.json();
+
+          if (data.warning) {
+            warningBox.hidden = false;
+            warningBox.className = 'panel warn-box';
+            warningBox.textContent = data.warning;
+          } else {
+            warningBox.hidden = true;
+          }
+
+          updatedAt.textContent = `Обновление: ${data.updated_at_utc || '—'}`;
+          renderStrength(data.strength || []);
+          renderGrid(data.currencies || [], data.pairs || []);
+          renderPairs(data.pairs || []);
+        } catch (error) {
+          warningBox.hidden = false;
+          warningBox.className = 'panel warn-box';
+          warningBox.textContent = 'Не удалось загрузить тепловую карту.';
+          renderStrength([]);
+          renderGrid([], []);
+          renderPairs([]);
+        }
+      }
+
+      loadHeatmap();
+    </script>
     <script src="/static/nav.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Добавить страницу и API для реальной тепловой карты валют по списку основных валют и пар, используя реальные котировки, а не синтетику.
- Показывать силу/слабость валюты, изменения по парам и явную индикацию недоступности данных, чтобы бэкенд никогда не возвращал «фейковые» значения. 
- Сохранить существующую архитектуру и не трогать страницу `ideas` или её логику. 

### Description
- Добавлены константы `HEATMAP_CURRENCIES` и `HEATMAP_PAIRS` и новый публичный эндпоинт `GET /api/heatmap`, реализующий `build_currency_heatmap()` в `app/main.py`.
- Реализованы вспомогательные функции `_fetch_heatmap_pair()` и `_fetch_twelvedata_previous_close()` для получения текущей цены и предыдущего закрытия через TwelveData (quote + fallback на `time_series`), расчёта `change_pct` по формуле `((current - previous_close) / previous_close) * 100` и маркировки статуса `delayed|unavailable` без генерации фейковых чисел.
- Расчёт силы валюты сделан как суммирование вкладов пар (base получает `+change_pct`, quote получает `-change_pct`) с усреднением и ранжированием; результат возвращается в поле `strength`, а также добавлены диагностические метрики в `diagnostics`.
- Обновлена страница пользовательского интерфейса `app/static/heatmap.html` для отображения навигации, блока «Как читать карту», списка рейтинга валют, матрицы тепловой карты (строки=base, столбцы=quote), таблицы пар, времени обновления и явного предупреждения при отсутствии данных; применены CSS-классы `heatmap-cell--positive/negative/neutral` и интенсивность цвета по величине изменения.
- При отсутствии реальных котировок API возвращает пустой `pairs`/`strength` и поле `warning` с сообщением на русском: `Реальные FX-данные временно недоступны. Тепловая карта не строится без котировок.`

### Testing
- Выполнена проверка синтаксиса/компиляции через `python -m compileall app/main.py app/static/heatmap.html` и она прошла успешно.
- Локальная проверка с `fastapi.testclient` выполнила `GET /api/heatmap` (HTTP 200, ответ содержит ключи `currencies`, `pairs`, `strength`, `updated_at_utc`, `diagnostics` и `warning` при отсутствии котировок) и `GET /heatmap/page` (HTTP 200, HTML-страница вернулась). 
- Попытка сделать скриншот через Playwright не удалась из-за отсутствующей системной зависимости в окружении (`libatk-1.0.so.0`), поэтому визуальная скринпроверка не была завершена; попытка запуска сервера + Playwright показала эту ошибку.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10f59c6a483319102ee8b631fd7f6)