### PR TITLE
Добавить интеграцию forexclientsentiment (опциональный сентимент)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -29,6 +30,8 @@ FMP_API_KEY = os.getenv("FMP_API_KEY", "").strip()
 CANDLE_CACHE: dict[str, dict[str, Any]] = {}
 CANDLE_CACHE_TTL_SECONDS = 900
 STALE_CANDLE_CACHE_TTL_SECONDS = 86400
+SENTIMENT_CACHE: dict[str, dict[str, Any]] = {}
+SENTIMENT_CACHE_TTL_SECONDS = 900
 
 ACTIVE_FILE = Path("active_trades.json")
 ARCHIVE_FILE = Path("archive.json")
@@ -479,6 +482,7 @@ def build_signal(symbol: str) -> dict[str, Any]:
 
     if current_price is None:
         return empty_signal(symbol, price_data, candles_by_tf)
+    sentiment = fetch_forex_client_sentiment(symbol)
 
     proposed_bias = resolve_proposed_bias(candles_by_tf)
     decision = HTF_FILTER.evaluate(
@@ -581,6 +585,7 @@ def build_signal(symbol: str) -> dict[str, Any]:
         runtime_status=runtime_status,
         runtime_text=runtime_text,
         htf_decision=decision,
+        sentiment=sentiment,
     )
 
     m15_candles = candles_by_tf.get("M15", [])
@@ -628,6 +633,7 @@ def build_signal(symbol: str) -> dict[str, Any]:
         "full_text": summary,
         "compact_summary": summary,
         "warning_ru": human_price_warning(price_data),
+        "sentiment": sentiment,
         "auto_close_skipped_ru": trade.get("auto_close_skipped_ru"),
         "setup_quality": "HTF_CONTEXT_REAL_CANDLES_ONLY",
         "risk_filter": "MN_W1_D1_H4_H1_M15_ALIGNMENT",
@@ -1353,6 +1359,7 @@ def build_summary(
     runtime_status: str,
     runtime_text: str,
     htf_decision,
+    sentiment: dict[str, Any] | None = None,
 ) -> str:
     signal = trade.get("signal")
     context = htf_decision.context
@@ -1373,6 +1380,8 @@ def build_summary(
             "не дают согласованную картину."
         )
 
+    sentiment_text = build_sentiment_context_text(sentiment or {})
+
     return (
         f"{symbol}: {scenario} "
         f"HTF bias: {htf_decision.htf_bias}. "
@@ -1380,9 +1389,122 @@ def build_summary(
         f"H4={context.get('h4_bias')}, H1={context.get('h1_bias')}, M15={context.get('m15_bias')}. "
         f"Entry: {trade.get('entry')}, SL: {trade.get('sl')}, TP: {trade.get('tp')}. "
         f"Текущая цена: {current_price}. "
+        f"{sentiment_text} "
         f"{htf_decision.reason} "
         f"Статус: {runtime_status}. {runtime_text}"
     )
+
+
+def fetch_forex_client_sentiment(symbol: str) -> dict[str, Any]:
+    normalized_symbol = normalize_symbol(symbol)
+    cache_item = SENTIMENT_CACHE.get(normalized_symbol)
+    now_ts = time.time()
+    if cache_item and now_ts - cache_item.get("updated_at", 0) <= SENTIMENT_CACHE_TTL_SECONDS:
+        return cache_item.get("payload", build_unavailable_sentiment())
+
+    try:
+        response = requests.get(
+            "https://forexclientsentiment.com/forex-sentiment",
+            timeout=8,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; ForexSignalPlatform/1.0)"},
+        )
+        response.raise_for_status()
+        payload = _parse_forex_client_sentiment_html(response.text, normalized_symbol)
+        payload["source"] = "forexclientsentiment"
+        payload["warning"] = None
+        SENTIMENT_CACHE[normalized_symbol] = {
+            "updated_at": now_ts,
+            "payload": payload,
+        }
+        return payload
+    except Exception:
+        if cache_item:
+            return cache_item.get("payload", build_unavailable_sentiment())
+        return build_unavailable_sentiment()
+
+
+def _parse_forex_client_sentiment_html(html_text: str, symbol: str) -> dict[str, Any]:
+    target = _format_sentiment_symbol(symbol)
+    rows = re.findall(r"<tr[^>]*>.*?</tr>", html_text, flags=re.IGNORECASE | re.DOTALL)
+    for row in rows:
+        plain = _strip_html_tags(row)
+        compact_plain = plain.replace(" ", "").upper()
+        if target.upper() not in plain.upper() and symbol.upper() not in compact_plain:
+            continue
+
+        percents = re.findall(r"(\d{1,3}(?:[.,]\d+)?)\s*%", plain)
+        if len(percents) < 2:
+            continue
+        long_pct = _parse_percent(percents[0])
+        short_pct = _parse_percent(percents[1])
+        if long_pct is None or short_pct is None:
+            continue
+
+        bias = "neutral"
+        lower_plain = plain.lower()
+        if "bullish" in lower_plain:
+            bias = "crowd_long"
+        elif "bearish" in lower_plain:
+            bias = "crowd_short"
+
+        return {
+            "long_pct": long_pct,
+            "short_pct": short_pct,
+            "bias": bias,
+            "source": "forexclientsentiment",
+            "warning": None,
+        }
+
+    raise ValueError(f"sentiment_row_not_found:{symbol}")
+
+
+def build_unavailable_sentiment() -> dict[str, Any]:
+    return {
+        "long_pct": None,
+        "short_pct": None,
+        "bias": "neutral",
+        "source": "unavailable",
+        "warning": "Сентимент временно недоступен",
+    }
+
+
+def _format_sentiment_symbol(symbol: str) -> str:
+    if len(symbol) == 6:
+        return f"{symbol[:3]}/{symbol[3:]}"
+    return symbol
+
+
+def _strip_html_tags(value: str) -> str:
+    stripped = re.sub(r"<[^>]+>", " ", value)
+    return re.sub(r"\s+", " ", stripped).strip()
+
+
+def _parse_percent(value: str) -> int | None:
+    normalized = str(value).replace(",", ".")
+    try:
+        parsed = float(normalized)
+    except ValueError:
+        return None
+    parsed = max(0.0, min(100.0, parsed))
+    return int(round(parsed))
+
+
+def build_sentiment_context_text(sentiment: dict[str, Any]) -> str:
+    long_pct = sentiment.get("long_pct")
+    short_pct = sentiment.get("short_pct")
+    bias = sentiment.get("bias")
+
+    if bias == "crowd_long" and long_pct is not None:
+        return (
+            f"Большинство участников рынка (~{long_pct}%) уже в покупках. "
+            "Это создаёт риск движения против толпы — такие перекосы часто заканчиваются выносом long-позиций."
+        )
+    if bias == "crowd_short" and short_pct is not None:
+        return (
+            f"Толпа перегружена в шортах (~{short_pct}%), "
+            "что может дать топливо для роста при выносе стопов."
+        )
+    return "Сентимент нейтральный — рынок не перекошен, основную роль играет техническая структура."
 
 
 def empty_signal(

--- a/app/static/ideas.css
+++ b/app/static/ideas.css
@@ -171,11 +171,34 @@ h1 {
 }
 
 .idea-chart-wrap {
+  position: relative;
   margin-top: 20px;
   overflow: hidden;
   border-radius: 22px;
   border: 1px solid rgba(255,255,255,.08);
   background: #0b1222;
+}
+
+.idea-sentiment-badge {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, .78);
+  border: 1px solid rgba(148, 163, 184, .45);
+  color: #e2e8f0;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.idea-sentiment-badge-warn {
+  border-color: rgba(251, 191, 36, .7);
+  color: #fde68a;
 }
 
 .idea-chart-image {

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -127,17 +127,30 @@ function resolveVisibleNarrative(idea) {
 }
 
 function renderChartBlock(idea, chartImageUrl) {
+  const sentimentBadge = buildSentimentBadge(idea?.sentiment);
   if (chartImageUrl) {
     return `<div class="idea-chart-wrap">
+      ${sentimentBadge}
       <img class="idea-chart-image" src="${escapeHtml(chartImageUrl)}?t=${Date.now()}" alt="${escapeHtml(idea.title || "chart")}" />
     </div>`;
   }
   const fallbackCandles = idea?.chartData?.candles || idea?.chart_data?.candles || [];
   const fallbackSvg = buildFallbackSvg(fallbackCandles);
   if (fallbackSvg) {
-    return `<div class="idea-chart-wrap">${fallbackSvg}</div>`;
+    return `<div class="idea-chart-wrap">${sentimentBadge}${fallbackSvg}</div>`;
   }
   return `<div class="idea-chart-missing">Снапшот графика недоступен (${escapeHtml(idea.chartSnapshotStatus || idea.chart_snapshot_status || "no_data")}).</div>`;
+}
+
+function buildSentimentBadge(sentiment) {
+  const longPct = Number(sentiment?.long_pct);
+  const shortPct = Number(sentiment?.short_pct);
+  if (!Number.isFinite(longPct) || !Number.isFinite(shortPct)) return "";
+  const extreme = Math.max(longPct, shortPct) > 70;
+  return `<div class="idea-sentiment-badge ${extreme ? "idea-sentiment-badge-warn" : ""}">
+    ${extreme ? '<span class="idea-sentiment-icon" aria-hidden="true">⚠️</span>' : ""}
+    Long ${escapeHtml(longPct.toFixed(0))}% / Short ${escapeHtml(shortPct.toFixed(0))}%
+  </div>`;
 }
 
 function buildFallbackSvg(candles) {


### PR DESCRIPTION
### Motivation
- Добавить опциональный контекст сентимента из `forexclientsentiment.com` для повышения информативности идей без изменения логики сигналов. 
- Обеспечить безопасный парсинг и кеширование, чтобы внешний провайдер не влиял критически на работу системы.

### Description
- Добавлена функция `fetch_forex_client_sentiment(symbol)` в `app/main.py`, реализующий запрос страницы, безопасный HTML-парсинг строки инструмента, извлечение `long_pct`, `short_pct` и сопоставление bias (`Bullish` → `crowd_long`, `Bearish` → `crowd_short`, иначе `neutral`).
- Реализован TTL-кэш `SENTIMENT_CACHE` с 15-минутным TTL и поведение: при ошибке возвращается кэш а при его отсутствии — безопасный fallback `build_unavailable_sentiment()` с предупреждением на русском.
- Интеграция в генерацию идеи: в `build_signal` выполняется сбор сентимента, он добавляется в итоговый payload под ключом `sentiment` и прокидывается в `build_summary` где вставляется короткая русская фраза в основной текст (без отдельного блока).
- Фронтенд: бейдж над графиком в `app/static/ideas.js` и стили в `app/static/ideas.css` показывают `Long X% / Short Y%` и отображают иконку предупреждения при перекосе >70%, при этом график и маршрут `/ideas` не менялись.

### Testing
- Выполнена проверка синтаксиса Python: `python -m py_compile app/main.py` и проверка JS: `node --check app/static/ideas.js`, обе проверки успешны.
- Локальный парсинг протестирован небольшим скриптом, который корректно извлекает `long_pct/short_pct` и формирует текстовую фразу (успешно).
- Запуск `pytest -q tests/api/test_ideas_api.py` завершился с ошибкой импорта `cannot import name 'canonical_market_service' from 'app.main'`, что является существующей проблемой в тестах и не связано с внесёнными изменениями.
- Изменения ограничены и не ломают логику сигналов, маршруты или генерацию идей по условию anti-conflict.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1100c0e348331acb4ba0e7fd2e592)