### PR TITLE
Исправить рендер переключателя голоса на /ideas

### DIFF
--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -105,17 +105,21 @@ function updateVoiceToggleLabel(button) {
 }
 
 function initVoiceToggle() {
-  if (!ideasUpdatedAt || document.getElementById("voiceToggleButton")) return;
+  if (!document.body || document.getElementById("voice-toggle-btn")) return;
   if (localStorage.getItem(VOICE_STORAGE_KEY) !== "1" && localStorage.getItem(VOICE_STORAGE_KEY) !== "0") {
     setVoiceEnabled(false);
   }
 
   const button = document.createElement("button");
-  button.id = "voiceToggleButton";
+  button.id = "voice-toggle-btn";
   button.type = "button";
-  button.style.marginLeft = "10px";
-  button.style.padding = "4px 10px";
+  button.style.position = "fixed";
+  button.style.top = "16px";
+  button.style.right = "16px";
+  button.style.zIndex = "9999";
+  button.style.padding = "8px 12px";
   button.style.fontSize = "12px";
+  button.style.borderRadius = "8px";
   button.style.cursor = "pointer";
   updateVoiceToggleLabel(button);
 
@@ -124,7 +128,7 @@ function initVoiceToggle() {
     updateVoiceToggleLabel(button);
   });
 
-  ideasUpdatedAt.insertAdjacentElement("afterend", button);
+  document.body.appendChild(button);
 }
 
 function enqueueVoiceMessage(message) {
@@ -343,6 +347,14 @@ async function loadIdeas() {
   }
 }
 
-initVoiceToggle();
-loadIdeas();
-setInterval(loadIdeas, 60000);
+function startIdeasPage() {
+  initVoiceToggle();
+  loadIdeas();
+  setInterval(loadIdeas, 60000);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", startIdeasPage);
+} else {
+  startIdeasPage();
+}


### PR DESCRIPTION
### Motivation
- Переключатель голосовых уведомлений мог не отображаться из‑за вставки рядом с конкретным контейнером страницы, что ломало видимость при изменениях layout. 
- Требовалось гарантировать, что кнопка всегда присутствует в DOM и не затрагивать бэкенд или другие части приложения.

### Description
- Инициализация перенесена в безопасный старт после готовности DOM через `startIdeasPage()` и запуск через `DOMContentLoaded` либо сразу, если DOM уже загружен. 
- `initVoiceToggle()` теперь создаёт кнопку с `id="voice-toggle-btn"`, проверяет наличие `document.body` и предотвращает дублирование по id. 
- Кнопка добавляется в документ через `document.body.appendChild(button)` и позиционируется фиксировано в правом верхнем углу с `position: fixed`, `top/right`, `z-index` и базовой стилевой обёрткой. 
- Сохранение состояния по ключу `voice_notifications_enabled` осталось прежним, а текст кнопки отображает `Голос: ON / OFF` и переключается обработчиком клика.

### Testing
- Автоматические unit/integration тесты не запускались. 
- Локальная проверка файла подтвердила, что `app/static/ideas.js` содержит обновлённую логику инициализации кнопки и безопасный старт после загрузки DOM.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f396144c5c83318210b41569097cd4)