### PR TITLE
Предпочесть MT4 bridge как источник данных для профессиональной аналитики

### DIFF
--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -1073,17 +1073,19 @@ class SignalEngine:
         normalized_sources = [source.split("_derived_h4")[0] for source in sources]
         has_yahoo = any(source == "yahoo_finance" for source in normalized_sources)
         has_twelvedata = any(source == "twelvedata" for source in normalized_sources)
+        has_mt4_bridge = any(source == "mt4_bridge" for source in normalized_sources)
         sufficient_candles = min(candles_counts) >= PROFESSIONAL_MIN_CANDLES if candles_counts else False
 
-        if has_twelvedata and sufficient_candles and not has_yahoo:
+        if sufficient_candles and not has_yahoo and (has_mt4_bridge or has_twelvedata):
+            preferred_provider = "mt4_bridge" if has_mt4_bridge else "twelvedata"
             return {
-                "data_provider": "twelvedata",
+                "data_provider": preferred_provider,
                 "analysis_mode": "professional",
                 "data_quality": "high",
                 "warning": "",
             }
         return {
-            "data_provider": "yahoo_finance" if has_yahoo else "yahoo_finance",
+            "data_provider": "yahoo_finance",
             "analysis_mode": "directional_fallback",
             "data_quality": "medium",
             "warning": FALLBACK_WARNING_RU,

--- a/tests/signals/test_signal_engine_resilience.py
+++ b/tests/signals/test_signal_engine_resilience.py
@@ -209,6 +209,18 @@ def test_signal_engine_preserves_strict_confluence_for_high_quality_source(monke
     assert signal["signal_policy_mode"] == "strict_smc"
 
 
+def test_analysis_contract_prefers_mt4_bridge_for_professional_mode() -> None:
+    contract = SignalEngine._resolve_analysis_contract(
+        htf={"source": "mt4_bridge", "candles": _candles()},
+        mtf={"source": "mt4_bridge", "candles": _candles()},
+        ltf={"source": "mt4_bridge", "candles": _candles()},
+    )
+
+    assert contract["analysis_mode"] == "professional"
+    assert contract["data_quality"] == "high"
+    assert contract["data_provider"] == "mt4_bridge"
+
+
 def test_signal_engine_keeps_idea_when_snapshot_status_unavailable_but_candles_exist(monkeypatch) -> None:
     engine = SignalEngine()
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Обеспечить, чтобы аналитика (включая Grok reasoning) использовала реальные MT4-свечи вместо TwelveData, когда MT4 bridge доступен и содержит достаточное число баров.
- Сохранить существующее поведение резервного отката на TwelveData/Yahoo при недостатке или устаревании данных.

### Description
- Добавлена детекция `mt4_bridge` в `SignalEngine._resolve_analysis_contract` и логика выбора `preferred_provider` между `mt4_bridge` и `twelvedata` при достаточном количестве свечей и отсутствии Yahoo в источниках.
- При срабатывании условия профессионального режима теперь возвращается `"data_provider": "mt4_bridge"` (или `twelvedata`, если MT4 недоступен) и `"analysis_mode": "professional"` с `data_quality: high`.
- Добавлен тест `test_analysis_contract_prefers_mt4_bridge_for_professional_mode` в `tests/signals/test_signal_engine_resilience.py`, который проверяет, что контракт выбирает `mt4_bridge` при наличии достаточных MT4-баров.

### Testing
- Запуск добавленного теста и связанного набора: `pytest -q tests/signals/test_signal_engine_resilience.py -k "analysis_contract_prefers_mt4_bridge or directional_fallback_contract_when_any_timeframe_from_yahoo"` — тесты прошли успешно.
- Полный запуск файла `tests/signals/test_signal_engine_resilience.py` показал 4 существующих не связанных с этим изменением падения (сценарии ожидают `BUY/SELL`, а получают `NO_TRADE`), что не вызвано данной правкой.
- Добавленный тест проходит локально и подтверждает корректное поведение выбора `mt4_bridge` как первичного провайдера для профессионального режима.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f481c57a088331a90b2c4d56ff1687)