### PR TITLE
Убрать полноэкранный режим модалки карточки идеи

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -406,8 +406,8 @@
       inset: 0;
       z-index: 9999;
       display: flex;
-      align-items: stretch;
-      justify-content: stretch;
+      align-items: center;
+      justify-content: center;
       background: rgba(2, 8, 20, 0.85);
       backdrop-filter: blur(10px);
       visibility: hidden;
@@ -425,17 +425,17 @@
 
     .modal,
     .ideas-modal__content {
-      width: 100%;
-      height: 100%;
-      border-radius: 0;
-      margin: 0;
+      width: min(1280px, calc(100vw - 48px));
+      height: min(920px, calc(100vh - 48px));
+      border-radius: 22px;
+      margin: 24px;
       padding: 0;
       overflow: hidden;
       background: linear-gradient(145deg, rgba(6,18,36,.98), rgba(3,10,22,.98));
       display: flex;
       flex-direction: column;
-      border: none;
-      box-shadow: none;
+      border: 1px solid rgba(95,145,203,.44);
+      box-shadow: 0 30px 70px rgba(0,0,0,.45);
     }
 
     .ideas-modal__content {
@@ -712,6 +712,13 @@
       .hero { flex-direction: column; }
       .grid, .stats, .modal-grid, .legend-grid, .ideas-archive__list { grid-template-columns: 1fr; }
       .chart { height: 390px; }
+      .modal,
+      .ideas-modal__content {
+        width: calc(100vw - 16px);
+        height: calc(100vh - 16px);
+        margin: 8px;
+        border-radius: 16px;
+      }
     }
 
     @media (max-width: 768px) {


### PR DESCRIPTION
### Motivation
- Модалка карточки идеи на странице `/ideas` открывалась в полноэкранном режиме и график в карточке отображался неудобно. 
- Нужно вернуть центрированную модалку с ограниченными размерами и адаптацией для мобильных устройств для предсказуемой компоновки.

### Description
- Внесены изменения в CSS в `app/static/ideas.html`: контейнеры `.modal-backdrop` / `.ideas-modal` переключены на центрирование (`align-items`/`justify-content: center`) и заданы ограниченные размеры через `width: min(1280px, calc(100vw - 48px))` и `height: min(920px, calc(100vh - 48px))`, а также добавлены `border-radius`, `margin`, `border` и `box-shadow`.
- Добавлены медиа-правила для мобильных экранов, где модалка использует `width: calc(100vw - 16px)` и `height: calc(100vh - 16px)`; JavaScript логика отрисовки графика не изменялась.

### Testing
- Автоматических тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11522fd7c83318532a6f0c8d2ad97)