### PR TITLE
Разделить подзаголовок и основной тезис в модальном окне /ideas

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -1169,7 +1169,7 @@
       const statusReason = buildIdeaStatusReason(idea, statusView);
 
       modalTitle.textContent = `${symbol} • ${signal} • ${statusView.label}`;
-      modalSubtitle.textContent = pickText(idea);
+      modalSubtitle.textContent = pickSubtitleText(idea);
 
       modalContent.innerHTML = `
         <div class="ideas-modal__top">
@@ -1184,7 +1184,7 @@
           </div>
 
           <div class="modal-section-title">Основная идея</div>
-          <div class="box modal-text">${escapeHtml(pickText(idea))}</div>
+          <div class="box modal-text">${escapeHtml(pickMainIdeaText(idea))}</div>
           ${renderSmartMoneyContext(idea)}
           ${renderFundamentalContext(idea)}
           <div class="status-reason">${escapeHtml(statusReason)}</div>
@@ -1959,6 +1959,36 @@
 
     function pickText(idea) {
       return (
+        idea.idea_thesis ||
+        idea.unified_narrative ||
+        idea.full_text ||
+        idea.fullText ||
+        idea.summary_ru ||
+        idea.summary ||
+        idea.short_text ||
+        idea.description_ru ||
+        "Описание идеи отсутствует."
+      );
+    }
+
+    function pickSubtitleText(idea) {
+      return (
+        idea.full_text ||
+        idea.fullText ||
+        idea.unified_narrative ||
+        idea.summary_ru ||
+        idea.summary ||
+        idea.short_text ||
+        idea.idea_thesis ||
+        idea.description_ru ||
+        "Описание идеи отсутствует."
+      );
+    }
+
+    function pickMainIdeaText(idea) {
+      const detailBrief = idea && typeof idea.detail_brief === "object" ? idea.detail_brief : null;
+      return (
+        detailBrief?.summary_narrative ||
         idea.idea_thesis ||
         idea.unified_narrative ||
         idea.full_text ||


### PR DESCRIPTION
### Motivation
- В интерфейсе модального окна `/ideas` подзаголовок и блок «Основная идея» рендерили один и тот же текст, из‑за чего терялся отдельный главный тезис; нужно показать в подзаголовке длинный narrative, а в секции — более целевой тезис. 

### Description
- В `app/static/ideas.html` заменил `modalSubtitle.textContent = pickText(idea)` на `modalSubtitle.textContent = pickSubtitleText(idea)` и переключил рендер секции «Основная идея» на `pickMainIdeaText(idea)`.
- Добавил две новые функции `pickSubtitleText(idea)` и `pickMainIdeaText(idea)`, где `pickMainIdeaText` даёт приоритет `detail_brief.summary_narrative`, затем `idea_thesis`, `unified_narrative` и далее стандартные fallback‑поля (`full_text`, `summary_ru` и т.д.).
- Изменения минимальны и сохраняют обратную совместимость с существующими полями идеи и поведением модалки. 

### Testing
- Запущен `pytest -q tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, который завершился с ошибкой импорта: `ImportError: cannot import name 'canonical_market_service' from 'app.main'`, что не связано с внесёнными фронтенд‑изменениями.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b96fb76c8331970e391e22a4e2f3)