### PR TITLE
Сделать шапку /ideas компактнее без изменения стиля

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -51,6 +51,25 @@
       margin-bottom: 22px;
     }
 
+    .hero nav {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      overflow-y: hidden;
+      scrollbar-width: thin;
+      padding-bottom: 2px;
+      max-width: 100%;
+    }
+
+    .hero nav .home-link {
+      padding: 8px 12px;
+      font-size: 13px;
+      white-space: nowrap;
+      flex: 0 0 auto;
+    }
+
     .ideas-page-header {
       display: grid;
       grid-template-columns: minmax(0, 1fr) 420px;
@@ -119,7 +138,7 @@
 
     .ideas-performance-panel {
       margin-top: 18px;
-      padding: 14px;
+      padding: 10px;
       border-radius: 18px;
       background:
         radial-gradient(circle at 20% 0%, rgba(49,245,157,.18), transparent 35%),
@@ -129,9 +148,9 @@
     }
 
     .ideas-performance-panel__title {
-      margin-bottom: 10px;
+      margin-bottom: 8px;
       color: rgba(219,238,255,.9);
-      font-size: 12px;
+      font-size: 11px;
       font-weight: 950;
       text-transform: uppercase;
       letter-spacing: .1em;
@@ -140,12 +159,12 @@
     .ideas-performance-grid {
       display: grid;
       grid-template-columns: repeat(5, minmax(0, 1fr));
-      gap: 8px;
+      gap: 6px;
     }
 
     .ideas-performance-item {
-      min-height: 54px;
-      padding: 8px 10px;
+      min-height: 46px;
+      padding: 6px 8px;
       border-radius: 14px;
       background: rgba(3,14,28,.72);
       border: 1px solid rgba(95,156,230,.25);
@@ -153,16 +172,16 @@
 
     .ideas-performance-item span {
       display: block;
-      margin-bottom: 4px;
+      margin-bottom: 3px;
       color: rgba(185,214,248,.72);
-      font-size: 10px;
+      font-size: 9px;
       font-weight: 900;
       text-transform: uppercase;
     }
 
     .ideas-performance-item strong {
       color: #f4f8ff;
-      font-size: 20px;
+      font-size: 17px;
       font-weight: 950;
     }
 


### PR DESCRIPTION
### Motivation
- Уменьшить высоту и плотность верхней навигации на странице `/ideas`, чтобы меню не переносилось на две строки и не перекрывалось с заголовком. 
- Сделать панель «Статистика идей» ниже и компактнее, сохранив все метрики видимыми. 
- Сохранять существующий тёмный premium-стиль и порядок пунктов меню. 

### Description
- Добавлены компактные правила для навигации в шапке: новые селекторы ` .hero nav` и `.hero nav .home-link` с `flex-wrap: nowrap`, `overflow-x: auto`, уменьшёнными `padding`, `font-size` и `gap`. 
- Навигация зафиксирована в одну строку и при нехватке ширины становится горизонтально скроллируемой вместо переноса. 
- Уменьшена высота панели `ideas-performance-panel` и её вложенных элементов: снижены `padding`, `gap`, `min-height`, размеры меток (`font-size`) и значений (`strong`). 
- Изменения внесены только в `app/static/ideas.html` (inline CSS) и не затрагивают backend, API, логику сигналов или карточки идей. 

### Testing
- Автоматические тесты не запускались в рамках этого изменения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44a5b65608331a84aafcef80fb61b)