### PR TITLE
Вернуть модалку идей из fullscreen и восстановить высоту графика

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -404,45 +404,40 @@
     .ideas-modal {
       position: fixed;
       inset: 0;
-      height: 100vh;
       z-index: 9999;
-      display: flex;
-      align-items: stretch;
-      justify-content: stretch;
-      background: rgba(2, 8, 20, 0.85);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: rgba(0,0,0,.78);
       backdrop-filter: blur(10px);
-      visibility: hidden;
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity .16s ease;
     }
 
     .modal-backdrop.open,
     .ideas-modal.open {
-      visibility: visible;
-      opacity: 1;
-      pointer-events: auto;
+      display: flex;
     }
 
     .modal,
     .ideas-modal__content {
-      width: 100%;
-      height: 100%;
-      border-radius: 0;
-      margin: 0;
-      padding: 0;
-      overflow: hidden;
-      background: linear-gradient(145deg, rgba(6,18,36,.98), rgba(3,10,22,.98));
+      width: min(1400px, 92vw);
+      height: 88vh;
+      max-height: 88vh;
+      overflow: auto;
+      border-radius: 26px;
+      background:
+        radial-gradient(circle at 90% 0%, rgba(69,202,255,.18), transparent 34%),
+        linear-gradient(160deg, rgba(24,58,103,.98), rgba(5,17,33,.98) 72%);
+      border: 1px solid rgba(124,184,255,.62);
+      box-shadow: 0 34px 110px rgba(0,0,0,.68);
+      padding: 24px;
       display: flex;
       flex-direction: column;
-      border: none;
-      box-shadow: none;
     }
 
     .ideas-modal__content {
       display: flex;
       flex-direction: column;
-      height: 100%;
     }
 
     .modal-head,
@@ -451,7 +446,7 @@
       justify-content: space-between;
       gap: 16px;
       margin: 0;
-      padding: 16px 20px;
+      padding: 0 0 16px;
       border-bottom: 1px solid rgba(255,255,255,.08);
       flex-shrink: 0;
     }
@@ -513,8 +508,8 @@
       flex: 1;
       display: flex;
       flex-direction: column;
-      padding: 14px 20px 18px;
-      overflow: hidden;
+      padding: 14px 0 18px;
+      overflow: auto;
       gap: 0;
     }
 
@@ -573,7 +568,7 @@
       overflow: hidden;
       background: rgba(2,10,20,.88);
       flex: 1;
-      min-height: 340px;
+      min-height: 620px;
       display: flex;
       flex-direction: column;
     }
@@ -622,15 +617,15 @@
     }
 
     .chart {
-      height: 520px;
+      height: 620px;
       width: 100%;
       position: relative;
     }
 
     .ideas-modal__body .chart {
       flex: 1;
-      min-height: 0;
-      height: 100%;
+      min-height: 620px;
+      height: 620px;
     }
 
     .ideas-modal__chart {
@@ -1238,6 +1233,7 @@
 
       setTimeout(() => renderIdeaChart(idea), 50);
       setTimeout(resizeIdeaChartSafely, 100);
+      setTimeout(resizeIdeaChartSafely, 300);
     }
 
     function renderFundamentalContext(idea) {
@@ -1273,11 +1269,18 @@
 
     function resizeIdeaChartSafely() {
       const container = document.getElementById("ideaChart");
-      if (!container || !state.chart || typeof state.chart.applyOptions !== "function") return;
-      state.chart.applyOptions({
-        width: Math.max(container.clientWidth, 320),
-        height: Math.max(container.clientHeight, 480),
-      });
+      if (!container || !state || !state.chart) return;
+
+      const rect = container.getBoundingClientRect();
+      const width = Math.max(320, Math.floor(rect.width));
+      const height = Math.max(560, Math.floor(rect.height));
+
+      try {
+        state.chart.resize(width, height);
+        state.chart.timeScale().fitContent();
+      } catch (error) {
+        console.warn("Idea chart resize skipped:", error);
+      }
     }
 
     async function renderIdeaChart(idea) {


### PR DESCRIPTION
### Motivation
- Текущий fullscreen-модал сжимает и смещает график, из‑за чего чарт становится слишком низким и неудобным для анализа.
- Нужно вернуть большой центрированный модал с ограничением ширины/высоты и естественной прокруткой контента, чтобы график был хорошо виден. 
- При этом не менять бэкенд, логику свечей/аннотаций и существующие ID/классы, используемые JS.

### Description
- Заменил CSS правилa для backdrop/модалки: отключено fullscreen-растяжение и добавлено центрирование с `width: min(1400px, 92vw)` и `height: 88vh`, скруглениями и внутренним скроллом (в файле `app/static/ideas.html`).
- Удалил/переопределил правила `width:100%/100vw`, `height:100%/100vh` и `border-radius:0`, а также подправил отступы в шапке и контенте чтобы текст не «съедал» вертикальную область модалки.
- Увеличил область графика: `min-height`/`height` установлены ~620px в стилях для `.chart` / `.ideas-modal__chart` и для `.chart-wrap`, чтобы убрать вертикальную компрессию.
- Обновил JS ресайз: добавил дополнительный отложенный вызов `setTimeout(resizeIdeaChartSafely, 300)`, и переписал `resizeIdeaChartSafely()` на более устойчивую версию, использующую `state.chart.resize(width,height)` + `state.chart.timeScale().fitContent()` в `try/catch`, с проверкой наличия `state` и `state.chart` (в `app/static/ideas.html`).

### Testing
- Выполнил статическую проверку изменений и просмотр патча с помощью `rg`, `sed` и `git diff` для `app/static/ideas.html` и подтвердил внесённые правки. 
- Успешно зафиксировал изменения коммитом через `git commit`.
- Автоматические тесты проекта не запускались, внесение ограничено только фронтенд-файлом и не меняет серверную логику.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c02bef7483318f6b8505b2e3b123)