### PR TITLE
Fix missing JSONResponse import for MT4 bridge

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import requests
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.services.htf_context_filter import HtfContextFilter


### PR DESCRIPTION
### Motivation
- Устранить `NameError` при обработке `/api/mt4/push-candles` путём добавления отсутствующего импорта `JSONResponse`.

### Description
- Добавлен импорт `JSONResponse` в `app/main.py` рядом с существующим `FileResponse`, без изменений логики эндпоинтов.

### Testing
- Проверено с помощью `fastapi.testclient`: `GET /api/debug/mt4-bridge` вернул `200`, `POST /api/mt4/push-candles` с пустым payload вернул `400 invalid_payload`, и ошибка `NameError: JSONResponse is not defined` больше не возникает.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32606795c83319fb8e42fd8582b96)