### PR TITLE
Показать кнопку "Голос" на странице /ideas

### DIFF
--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -116,11 +116,15 @@ function initVoiceToggle() {
   button.style.position = "fixed";
   button.style.top = "16px";
   button.style.right = "16px";
-  button.style.zIndex = "9999";
+  button.style.zIndex = "999999";
   button.style.padding = "8px 12px";
   button.style.fontSize = "12px";
   button.style.borderRadius = "8px";
   button.style.cursor = "pointer";
+  button.style.background = "#111827";
+  button.style.color = "#f9fafb";
+  button.style.border = "1px solid #374151";
+  button.style.boxShadow = "0 4px 12px rgba(0, 0, 0, 0.35)";
   updateVoiceToggleLabel(button);
 
   button.addEventListener("click", () => {


### PR DESCRIPTION
### Motivation
- На странице `/ideas` кнопка голосовых уведомлений была невидима из‑за низкого `z-index` и недостаточного контраста, поэтому нужно было гарантировать её видимость без изменений бэкенда или верстки контейнеров.

### Description
- Обновлён файл `app/static/ideas.js`: увеличен `z-index` кнопки `#voice-toggle-btn` до `999999` и добавлены минимальные inline‑стили (`background`, `color`, `border`, `boxShadow`) для гарантированного отображения при фиксированном позиционировании; логика создания кнопки, добавление через `document.body.appendChild(button)`, `id="voice-toggle-btn"`, хранение состояния в `localStorage` (`voice_notifications_enabled`) и поведение переключателя остались без изменений.

### Testing
- Выполнены команды `git diff -- app/static/ideas.js` и `git commit -m "Fix visible voice toggle button on ideas page"`, обе команды выполнились успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39c6a39a48331b7e1dbc40874a07a)