### PR TITLE
Add main navigation links to ideas page header

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -1005,7 +1005,14 @@
               Entry / SL / TP фиксируются. График строится только по реальным свечам backend. Фейковые свечи отключены.
             </div>
           </div>
-          <a class="home-link" href="/">На главную</a>
+          <nav aria-label="Основная навигация">
+            <a class="home-link" href="/">Главная</a>
+            <a class="home-link" href="/ideas">Идеи</a>
+            <a class="home-link" href="/analytics">Аналитика</a>
+            <a class="home-link" href="/news">Новости</a>
+            <a class="home-link" href="/calendar">Календарь</a>
+            <a class="home-link" href="/heatmap/page">Тепловая карта</a>
+          </nav>
         </div>
 
         <section class="controls">


### PR DESCRIPTION
### Motivation
- Replace a single home link with an accessible page-level navigation to allow quick access to other site sections from the ideas page header.

### Description
- Updated `app/static/ideas.html` to replace the single `<a class="home-link">` with a `<nav aria-label="Основная навигация">` containing links to `"/"`, `"/ideas"`, `"/analytics"`, `"/news"`, `"/calendar"`, and `"/heatmap/page"`, and changed the home link text from `"На главную"` to `"Главная"`.

### Testing
- No automated tests were run for this small static HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4471b04588331bea1fcb32133f9b5)