### PR TITLE
Исправить `/api/chat`: корректный вызов AI и устойчивый JSON-фоллбек

### DIFF
--- a/backend/chat_service.py
+++ b/backend/chat_service.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+import re
 from typing import Any
 
 from openai import AsyncOpenAI
 
 from app.core.env import get_openrouter_api_key, get_openrouter_model
 from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger(__name__)
 
 
 CHAT_SYSTEM_PROMPT = """
@@ -155,24 +160,25 @@ class ForexChatService:
                 if smc_analysis_mode
                 else CHAT_SYSTEM_PROMPT
             )
-            response = await self.client.responses.create(
+            response = await self.client.chat.completions.create(
                 model=self.model,
-                input=[
+                messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0.1 if explanation_mode else 0.2,
             )
-            text = (response.output_text or "").strip()
+            text = (response.choices[0].message.content or "").strip() if response.choices else ""
             if not text:
                 return self._fallback(
-                    "Модель не вернула содержательный ответ. Попробуйте уточнить вопрос по сигналу, риску или аналитике.",
+                    self._build_mock_analysis(message),
                     warnings=["empty_model_response"],
                 )
             return ChatResponse(reply=text, source="openrouter", dataStatus="live", warnings=[])
         except Exception:
+            logger.exception("Ошибка запроса к AI-модели в /api/chat")
             return self._fallback(
-                "Не удалось получить ответ от AI-модели. Попробуйте позже или задайте более узкий вопрос по forex-сценарию.",
+                self._build_mock_analysis(message),
                 warnings=["openrouter_request_failed"],
             )
 
@@ -284,3 +290,14 @@ class ForexChatService:
     @staticmethod
     def _fallback(message: str, *, warnings: list[str]) -> ChatResponse:
         return ChatResponse(reply=message, source="openrouter", dataStatus="fallback", warnings=warnings)
+
+    @staticmethod
+    def _build_mock_analysis(message: str) -> str:
+        pair_match = re.search(r"\b(EURUSD|GBPUSD|USDJPY|USDCHF|AUDUSD|NZDUSD|USDCAD|XAUUSD)\b", message.upper())
+        payload = {
+            "pair": pair_match.group(1) if pair_match else "EURUSD",
+            "bias": "neutral",
+            "summary": "Недостаточно данных для анализа",
+            "confidence": 0,
+        }
+        return json.dumps(payload, ensure_ascii=False)


### PR DESCRIPTION
### Motivation
- Фронтенд падал при вызове `POST /api/chat` с ошибкой «Не удалось получить ответ от AI-модели» из-за несовместного вызова SDK; нужно восстановить работу endpoint без изменения контрактов.
- Нельзя менять фронтенд, маршрутизацию или данные рынка, поэтому исправление должно быть только в бэкенд-чате и быть обратимо-совместимым.
- При недоступности внешней модели требуется безопасный структурированный фоллбек вместо ошибки, чтобы UI продолжал работать.

### Description
- Заменён вызов несовместного метода `responses.create` на совместимый с текущим SDK вызов `chat.completions.create` и адаптирован разбор ответа (`response.choices[0].message.content`).
- Добавлено логирование ошибок запроса к модели через `logger.exception(...)` для удобства диагностики.
- Реализован метод `_build_mock_analysis` который собирает безопасный JSON-фоллбек (поля `pair`, `bias`, `summary`, `confidence`) и возвращает его в `reply` при пустом ответе или исключении, сохраняя прежнюю структуру ответа (`reply`, `source`, `dataStatus`, `warnings`).
- Внесены минимальные изменения только в `backend/chat_service.py` без изменений API-контрактов или фронтенда.

### Testing
- Запущены автоматические тесты `pytest -q tests/test_chat.py`, все тесты пройдены (7 passed).
- Юнит-тесты подтверждают поведение фоллбека при отсутствии конфигурации OpenRouter и контракт ответа endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44756c8248331a3134ead9a5b67de)