### PR TITLE
Использовать MT4 M15-кэш свечей для аналитики в `/api/chat`

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -148,9 +148,56 @@ def analytics_page():
 
 @app.post("/api/chat")
 async def api_chat(payload: ChatRequest):
+    analytics_pair = _extract_analytics_pair(payload.message)
+    if analytics_pair:
+        return JSONResponse(_build_mt4_chat_analytics_response(analytics_pair))
     return await chat_service.chat(payload)
 
 
+
+
+def _extract_analytics_pair(message: str) -> str | None:
+    text = (message or "").upper()
+    for pair in DEFAULT_IDEA_SYMBOLS:
+        if pair in text:
+            return pair
+    return None
+
+
+def _build_mt4_chat_analytics_response(pair: str) -> dict[str, Any]:
+    normalized_pair = (pair or "").upper().strip()
+    store_key = f"{normalized_pair}:M15"
+    snapshot = MT4_CANDLE_STORE.get(store_key) or {}
+    updated_at = snapshot.get("updated_at") if isinstance(snapshot, dict) else None
+    candles = snapshot.get("candles") if isinstance(snapshot, dict) else []
+    is_fresh = isinstance(updated_at, datetime) and (datetime.now(timezone.utc) - updated_at).total_seconds() <= MT4_CANDLE_FRESH_SECONDS
+    if not isinstance(candles, list) or not candles or not is_fresh:
+        return {
+            "pair": normalized_pair,
+            "data_source": "mt4_bridge",
+            "candles_count": 0,
+            "summary": "Нет свежих MT4-свечей для этой пары",
+            "confidence": 0,
+        }
+
+    first_close = float(candles[0].get("close", 0.0))
+    last_close = float(candles[-1].get("close", 0.0))
+    if last_close > first_close:
+        bias = "bullish"
+    elif last_close < first_close:
+        bias = "bearish"
+    else:
+        bias = "neutral"
+
+    return {
+        "pair": normalized_pair,
+        "data_source": "mt4_bridge",
+        "candles_count": len(candles),
+        "last_close": last_close,
+        "bias": bias,
+        "summary": f"M15 MT4: {len(candles)} свечей по {normalized_pair}, смещение {bias}.",
+        "confidence": 0.8,
+    }
 def get_fallback_calendar_events() -> list[dict[str, Any]]:
     return [
         {


### PR DESCRIPTION
### Motivation
- Обеспечить быстрые и правдивые ответы аналитики в `POST /api/chat` по ключевым парам, используя реальные M15-свечи из MT4 вместо вызова LLM для запросов о парах. 
- Поддержать список основных символов (EURUSD, GBPUSD, USDJPY, XAUUSD) и вернуть однозначный прокси-ответ, если свежих MT4-свечей нет.

### Description
- В `app/main.py` добавлена перехватывающая ветка в `POST /api/chat`, которая извлекает символ запросa через ` _extract_analytics_pair` и для совпадающих пар возвращает ответ из MT4-кэша. 
- Добавлены вспомогательные функции ` _extract_analytics_pair` и ` _build_mt4_chat_analytics_response` в `app/main.py` для формирования аналитического JSON-ответа. 
- Ответ читает M15-данные из `MT4_CANDLE_STORE` по ключу `<PAIR>:M15` и проверяет свежесть по полю `updated_at` с порогом `MT4_CANDLE_FRESH_SECONDS`, а при наличии свечей возвращает поля `pair`, `data_source="mt4_bridge"`, `candles_count`, `last_close`, `bias`, `summary`, `confidence`. 
- Если свечей нет или они устарели, возвращается `candles_count=0`, `summary="Нет свежих MT4-свечей для этой пары"` и `confidence=0`; смещение (`bias`) вычисляется просто как сравнение `last_close` versus `first_close` (bullish/bearish/neutral). 

### Testing
- Запущена проверка синтаксиса: `python -m py_compile app/main.py` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4873019448331835cb196fe08fcd0)