### PR TITLE
Модалка идеи: краткий верхний блок и полноэкранный график

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -525,7 +525,9 @@
     .ideas-modal__top-actions {
       display: flex;
       justify-content: flex-end;
+      gap: 8px;
       margin-bottom: 10px;
+      flex-wrap: wrap;
     }
 
     .ideas-toggle-summary-btn {
@@ -925,6 +927,11 @@
     document.addEventListener("keydown", (event) => {
       if (event.key === "Escape") closeModal();
     });
+    document.addEventListener("fullscreenchange", () => {
+      const fullscreenChartBtn = document.getElementById("fullscreenChartBtn");
+      updateFullscreenButton(fullscreenChartBtn);
+      resizeIdeaChartSafely();
+    });
 
     async function loadIdeas(manual = false) {
       if (manual) {
@@ -1181,6 +1188,7 @@
         <div class="ideas-modal__top">
           <div class="ideas-modal__top-actions">
             <button id="toggleSummaryBtn" class="ideas-toggle-summary-btn" type="button" aria-expanded="true">Свернуть описание</button>
+            <button id="fullscreenChartBtn" class="ideas-toggle-summary-btn" type="button">График на весь экран</button>
           </div>
           <div class="modal-grid">
             <div class="level entry">ENTRY<br>${formatValue(idea.entry || idea.entry_price || idea.entry_zone)}</div>
@@ -1237,12 +1245,40 @@
 
       const toggleSummaryBtn = document.getElementById("toggleSummaryBtn");
       if (toggleSummaryBtn) toggleSummaryBtn.addEventListener("click", toggleSummarySection);
+      const fullscreenChartBtn = document.getElementById("fullscreenChartBtn");
+      if (fullscreenChartBtn) {
+        fullscreenChartBtn.addEventListener("click", () => toggleChartFullscreen(fullscreenChartBtn));
+        updateFullscreenButton(fullscreenChartBtn);
+      }
 
       applySummaryState();
 
       setTimeout(() => renderIdeaChart(idea), 50);
       setTimeout(resizeIdeaChartSafely, 100);
       setTimeout(resizeIdeaChartSafely, 300);
+    }
+
+
+    function updateFullscreenButton(button) {
+      if (!button) return;
+      const isFullscreen = Boolean(document.fullscreenElement);
+      button.textContent = isFullscreen ? "Выйти из полноэкранного" : "График на весь экран";
+    }
+
+    async function toggleChartFullscreen(button) {
+      const chartWrap = document.querySelector(".chart-wrap");
+      if (!chartWrap) return;
+      try {
+        if (document.fullscreenElement) {
+          await document.exitFullscreen();
+        } else if (chartWrap.requestFullscreen) {
+          await chartWrap.requestFullscreen();
+        }
+      } catch (error) {
+        console.warn("Fullscreen toggle skipped:", error);
+      }
+      updateFullscreenButton(button);
+      setTimeout(resizeIdeaChartSafely, 80);
     }
 
     function renderFundamentalContext(idea) {
@@ -1988,25 +2024,22 @@
     }
 
     function pickSubtitleText(idea) {
-      return (
-        idea.full_text ||
-        idea.fullText ||
-        idea.unified_narrative ||
+      const shortText = (
+        idea.idea_thesis ||
         idea.summary_ru ||
         idea.summary ||
         idea.short_text ||
-        idea.idea_thesis ||
         idea.description_ru ||
         "Описание идеи отсутствует."
       );
+      return trimToLength(shortText, 170);
     }
 
     function pickMainIdeaText(idea) {
       const detailBrief = idea && typeof idea.detail_brief === "object" ? idea.detail_brief : null;
       return (
-        detailBrief?.summary_narrative ||
-        idea.idea_thesis ||
         idea.unified_narrative ||
+        detailBrief?.summary_narrative ||
         idea.full_text ||
         idea.fullText ||
         idea.summary_ru ||
@@ -2015,6 +2048,13 @@
         idea.description_ru ||
         "Описание идеи отсутствует."
       );
+    }
+
+    function trimToLength(text, maxLength = 170) {
+      const normalized = String(text || "").replace(/\s+/g, " ").trim();
+      if (!normalized) return "Описание идеи отсутствует.";
+      if (normalized.length <= maxLength) return normalized;
+      return `${normalized.slice(0, maxLength - 1).trim()}…`;
     }
 
     function renderSentimentBadge(idea) {


### PR DESCRIPTION
### Motivation
- Сделать верхний блок модалки действительно кратким, чтобы не дублировать длинный текст вверху и в основной секции. 
- Отделить краткий заголовок/подзаголовок от основного объяснения идеи, чтобы `unified_narrative` (Grok/LLM) был основным источником для блока «Основная идея». 
- Добавить возможность развернуть график на весь экран для детального анализа. 
- Сохранить существующее поведение скрытия/разворачивания описания по клику и обеспечить корректный ресайз графика после изменений размеров или перехода в full‑screen.

### Description
- В `app/static/ideas.html` добавлена кнопка `График на весь экран` и реализация Fullscreen API с функциями `toggleChartFullscreen` и `updateFullscreenButton` для входа/выхода из полноэкранного режима и обновления подписи кнопки. 
- Добавлена обработка события `fullscreenchange`, чтобы автоматически ресайзить график через `resizeIdeaChartSafely` при смене режима. 
- Верхний текст (subtitle) теперь формируется новой логикой: `pickSubtitleText` выбирает короткие поля и обрезает текст до ~170 символов через `trimToLength`, чтобы убрать дубли и сделать краткое описание. 
- Основной блок `Основная идея` теперь отдаёт приоритет `unified_narrative` в `pickMainIdeaText` (fallback — legacy поля), и сохранены существующие рендеры `smart_money_context` и `fundamental_context`. 
- Небольшие CSS‑правки для `.ideas-modal__top-actions` (отступы/перенос) и поддержка адаптивного поведения modal/chart layout.

### Testing
- Запущена автоматическая компиляция Python: `python -m compileall app` — выполнение завершилось с ошибкой не связанной с этими изменениями (`SyntaxError` в `app/services/chart_snapshot_service.py`: строка содержит `from **future** import annotations`). 
- Изменения в `app/static/ideas.html` проверены через просмотр diff и статический анализ содержимого файла (ревью изменений по файлу `app/static/ideas.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ca276e248331b1de98fdb4e66145)