### PR TITLE
Исправить /api/signals — делать MT4 свечи первичным источником

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2555,6 +2555,29 @@ def build_empty_timeframe_ideas(
 def get_price(symbol: str) -> dict[str, Any]:
     symbol = normalize_symbol(symbol)
 
+    # MT4 bridge/candles are primary for signal pricing.
+    try:
+        candles_payload = fetch_candles(symbol, tf="M15", limit=2)
+        candles = candles_payload.get("candles") or []
+        if candles:
+            last_close = first_float(candles[-1].get("close"))
+            if last_close is not None:
+                cache_status = str(candles_payload.get("cache_status") or "").lower()
+                provider = str(candles_payload.get("provider") or "unknown")
+                return {
+                    "symbol": symbol,
+                    "source_symbol": candles_payload.get("source_symbol") or symbol,
+                    "price": float(last_close),
+                    "source": provider,
+                    "provider": provider,
+                    "data_status": "real" if cache_status == "live" else "delayed",
+                    "is_live_market_data": cache_status == "live",
+                    "updated_at_utc": candles_payload.get("updated_at_utc"),
+                }
+    except Exception:
+        # Never block signal generation on primary source read errors.
+        pass
+
     ws = twelvedata_ws_service.get_price(symbol)
 
     if ws.get("price") is not None and ws.get("data_status") == "real":


### PR DESCRIPTION
### Motivation
- Фронтенд показывал «Не удалось загрузить котировки /api/signals» потому что путь формирования сигнала не использовал MT4 bridge как первичный источник цен. 
- Нужно сделать MT4/bridge свечи приоритетными и при этом не блокировать выдачу сигналов при ошибках резервных провайдеров.

### Description
- В `app/main.py` в `get_price()` добавлен приоритет: сначала вызывается `fetch_candles(symbol, tf="M15", limit=2)` и цена берётся из `candles[-1]["close"]` при наличии свечей. 
- Из payload свечей прокидываются `provider`, `data_status` (`real`/`delayed`), `is_live_market_data` и `updated_at_utc`, а при ошибках чтения primary-источника выполнение мягко падает к существующим WS/REST fallback-провайдерам. 
- MT4 bridge и fallback-логика не удалялись и схема ответов на уровне API не изменялась, чтобы не ломать фронтенд.

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile app/main.py`, сборка файла прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3642004dc8331af3d7a50e3371a63)