### PR TITLE
Обновить голосовые оповещения: русские названия инструментов и без озвучки цен

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -1200,18 +1200,29 @@
       );
     }
 
+    function voiceSymbolLabel(symbolRaw) {
+      const symbol = String(symbolRaw || "").toUpperCase();
+      if (symbol === "EURUSD") return "евродоллар";
+      if (symbol === "USDJPY") return "доллар йена";
+      if (symbol === "GBPUSD") return "фунт доллар";
+      if (symbol === "XAUUSD") return "золото";
+      return "инструмент";
+    }
+
+    function voiceActionLabel(actionRaw) {
+      const action = String(actionRaw || "").toUpperCase();
+      if (action === "BUY") return "покупка";
+      if (action === "SELL") return "продажа";
+      return "ожидание";
+    }
+
     function speakIdeaChange(idea) {
       if (!window.speechSynthesis) return;
       if (localStorage.getItem("ideas_voice_enabled") !== "true") return;
 
-      const symbol = idea.symbol || "инструмент";
-      const action = idea.action || idea.signal || "WAIT";
-      const status = idea.status || "";
-      const entry = idea.entry ? `Вход ${idea.entry}.` : "";
-      const sl = idea.sl ? `Стоп ${idea.sl}.` : "";
-      const tp = idea.tp ? `Тейк ${idea.tp}.` : "";
-
-      const text = `Новая идея по ${symbol}. Сигнал ${action}. ${status}. ${entry} ${sl} ${tp}`;
+      const symbolLabel = voiceSymbolLabel(idea.symbol);
+      const actionLabel = voiceActionLabel(idea.action || idea.signal || "WAIT");
+      const text = `${symbolLabel} ${actionLabel}`;
 
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.lang = "ru-RU";

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -76,19 +76,28 @@ function createIdeaComparableState(idea) {
   };
 }
 
-function formatVoiceMessage(type, idea) {
-  const symbol = String(idea?.instrument || idea?.symbol || "инструмент").trim() || "инструмент";
-  const signal = String(idea?.signal || idea?.label || "сигнал").trim() || "сигнал";
-  const entry = String(idea?.entry ?? "").trim();
-  const sl = String(idea?.sl ?? idea?.stop_loss ?? "").trim();
-  const tp = String(idea?.tp ?? idea?.target ?? "").trim();
+function voiceSymbolLabel(symbolRaw) {
+  const symbol = String(symbolRaw || "").trim().toUpperCase();
+  if (symbol === "EURUSD") return "евродоллар";
+  if (symbol === "USDJPY") return "доллар йена";
+  if (symbol === "GBPUSD") return "фунт доллар";
+  if (symbol === "XAUUSD") return "золото";
+  return "инструмент";
+}
 
-  const prefix = type === "new" ? "Новая идея" : "Обновление идеи";
-  const parts = [`${prefix} ${symbol}.`, `${signal}.`];
-  if (entry) parts.push(`Вход ${entry}.`);
-  if (sl) parts.push(`Стоп ${sl}.`);
-  if (tp) parts.push(`Цель ${tp}.`);
-  return parts.join(" ");
+function voiceActionLabel(signalRaw) {
+  const signal = String(signalRaw || "").trim().toUpperCase();
+  if (signal === "BUY" || signal === "ИДЕЯ ПОКУПКИ") return "покупка";
+  if (signal === "SELL" || signal === "ИДЕЯ ПРОДАЖИ") return "продажа";
+  return "ожидание";
+}
+
+function formatVoiceMessage(type, idea) {
+  const symbol = String(idea?.instrument || idea?.symbol || "").trim();
+  const signal = String(idea?.signal || idea?.label || "").trim();
+  const symbolLabel = voiceSymbolLabel(symbol);
+  const actionLabel = voiceActionLabel(signal);
+  return `${symbolLabel} ${actionLabel}`;
 }
 
 function isVoiceEnabled() {


### PR DESCRIPTION
### Motivation
- Сделать голосовые уведомления краткими и понятными на русском для ключевых инструментов и убрать чтение цен по требованию продукта.
- Устранить дублирование формата озвучки в двух фронтенд-потоках, чтобы везде звучали одинаковые короткие фразы.

### Description
- В `app/static/ideas.html` добавлены функции `voiceSymbolLabel` и `voiceActionLabel`, а в `speakIdeaChange` формируется короткая фраза вида `${symbolLabel} ${actionLabel}` вместо полной строки с ценами и статусом. 
- В `app/static/ideas.js` введены те же функции `voiceSymbolLabel` и `voiceActionLabel` и изменён `formatVoiceMessage`, чтобы генерация очереди голосовых уведомлений возвращала такой же короткий формат. 
- Поддерживаются русские голосовые метки для `EURUSD`, `USDJPY`, `GBPUSD` и `XAUUSD` как `евродоллар`, `доллар йена`, `фунт доллар`, `золото`, а направления `BUY/SELL` конвертируются в `покупка/продажа`.
- Изменения ограничены фронтендом и не затрагивают API, контракты данных или серверную логику.

### Testing
- Проверен `git diff -- app/static/ideas.html app/static/ideas.js` и подтверждён ожидаемый набор изменений в голосовой логике. (успешно)
- Выполнен `git status --short` для проверки состояния рабочего дерева и подтверждена чистота после изменений. (успешно)
- Просмотрены выпуски с помощью `nl -ba` / `sed` для `app/static/ideas.html` и `app/static/ideas.js`, чтобы убедиться в корректной вставке новых функций и формировании текста для `SpeechSynthesisUtterance`. (успешно)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a80a79ac83319b20ee58502c0951)