### PR TITLE
Показать на карточке идеи статус теста уровня входа

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -1114,6 +1114,7 @@
       const statusView = resolveIdeaStatusView(idea);
       const statusReason = buildIdeaStatusReason(idea, statusView);
       const closeMeta = buildCloseMeta(idea);
+      const entryTouch = resolveEntryTouchView(idea, statusView);
 
       card.className = "card";
       card.dataset.ideaId = id;
@@ -1132,6 +1133,7 @@
           <span class="chip">Entry ${formatValue(idea.entry || idea.entry_price || idea.entry_zone)}</span>
           <span class="chip">SL ${formatValue(idea.stop_loss || idea.stopLoss || idea.sl)}</span>
           <span class="chip">TP ${formatValue(idea.take_profit || idea.takeProfit || idea.tp)}</span>
+          <span class="chip">Тест уровня входа: ${escapeHtml(entryTouch.label)}</span>
         </div>
 
         <div class="box">${escapeHtml(summary)}</div>
@@ -2070,6 +2072,26 @@
         icon: "👀",
         badgeClass: "badge-status-wait",
       };
+    }
+
+    function resolveEntryTouchView(idea, statusView = null) {
+      const rawStatus = String(idea.status || "").trim().toLowerCase();
+      const result = String(idea.result || "").trim().toUpperCase();
+      const updates = Array.isArray(idea.updates) ? idea.updates : [];
+      const hasTriggerEvent = updates.some((row) => {
+        const event = String((row && row.event) || "").trim().toLowerCase();
+        return event === "triggered" || event === "active";
+      });
+
+      if (["closed_tp", "closed_sl", "tp_hit", "sl_hit", "active", "triggered"].includes(rawStatus) || ["TP", "SL"].includes(result) || hasTriggerEvent) {
+        return { touched: true, label: "был" };
+      }
+
+      if (statusView && String(statusView.code || "") === "waiting") {
+        return { touched: false, label: "ещё не было" };
+      }
+
+      return { touched: false, label: "нет подтверждения" };
     }
 
     function buildIdeaStatusReason(idea, statusView) {


### PR DESCRIPTION
### Motivation
- Нужно быстро видеть на листинге идей, был ли уже вход от уровня `entry`, чтобы не открывать детальную карточку для проверки статуса входа.

### Description
- В `app/static/ideas.html` добавлена функция `resolveEntryTouchView(idea, statusView)`, которая определяет факт теста входа по `status`, `result` и событиям в `updates` (`triggered`/`active`).
- В рендере карточки (`renderCard`) вычисляется `entryTouch` и отображается новый чип в `chip-row`: `Тест уровня входа: был / ещё не было / нет подтверждения`.

### Testing
- Автоматизированные тесты не запускались; изменения ограничены фронтенд-шаблоном `app/static/ideas.html` и не затрагивают API-контракты.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ba9cec40833193590b25c5aff708)