### PR TITLE
Упростить верхний блок модального окна идеи

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -1284,13 +1284,12 @@
       state.currentTf = pickDefaultTf(idea);
       state.isSummaryCollapsed = false;
 
-      const symbol = normalizeSymbol(idea.symbol || idea.pair || "MARKET");
       const signal = normalizeSignal(idea.final_signal || idea.signal || idea.direction || idea.bias);
       const statusView = resolveIdeaStatusView(idea);
       const statusReason = buildIdeaStatusReason(idea, statusView);
 
-      modalTitle.textContent = `${symbol} • ${signal} • ${statusView.label}`;
-      modalSubtitle.textContent = pickSubtitleText(idea);
+      modalTitle.textContent = `${signal} • ${statusView.label}`;
+      modalSubtitle.textContent = "";
 
       modalContent.innerHTML = `
         <div class="ideas-modal__top">


### PR DESCRIPTION
### Motivation
- Упростить верхний UI модалки идеи: в заголовке оставить только направление и статус, убрать громоздкий подзаголовок для снижения визуального шума.

### Description
- В `app/static/ideas.html` в `openModal` заголовок теперь формируется как `${signal} • ${statusView.label}` и `modalSubtitle` очищается, символ инструмента из верхнего блока убран, остальная разметка модалки сохранена.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e05e8264833181a62a18b1d8c4be)