### PR TITLE
Finish real candle fallback diagnostics safely

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -501,6 +501,7 @@ def api_debug_candles(symbol: str, tf: str, limit: int = 160):
         "source_symbol": payload.get("source_symbol"),
         "interval": payload.get("interval"),
         "cache_status": payload.get("cache_status"),
+        "providers_tried": payload.get("providers_tried") or [],
         "warning_ru": payload.get("warning_ru"),
         "raw_error": payload.get("raw_error"),
         "first": candles[0] if candles else None,
@@ -514,7 +515,6 @@ def api_debug_dukascopy(symbol: str, tf: str, limit: int = 160):
     candles = payload.get("candles") or []
     return {
         "symbol": normalize_symbol(symbol),
-        "provider_symbol": to_dukascopy_symbol(symbol),
         "tf": tf,
         "count": len(candles),
         "provider": payload.get("provider"),
@@ -826,6 +826,8 @@ def get_candles_with_markup(symbol: str, tf: str = "M15", limit: int = 160) -> d
         "annotations": annotations,
         "market_structure": market_structure,
         "warning_ru": candles_payload.get("warning_ru"),
+        "providers_tried": candles_payload.get("providers_tried") or [],
+        "candles_count": len(candles),
         "diagnostics": {
             "attempts": candles_payload.get("attempts"),
             "raw_error": candles_payload.get("raw_error"),
@@ -893,13 +895,22 @@ def to_dukascopy_period(tf: str) -> str:
         "H1": "60",
         "H4": "240",
         "D1": "1440",
-    }.get(tf, "15")
+    }.get(tf, "")
 
 
 def fetch_dukascopy_candles(symbol: str, tf: str = "M15", limit: int = 160) -> dict[str, Any]:
     normalized_symbol = normalize_symbol(symbol)
     provider_symbol = to_dukascopy_symbol(normalized_symbol)
     period = to_dukascopy_period(tf)
+    if not period:
+        return {
+            "candles": [],
+            "provider": "dukascopy",
+            "source_symbol": provider_symbol,
+            "interval": None,
+            "warning_ru": f"Dukascopy не поддерживает таймфрейм {str(tf).upper()}.",
+            "raw_error": "unsupported_timeframe",
+        }
     if provider_symbol == "XAUUSD":
         return {
             "candles": [],


### PR DESCRIPTION
### Motivation
- Устранить причину пустого графика идей, добавив явную диагностику и безопасный fallback на Dukascopy без генерации фейковых свечей.
- Дать фронтенду точную информацию о том, какие провайдеры пробовались (TwelveData → Dukascopy) и почему свечи недоступны.

### Description
- В `/api/debug/candles/{symbol}/{tf}` добавлено поле `providers_tried` для явного отображения последовательности попыток провайдеров.
- Приведён `/api/debug/dukascopy/{symbol}/{tf}` к требуемому формату (убран `provider_symbol`, сохранены `count`, `provider`, `warning_ru`, `raw_error`, `first`, `last`).
- Изменён `to_dukascopy_period` чтобы не маппить неизвестные таймфреймы на `M15`, и в `fetch_dukascopy_candles` добавлена ранняя безопасная обработка неподдерживаемого таймфрейма с `warning_ru` и `raw_error=unsupported_timeframe`.
- В пакетном ответе `get_candles_with_markup` добавлены `providers_tried` и `candles_count` и сохранён блок `diagnostics`, чтобы `/api/canonical/chart/{symbol}/{tf}` возвращал необходимую информацию для фронтенда.

### Testing
- Выполнена проверка синтаксиса `python -m py_compile app/main.py` — успешно.
- Локальный smoke тест импорта и вызова функций показал, что `fetch_candles('EURUSD','M15',10)` возвращает `providers_tried` содержащий `['twelvedata','dukascopy']`, `api_debug_candles(...)` и `api_debug_dukascopy(...)` возвращают ожидаемые ключи, а `get_candles_with_markup(...)` содержит `candles_count` и `providers_tried`; все проверки успешны.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e85b83488331ac12510875f23b5e)