### PR TITLE
Исправить прокрутку модалки и восстановить видимость графика

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -792,8 +792,8 @@
   overflow: hidden !important;
   padding: 16px !important;
   border-radius: 24px !important;
-  display: grid !important;
-  grid-template-rows: auto 1fr !important;
+  display: flex !important;
+  flex-direction: column !important;
 }
 
 .modal-head {
@@ -814,26 +814,21 @@
 
 #modalContent {
   min-height: 0 !important;
-  overflow: hidden !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  flex: 1 !important;
   display: grid !important;
   grid-template-rows: auto 1fr !important;
   gap: 10px !important;
-}
-
-/* Hide/compact text-heavy blocks so chart gets space */
-#modalContent .modal-grid,
-#modalContent .modal-section-title,
-#modalContent .modal-text,
-#modalContent .status-reason {
-  display: none !important;
+  scroll-behavior: smooth;
 }
 
 .chart-wrap {
-  min-height: 0 !important;
+  min-height: 500px !important;
   height: 100% !important;
   display: grid !important;
   grid-template-rows: auto auto 1fr auto !important;
-  margin: 0 !important;
+  margin-top: 12px !important;
 }
 
 .chart-toolbar {
@@ -853,9 +848,9 @@
 
 .chart,
 #ideaChart {
-  height: 100% !important;
-  min-height: 560px !important;
   width: 100% !important;
+  height: 500px !important;
+  min-height: 500px !important;
 }
 
 .chart-note {


### PR DESCRIPTION
### Motivation
- Модальное окно идей было не прокручиваемым и скрывало график из-за `overflow: hidden` на контейнерах, что делало график недостижимым для пользователя.
- Нужно сохранить центрирование и общий layout модалки, но позволить вертикальную прокрутку внутри контента, чтобы график стал видим и доступен.

### Description
- Внесены точечные CSS-правки в `app/static/ideas.html`: контейнер `.modal` заменён на `display: flex` с `flex-direction: column` для корректного распределения заголовка и контента.
- В `#modalContent` заменён блокирующий `overflow` на `overflow-y: auto` и `overflow-x: hidden`, добавлены `flex: 1` и `scroll-behavior: smooth` для внутренней прокрутки.
- Удалены правила, которые скрывали текстовые секции внутри модалки (`.modal-grid`, `.modal-text` и т.п.), чтобы контент отображался корректно.
- Для области графика добавлены `margin-top: 12px` и `min-height: 500px`, а у `#ideaChart` задана высота `500px` и `min-height: 500px`, чтобы график был видим и доступен для взаимодействия.

### Testing
- Автоматические тесты не запускались.
- Изменения внесены автоматизированным скриптом и проверены наличием/корректностью правок с помощью `rg` и просмотра файла (`nl`), правки успешно применены в `app/static/ideas.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1dc5a2a24833190ef93faa090ef93)