### PR TITLE
Премиальный дизайн главной страницы (CSS only)

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2055,3 +2055,81 @@ a { color: inherit; }
     grid-template-columns: 1fr;
   }
 }
+
+
+/* Premium homepage visual upgrade */
+body[data-page="home"] {
+  background:
+    radial-gradient(circle at 12% 8%, rgba(49, 245, 157, 0.20), transparent 30%),
+    radial-gradient(circle at 85% 5%, rgba(255, 45, 149, 0.18), transparent 28%),
+    radial-gradient(circle at 50% 100%, rgba(69, 202, 255, 0.12), transparent 34%),
+    linear-gradient(145deg, #020617, #06111f 48%, #020814);
+}
+
+body[data-page="home"] .site-header {
+  position: relative;
+  overflow: hidden;
+  border-radius: 32px;
+  padding: clamp(28px, 5vw, 64px);
+  background: linear-gradient(145deg, rgba(18, 43, 78, 0.78), rgba(5, 18, 34, 0.88));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(14px);
+}
+
+body[data-page="home"] .site-header::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(49, 245, 157, 0.25), transparent 28%),
+    radial-gradient(circle at 80% 0%, rgba(255, 45, 149, 0.22), transparent 26%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+body[data-page="home"] .site-header > * {
+  position: relative;
+  z-index: 1;
+}
+
+body[data-page="home"] .site-header h1 {
+  font-size: clamp(42px, 7vw, 92px);
+  font-weight: 1000;
+  letter-spacing: -0.07em;
+  line-height: 0.95;
+  background: linear-gradient(90deg, #31f59d, #45caff, #7c3cff, #ff2d95, #ffd84d);
+  background-size: 300% 300%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: premiumTitleGradient 8s ease infinite;
+  text-shadow:
+    0 2px 0 rgba(255, 255, 255, 0.12),
+    0 12px 28px rgba(0, 0, 0, 0.45),
+    0 0 38px rgba(69, 202, 255, 0.28);
+}
+
+@keyframes premiumTitleGradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+body[data-page="home"] .top-nav a,
+body[data-page="home"] .nav-card,
+body[data-page="home"] button,
+body[data-page="home"] a.button,
+body[data-page="home"] .home-link {
+  transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+}
+
+body[data-page="home"] .top-nav a:hover,
+body[data-page="home"] .nav-card:hover,
+body[data-page="home"] button:hover,
+body[data-page="home"] a.button:hover,
+body[data-page="home"] .home-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 42px rgba(69, 202, 255, 0.22);
+  border-color: rgba(69, 202, 255, 0.7);
+}


### PR DESCRIPTION
### Motivation
- Обновить внешний вид главной страницы, сделав её более премиальной, цветной и объёмной без изменений бэкенда или маршрутов.
- Внести только визуальные правки, сохранив существующие ID/классы, поведение навигации и файл `app/static/ideas.html` без изменений.

### Description
- Внесены scoped-CSS правки в `app/static/styles.css` под селектором `body[data-page="home"]` чтобы не затронуть другие страницы. 
- Добавлен многослойный фон (radial glow + тёмный градиент) для глубины и цвета. 
- Преобразован верхний блок (`.site-header`) в glassmorphism-стиль с `backdrop-filter`, тенью, скруглением и внутренним свечением, плюс декоративный слой через `::before` с корректным `z-index` для контента. 
- Обновлён главный заголовок (`.site-header h1`) на крупный анимированный градиентный текст с volumetric shadow/glow, и улучшены hover-эффекты для `.top-nav a`, `.nav-card`, `button` и подобных элементов, сохраняя существующие ссылки и классы.

### Testing
- Выполнены контрольные команды: `git status --short` — успешно, и `git commit -m "Upgrade homepage premium design safely"` — коммит создан успешно. 
- Создан PR через внутренний `make_pr`/automation вызов — успешно.
- Внесение ограничено только CSS и не влияет на маршруты, JS-идентификаторы или файл `app/static/ideas.html`; автоматизированных интеграционных тестов интерфейса не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18993362483318ac4a35dc7e34e23)