### PR TITLE
Исправить роут `/analytics` в production entrypoint (`app/main.py`)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -138,6 +138,11 @@ def calendar_page():
     return FileResponse(STATIC_DIR / "calendar.html")
 
 
+@app.get("/analytics", include_in_schema=False)
+def analytics_page():
+    return FileResponse(STATIC_DIR / "analytics.html")
+
+
 def get_fallback_calendar_events() -> list[dict[str, Any]]:
     return [
         {


### PR DESCRIPTION
### Motivation
- Сейчас продакшен-Entrypoint использует `app/main.py`, а маршрут `/analytics` был добавлен только в корневой `main.py`, поэтому на Render приходил `{"detail":"Not Found"}`.
- Нужно гарантировать, что страница аналитики обслуживается из основного приложения и навигация ведёт на корректный путь.

### Description
- Добавлен route `GET /analytics` в `app/main.py`, возвращающий `FileResponse(STATIC_DIR / "analytics.html")`, и помещён рядом с существующими статическими страницами (`/`, `/ideas`, `/news`, `/calendar`, `/heatmap/page`).
- Файл страницы подтверждён в репозитории как `app/static/analytics.html`, а ссылки в `app/static/index.html` уже указывают на `/analytics` в верхней и быстрой навигации.
- Сохранена совместимость с корневым `main.py` и не изменялась логика `/ideas` или генерации сигналов, а также не раскрывались никакие API-ключи.

### Testing
- Запущен Unit-интеграционный запрос через `fastapi.testclient` с проверкой путей: `GET /analytics`, `GET /ideas`, `GET /health`.
- Результат теста: `/analytics` вернул `200` с `text/html`, `/ideas` вернул `200` с `text/html`, и `/health` вернул `200` с JSON `{ "status": "ok" }`.
- Коммит изменений присутствует в рабочем дереве и готов к деплою на Render; автоматические проверки для перечисленных маршрутов прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41b98b10083318e996d2ba9f7147b)