### PR TITLE
Добавить опциональный smart-money контекст и расширить контракт sentiment

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -1347,6 +1347,7 @@ class TradeIdeaService:
         action = signal.get("action", "NO_TRADE")
         bias = "bullish" if action == "BUY" else "bearish" if action == "SELL" else "neutral"
         signal_sentiment = signal.get("sentiment") or {}
+        signal_smart_money_context = signal.get("smart_money_context") if isinstance(signal.get("smart_money_context"), dict) else None
         created_at = existing.get("created_at") if existing else now.isoformat()
         version = int(existing.get("version", 1)) + 1 if existing else 1
         entry_value = self._extract_numeric(signal.get("entry"))
@@ -1653,6 +1654,7 @@ class TradeIdeaService:
             "latest_close": latest_close,
             "current_price": latest_close,
             "sentiment": signal_sentiment,
+            "smart_money_context": signal_smart_money_context,
             "rationale": rationale,
             "created_at": created_at,
             "updated_at": now.isoformat(),
@@ -4776,6 +4778,7 @@ class TradeIdeaService:
     ) -> dict[str, Any]:
         market_context = row.get("market_context") if isinstance(row.get("market_context"), dict) else {}
         sentiment = row.get("sentiment") if isinstance(row.get("sentiment"), dict) else {}
+        smart_money_context = row.get("smart_money_context") if isinstance(row.get("smart_money_context"), dict) else {}
         current_price = cls._extract_level(market_context, "current_price")
         daily_change = cls._extract_level(row, "daily_change_percent", "daily_change")
         entry = cls._extract_level(row, "entry", "entry_zone")
@@ -4924,6 +4927,7 @@ class TradeIdeaService:
     ) -> list[dict[str, Any]]:
         market_context = row.get("market_context") if isinstance(row.get("market_context"), dict) else {}
         sentiment = row.get("sentiment") if isinstance(row.get("sentiment"), dict) else {}
+        smart_money_context = row.get("smart_money_context") if isinstance(row.get("smart_money_context"), dict) else {}
         entry = cls._extract_level(row, "entry", "entry_zone")
         stop_loss = cls._extract_level(row, "stopLoss", "stop_loss")
         take_profit = cls._extract_level(row, "takeProfit", "take_profit")
@@ -4934,6 +4938,9 @@ class TradeIdeaService:
         sentiment_source = sentiment.get("source")
         sentiment_status = sentiment.get("data_status")
         sentiment_conf = sentiment.get("confidence")
+        sentiment_long = sentiment.get("long_pct")
+        sentiment_short = sentiment.get("short_pct")
+        sentiment_bias = sentiment.get("bias")
         sections: list[dict[str, Any]] = []
 
         def add_section(key: str, title: str, content: str, *, is_proxy: bool = False) -> None:
@@ -4989,10 +4996,24 @@ class TradeIdeaService:
         if sentiment and sentiment_status != "unavailable":
             bias = sentiment.get("contrarian_bias") or sentiment.get("sentiment_score") or "neutral"
             sentiment_text = f"Сентиментальный слой показывает bias {bias}."
+            if sentiment_long not in (None, "") and sentiment_short not in (None, ""):
+                sentiment_text += f" Retail positioning: Long {round(float(sentiment_long), 1)}% / Short {round(float(sentiment_short), 1)}%."
+            if sentiment_bias:
+                sentiment_text += f" Crowd bias: {sentiment_bias}."
             if sentiment_conf not in (None, ""):
                 sentiment_text += f" Confidence модели: {round(float(sentiment_conf) * 100)}%."
             if sentiment_source:
                 sentiment_text += f" Источник: {sentiment_source}."
+            if smart_money_context:
+                summary_ru = str(smart_money_context.get("summary_ru") or "").strip()
+                crowd_risk_ru = str(smart_money_context.get("crowd_risk_ru") or "").strip()
+                liquidity_alignment_ru = str(smart_money_context.get("liquidity_alignment_ru") or "").strip()
+                if summary_ru:
+                    sentiment_text += f" {summary_ru}"
+                if crowd_risk_ru:
+                    sentiment_text += f" {crowd_risk_ru}"
+                if liquidity_alignment_ru:
+                    sentiment_text += f" {liquidity_alignment_ru}"
             add_section("sentiment", "Сентимент / positioning", sentiment_text, is_proxy="mock" in str(sentiment_source).lower())
 
         liquidity_text = analysis.get("liquidity_ru") or f"Ближайшая ликвидность стоит у {target}. Пока {stop_loss} держится, сценарий на движение к цели остаётся в силе."

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -545,6 +545,15 @@
       border-bottom: 1px solid rgba(95,145,203,.3);
       background: rgba(8,25,48,.9);
     }
+    .sentiment-badge {
+      margin: 10px 10px 0;
+      padding: 6px 10px;
+      border-radius: 10px;
+      border: 1px solid rgba(255,255,255,.14);
+      background: rgba(18, 27, 42, .72);
+      color: var(--text);
+      font-size: 12px;
+    }
 
     .tf-btn {
       height: 34px;
@@ -1111,6 +1120,7 @@
 
           <div class="modal-section-title">Основная идея</div>
           <div class="box modal-text">${escapeHtml(pickText(idea))}</div>
+          ${renderSmartMoneyContext(idea)}
           ${renderFundamentalContext(idea)}
           <div class="status-reason">${escapeHtml(statusReason)}</div>
 
@@ -1129,6 +1139,7 @@
 
         <div class="ideas-modal__bottom">
           <div class="chart-wrap">
+            ${renderSentimentBadge(idea)}
             <div class="chart-toolbar">
               <button class="tf-btn" data-tf="M15">M15</button>
               <button class="tf-btn" data-tf="H1">H1</button>
@@ -1877,6 +1888,29 @@
         idea.description_ru ||
         "Описание идеи отсутствует."
       );
+    }
+
+    function renderSentimentBadge(idea) {
+      const sentiment = idea && typeof idea.sentiment === "object" ? idea.sentiment : null;
+      if (!sentiment || String(sentiment.data_status || "").toLowerCase() === "unavailable") {
+        return `<div class="sentiment-badge">Sentiment: нет данных</div>`;
+      }
+      const longPct = Number(sentiment.long_pct);
+      const shortPct = Number(sentiment.short_pct);
+      if (!Number.isFinite(longPct) || !Number.isFinite(shortPct)) {
+        return `<div class="sentiment-badge">Sentiment: нет данных</div>`;
+      }
+      return `<div class="sentiment-badge">Sentiment: Long ${escapeHtml(longPct.toFixed(0))}% / Short ${escapeHtml(shortPct.toFixed(0))}%</div>`;
+    }
+
+    function renderSmartMoneyContext(idea) {
+      const context = idea && typeof idea.smart_money_context === "object" ? idea.smart_money_context : null;
+      if (!context) return "";
+      const lines = [context.summary_ru, context.crowd_risk_ru, context.liquidity_alignment_ru]
+        .map((item) => String(item || "").trim())
+        .filter(Boolean);
+      if (!lines.length) return "";
+      return `<div class="box modal-text">${escapeHtml(lines.join(" "))}</div>`;
     }
 
     function normalizeSymbol(value) {

--- a/backend/sentiment_provider.py
+++ b/backend/sentiment_provider.py
@@ -29,6 +29,8 @@ class SentimentSnapshot(BaseModel):
     sentiment_score: float = Field(ge=-1.0, le=1.0)
     confidence: float = Field(ge=0.0, le=1.0)
     data_status: SentimentDataStatus
+    bias: Literal["crowd_long", "crowd_short", "neutral"] = "neutral"
+    warning: str | None = None
 
 
 class BaseSentimentProvider(ABC):
@@ -46,12 +48,15 @@ class BaseSentimentProvider(ABC):
 
         retail_bias: RetailBias = "neutral"
         contrarian_bias: ContrarianBias = "neutral"
+        bias: Literal["crowd_long", "crowd_short", "neutral"] = "neutral"
         if long_pct >= 65:
             retail_bias = "bullish"
             contrarian_bias = "bearish"
+            bias = "crowd_long"
         elif short_pct >= 65:
             retail_bias = "bearish"
             contrarian_bias = "bullish"
+            bias = "crowd_short"
 
         imbalance = abs(long_pct - short_pct) / 100
         score = 0.0
@@ -72,6 +77,7 @@ class BaseSentimentProvider(ABC):
             score = 0.0
             contrarian_bias = "neutral"
             retail_bias = "neutral"
+            bias = "neutral"
 
         return SentimentSnapshot(
             symbol=symbol.upper(),
@@ -88,6 +94,8 @@ class BaseSentimentProvider(ABC):
             sentiment_score=round(max(-1.0, min(1.0, score)), 4),
             confidence=round(max(0.0, min(1.0, confidence)), 4),
             data_status=data_status,
+            bias=bias,
+            warning=None if data_status != "unavailable" else "sentiment_unavailable",
         )
 
 

--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -274,6 +274,11 @@ class SignalEngine:
 
         sentiment_alignment = self._sentiment_alignment(action, sentiment)
         sentiment_delta = self._sentiment_delta(sentiment_alignment, sentiment)
+        smart_money_context = self._smart_money_context(
+            sentiment=sentiment,
+            mtf_features=mtf_features,
+            action=action,
+        )
         confidence += sentiment_delta
         confidence = max(20, min(confidence, 92))
         signal_threshold = PROFESSIONAL_MIN_CONFIDENCE if analysis_mode == "professional" else FALLBACK_MIN_CONFIDENCE
@@ -384,6 +389,7 @@ class SignalEngine:
             "created_at_utc": signal_time,
             "idea_id": self._idea_id(symbol, timeframe, action, mtf_pattern_summary),
             "sentiment": sentiment,
+            "smart_money_context": smart_money_context,
             "chart_patterns": mtf_patterns,
             "pattern_summary": mtf_pattern_summary,
             "pattern_signal_impact": pattern_impact,
@@ -419,6 +425,7 @@ class SignalEngine:
                 "patternAlignment": pattern_impact.get("patternAlignmentWithSignal", "neutral"),
                 "sentimentAlignment": sentiment_alignment,
                 "sentimentImpact": round(sentiment_delta / 100, 4),
+                "smart_money_context": smart_money_context,
                 "setup_quality": validation_state,
                 "weak_reasons": weak_reasons,
                 "scenario_type": scenario_type,
@@ -505,6 +512,7 @@ class SignalEngine:
             "created_at_utc": signal_time,
             "idea_id": self._idea_id(symbol, timeframe, action, pattern_summary or {}),
             "sentiment": snapshot.get("sentiment") or {},
+            "smart_money_context": snapshot.get("smart_money_context"),
             "chart_patterns": chart_patterns or [],
             "pattern_summary": pattern_summary or {},
             "pattern_signal_impact": pattern_impact,
@@ -620,6 +628,7 @@ class SignalEngine:
             "created_at_utc": signal_time,
             "idea_id": self._idea_id(symbol, timeframe, "NO_TRADE", summary),
             "sentiment": snapshot.get("sentiment") or {},
+            "smart_money_context": snapshot.get("smart_money_context"),
             "chart_patterns": chart_patterns or [],
             "pattern_summary": summary,
             "pattern_signal_impact": impact,
@@ -708,6 +717,7 @@ class SignalEngine:
             "created_at_utc": signal_time,
             "idea_id": self._idea_id(symbol, timeframe, "NO_TRADE", summary),
             "sentiment": snapshot.get("sentiment") or {},
+            "smart_money_context": snapshot.get("smart_money_context"),
             "chart_patterns": chart_patterns or [],
             "pattern_summary": summary,
             "pattern_signal_impact": impact,
@@ -830,6 +840,47 @@ class SignalEngine:
         if alignment == "conflicts":
             return -scaled
         return 0
+
+    @staticmethod
+    def _smart_money_context(*, sentiment: dict, mtf_features: dict, action: str) -> dict | None:
+        if not isinstance(sentiment, dict) or sentiment.get("data_status") == "unavailable":
+            return None
+        bias = str(sentiment.get("bias") or "neutral").lower()
+        if bias not in {"crowd_long", "crowd_short", "neutral"}:
+            bias = "neutral"
+        liquidity_sweep = bool(mtf_features.get("liquidity_sweep"))
+        order_block = str(mtf_features.get("order_block") or "").lower()
+        has_fvg = bool(mtf_features.get("fvg"))
+        has_enough_data = any((liquidity_sweep, bool(order_block), has_fvg))
+        if not has_enough_data:
+            return None
+
+        if bias == "crowd_long":
+            bearish_zone = order_block == "bearish" or has_fvg or liquidity_sweep
+            if bearish_zone:
+                modifier = -4 if action == "BUY" else 1
+                return {
+                    "summary_ru": "Толпа перегружена в long, поэтому smart-money контекст отмечает риск выноса лонгов и возврата цены вниз.",
+                    "crowd_risk_ru": "При crowd_long вероятен long squeeze: поздние покупатели могут стать топливом для резкого отката.",
+                    "liquidity_alignment_ru": "Если цена снимает buy-side ликвидность и реагирует от bearish OB/FVG, это усиливает сценарий разворота вниз.",
+                    "confidence_modifier": modifier,
+                }
+        if bias == "crowd_short":
+            bullish_zone = order_block == "bullish" or has_fvg or liquidity_sweep
+            if bullish_zone:
+                modifier = -4 if action == "SELL" else 1
+                return {
+                    "summary_ru": "Толпа перегружена в short, поэтому smart-money контекст отмечает риск выноса шортов и импульса вверх.",
+                    "crowd_risk_ru": "При crowd_short вероятен short squeeze: агрессивные продавцы могут ускорить движение вверх.",
+                    "liquidity_alignment_ru": "Если цена снимает sell-side ликвидность и удерживается над bullish OB/FVG, это усиливает сценарий разворота вверх.",
+                    "confidence_modifier": modifier,
+                }
+        return {
+            "summary_ru": "Сентимент нейтрален: smart-money контекст не добавляет сильного перекоса.",
+            "crowd_risk_ru": "Экстремума в позиционировании толпы нет, поэтому риск squeeze оценивается как умеренный.",
+            "liquidity_alignment_ru": "Приоритет остаётся за HTF/OB/FVG/Liquidity структурой без дополнительного перекоса от толпы.",
+            "confidence_modifier": 0,
+        }
 
     @staticmethod
     def _resolve_data_quality(*, htf: dict, mtf: dict, ltf: dict) -> str:

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -8,6 +8,8 @@ def test_mock_sentiment_returns_supported_contract() -> None:
 
     assert snapshot.symbol == "EURUSD"
     assert snapshot.data_status == "mock"
+    assert snapshot.bias in {"crowd_long", "crowd_short", "neutral"}
+    assert snapshot.warning is None
     assert -1.0 <= snapshot.sentiment_score <= 1.0
     assert 0.0 <= snapshot.confidence <= 1.0
 
@@ -33,5 +35,7 @@ def test_external_provider_falls_back_safely_without_base_url() -> None:
 
     assert snapshot.symbol == "GBPUSD"
     assert snapshot.data_status == "unavailable"
+    assert snapshot.bias == "neutral"
+    assert snapshot.warning == "sentiment_unavailable"
     assert snapshot.sentiment_score == 0.0
     assert snapshot.confidence == 0.0

--- a/tests/test_smart_money_context.py
+++ b/tests/test_smart_money_context.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from backend.signal_engine import SignalEngine
+
+
+def test_smart_money_context_for_crowd_long_near_bearish_zone() -> None:
+    context = SignalEngine._smart_money_context(
+        sentiment={"data_status": "live", "bias": "crowd_long"},
+        mtf_features={"liquidity_sweep": True, "order_block": "bearish", "fvg": True},
+        action="BUY",
+    )
+
+    assert context is not None
+    assert "long" in context["crowd_risk_ru"].lower()
+    assert context["confidence_modifier"] <= 0
+
+
+def test_smart_money_context_returns_none_without_inputs() -> None:
+    context = SignalEngine._smart_money_context(
+        sentiment={"data_status": "unavailable", "bias": "neutral"},
+        mtf_features={"liquidity_sweep": False, "order_block": None, "fvg": False},
+        action="BUY",
+    )
+
+    assert context is None


### PR DESCRIPTION
### Motivation
- В репозитории уже есть слой sentiment, нужно безопасно расширить его контракт и добавить поясняющий smart‑money контекст без дублирования логики. 
- Smart‑money объяснения должны быть опциональными и не менять существующие HTF/OB/FVG/Liquidity правила или блокировать/инвертировать сигналы. 

### Description
- Расширен `SentimentSnapshot` в `backend/sentiment_provider.py` полями `bias` (`crowd_long|crowd_short|neutral`) и `warning`, при этом поведение при `data_status == "unavailable"` сохранено. 
- Добавлен метод `_smart_money_context` в `backend/signal_engine.py`, который формирует опциональный `smart_money_context` (summary_ru, crowd_risk_ru, liquidity_alignment_ru, confidence_modifier) на основе позиционирования толпы и наличия OB/FVG/liquidity признаков, и поле аккуратно пробрасывается в сигналы и `market_context`. 
- В `app/services/trade_idea_service.py` добавлен passthrough `smart_money_context` и доработана секция сборки аналитики, чтобы при наличии данных отображать retail long/short, crowd bias и smart‑money пояснения в разделе `sentiment`. 
- Во фронтенде (`app/static/ideas.html`) добавлен небольшой бейдж над графиком `Sentiment: Long X% / Short Y%` (или `Sentiment: нет данных` если отсутствуют данные) и вывода smart‑money текста в теле модалки без редизайна модального окна. 
- Добавлены/обновлены тесты: `tests/test_sentiment.py` (asserts для новых полей) и новый `tests/test_smart_money_context.py`. 

### Testing
- Запущено `pytest -q tests/test_sentiment.py tests/test_smart_money_context.py` и оба теста прошли успешно. 
- При попытке запустить полный набор с `tests/test_idea_update.py` сборка упала на уже существующей синтаксической проблеме в `app/services/chart_snapshot_service.py`, не связанной с внесёнными изменениями; это отмечено и не блокирует изменения по sentiment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f110fbcf50833192c1896086da717a)