### PR TITLE
Добавить сворачивание описания идеи и увеличить размер графика в модалке

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -526,6 +526,37 @@
       padding-right: 4px;
     }
 
+    .ideas-modal__top-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 10px;
+    }
+
+    .ideas-toggle-summary-btn {
+      border: 1px solid rgba(95,145,203,.4);
+      border-radius: 999px;
+      background: rgba(7, 23, 44, 0.92);
+      color: #dbeeff;
+      font-size: 12px;
+      font-weight: 700;
+      padding: 8px 14px;
+      cursor: pointer;
+      transition: all .18s ease;
+    }
+
+    .ideas-toggle-summary-btn:hover {
+      border-color: rgba(125,180,255,.66);
+      box-shadow: 0 0 16px rgba(67, 136, 230, 0.25);
+    }
+
+    #modalContent.summary-collapsed .ideas-modal__top {
+      display: none;
+    }
+
+    #modalContent.summary-collapsed .ideas-modal__chart-zone {
+      flex: 1 1 100%;
+    }
+
     .ideas-modal__chart-zone,
     .ideas-modal__bottom {
       flex: 1;
@@ -604,7 +635,7 @@
 
     .ideas-modal__chart {
       flex: 1;
-      min-height: 480px;
+      min-height: 620px;
       width: 100%;
     }
 
@@ -836,6 +867,7 @@
       currentTf: "M15",
       realCandlesCache: {},
       candlesRequestSeq: 0,
+      isSummaryCollapsed: false,
     };
 
     const pairFilter = document.getElementById("pairFilter");
@@ -849,6 +881,25 @@
     const modalTitle = document.getElementById("modalTitle");
     const modalSubtitle = document.getElementById("modalSubtitle");
     const modalContent = document.getElementById("modalContent");
+
+    function updateSummaryToggleButton() {
+      const toggleBtn = document.getElementById("toggleSummaryBtn");
+      if (!toggleBtn) return;
+      toggleBtn.textContent = state.isSummaryCollapsed ? "Развернуть описание" : "Свернуть описание";
+      toggleBtn.setAttribute("aria-expanded", String(!state.isSummaryCollapsed));
+    }
+
+    function applySummaryState() {
+      if (!modalContent) return;
+      modalContent.classList.toggle("summary-collapsed", state.isSummaryCollapsed);
+      updateSummaryToggleButton();
+      setTimeout(resizeIdeaChartSafely, 60);
+    }
+
+    function toggleSummarySection() {
+      state.isSummaryCollapsed = !state.isSummaryCollapsed;
+      applySummaryState();
+    }
 
     pairFilter.addEventListener("change", () => {
       state.selectedPair = pairFilter.value;
@@ -1110,6 +1161,7 @@
     function openModal(idea) {
       state.activeIdea = idea;
       state.currentTf = pickDefaultTf(idea);
+      state.isSummaryCollapsed = false;
 
       const symbol = normalizeSymbol(idea.symbol || idea.pair || "MARKET");
       const signal = normalizeSignal(idea.final_signal || idea.signal || idea.direction || idea.bias);
@@ -1121,6 +1173,9 @@
 
       modalContent.innerHTML = `
         <div class="ideas-modal__top">
+          <div class="ideas-modal__top-actions">
+            <button id="toggleSummaryBtn" class="ideas-toggle-summary-btn" type="button" aria-expanded="true">Свернуть описание</button>
+          </div>
           <div class="modal-grid">
             <div class="level entry">ENTRY<br>${formatValue(idea.entry || idea.entry_price || idea.entry_zone)}</div>
             <div class="level sl">SL<br>${formatValue(idea.stop_loss || idea.stopLoss || idea.sl)}</div>
@@ -1174,6 +1229,11 @@
         });
       });
 
+      const toggleSummaryBtn = document.getElementById("toggleSummaryBtn");
+      if (toggleSummaryBtn) toggleSummaryBtn.addEventListener("click", toggleSummarySection);
+
+      applySummaryState();
+
       setTimeout(() => renderIdeaChart(idea), 50);
       setTimeout(resizeIdeaChartSafely, 100);
     }
@@ -1206,6 +1266,7 @@
         state.series = null;
       }
       state.activeIdea = null;
+      state.isSummaryCollapsed = false;
     }
 
     function resizeIdeaChartSafely() {


### PR DESCRIPTION
### Motivation
- Запрос: скрывать часть текста карточки идеи по кнопке «Свернуть/Развернуть» и получить крупный фокусный график, похожий на поведение в TradingView.
- Улучшить UX при разметке графика, чтобы график занимал максимум доступного пространства без изменений бекенд-контрактов.

### Description
- Внесены правки в `app/static/ideas.html`: добавлен блок действий `ideas-modal__top-actions` и кнопка `ideas-toggle-summary-btn` для переключения видимости описания.  
- Добавлено состояние `state.isSummaryCollapsed` и функции `toggleSummarySection`, `applySummaryState`, `updateSummaryToggleButton` с навешиванием обработчика кнопки и управлением `aria-expanded`.  
- Добавлен CSS для класса `summary-collapsed`, который скрывает верхнюю текстовую секцию модального окна и расширяет зону графика, а также увеличена минимальная высота контейнера графика (`.ideas-modal__chart` — `min-height: 620px`).  
- При закрытии модалки состояние свёрнутости сбрасывается и выполняется безопасный ресайз чарта через `resizeIdeaChartSafely`.

### Testing
- Автоматические тесты не запускались для этого изменения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b5f8de7c8331aa82c3eecb8228d5)