### PR TITLE
Добавить всегда видимую кнопку переключения голоса на /ideas

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -2653,5 +2653,44 @@
     loadIdeas();
     setInterval(() => loadIdeas(false), 120000);
   </script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  console.log("VOICE INIT START");
+
+  const btn = document.createElement("button");
+  btn.id = "voice-toggle-btn";
+
+  let enabled = localStorage.getItem("voice_notifications_enabled") === "1";
+
+  function updateText() {
+    btn.textContent = "Голос: " + (enabled ? "ON" : "OFF");
+  }
+
+  btn.style.position = "fixed";
+  btn.style.top = "20px";
+  btn.style.right = "20px";
+  btn.style.zIndex = "999999";
+  btn.style.padding = "10px 14px";
+  btn.style.borderRadius = "10px";
+  btn.style.background = "#0b1f3d";
+  btn.style.color = "#fff";
+  btn.style.border = "1px solid #4da3ff";
+  btn.style.fontSize = "14px";
+  btn.style.cursor = "pointer";
+
+  btn.onclick = () => {
+    enabled = !enabled;
+    localStorage.setItem("voice_notifications_enabled", enabled ? "1" : "0");
+    updateText();
+    console.log("VOICE TOGGLED:", enabled);
+  };
+
+  updateText();
+
+  document.body.appendChild(btn);
+
+  console.log("VOICE BUTTON ADDED");
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Исправить неработающую реализацию: кнопка голосовых уведомлений не отображалась в UI и должна быть гарантированно видимой на странице `/ideas`.
- Изменение выполнено строго на фронтенде без правок бэкенда или API по требованиям.

### Description
- В конец `app/static/ideas.html` перед `</body>` добавлен встроенный `<script>` который принудительно создаёт и добавляет в `document.body` кнопку с `id="voice-toggle-btn"` на каждом загрузке страницы.
- Скрипт управляет состоянием через `localStorage` под ключом `voice_notifications_enabled`, отображает текст `Голос: ON/OFF`, логирует `VOICE INIT START` и `VOICE BUTTON ADDED`, и обрабатывает `onclick` для переключения и сохранения состояния.
- Кнопка позиционируется фиксировано в правом верхнем углу через inline-стили (`position: fixed; top: 20px; right: 20px;`) и не зависит от существующей структуры DOM.

### Testing
- Автоматических тестов не запускалось.
- Файл `app/static/ideas.html` обновлён и закоммичен, изменения отражены в диффе проекта.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a05ca4848331b64ee6c960825cbc)