### PR TITLE
Зафиксировать уровни идей и исправить lifecycle (TP/SL/EXPIRED) в app/main.py

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1134,11 +1134,12 @@ def build_signal(symbol: str, detail: bool = False) -> dict[str, Any]:
         active = load_json(ACTIVE_FILE)
         trade_id = f"{symbol}-{signal}"
 
-        existing = next((x for x in active if x.get("id") == trade_id), None)
+        existing = next((x for x in active if x.get("symbol") == symbol and str(x.get("status") or "").upper() == "ACTIVE"), None)
 
         if signal in {"BUY", "SELL"}:
             if existing:
                 trade = existing
+                trade_id = str(trade.get("id") or trade_id)
             else:
                 m15_candles_for_levels = candles_by_tf.get("M15") or []
                 annotations_for_levels = build_chart_annotations(m15_candles_for_levels, symbol, signal, current_price)
@@ -1215,8 +1216,8 @@ def build_signal(symbol: str, detail: bool = False) -> dict[str, Any]:
                 **trade,
                 "current_price": current_price,
                 "result": close_result,
-                "status": "CLOSED_TP" if close_result == "TP" else "CLOSED_SL",
-                "runtime_status": "CLOSED_TP" if close_result == "TP" else "CLOSED_SL",
+                "status": str(close_result or "ACTIVE"),
+                "runtime_status": "CLOSED_TP" if close_result == "TP" else "CLOSED_SL" if close_result == "SL" else "CLOSED",
                 "runtime_text": auto_close_eval.get("reason_ru"),
                 "runtime_color": runtime_color,
                 "close_reason": auto_close_eval.get("close_reason"),
@@ -2856,6 +2857,18 @@ def build_market_structure(
 
 
 def evaluate_trade_result_by_price(trade: dict[str, Any], current_price: float | None) -> dict[str, Any]:
+    ttl_minutes = safe_float(trade.get("ttl_minutes"))
+    created_at = _parse_utc_datetime(trade.get("created_at"))
+    if ttl_minutes is not None and created_at is not None:
+        expire_at = created_at + timedelta(minutes=ttl_minutes)
+        if datetime.now(timezone.utc) > expire_at:
+            return {
+                "is_closed": True,
+                "result": "EXPIRED",
+                "close_reason": "ttl_expired",
+                "reason_ru": "TTL идеи истёк, идея перенесена в архив.",
+            }
+
     if current_price is None:
         return {
             "is_closed": False,


### PR DESCRIPTION
### Motivation
- Исправить lifecycle торговых идей так, чтобы уровни Entry/SL/TP сохранялись навсегда, идеи не пересоздавались для того же символа и корректно закрывались по TP/SL/TTL.

### Description
- В `build_signal` изменён поиск существующей сделки: теперь переиспользуется уже существующая идея с `status == "ACTIVE"` по полю `symbol`, чтобы предотвратить создание новой записи и перезапись уровней Entry/SL/TP.
- При автозакрытии идея формируется для архива с полями `result`, `closed_at`, `close_reason`, `closed_price`, `is_archived` и `status`, приводимым к значению результата (`TP`/`SL`/`EXPIRED`), при этом `runtime_status` адаптирован для четкого обозначения закрытия.
- Добавлена проверка TTL в `evaluate_trade_result_by_price`: если задано `ttl_minutes` и текущее время превысило `created_at + ttl`, возвращается закрытие с `result = "EXPIRED"` и соответствующим `close_reason`.
- Изменения минимальны и локальны в `app/main.py`, при этом используются существующие `load_json()` и `save_json()` для хранения данных и не тронуты остальные подсистемы или форматы ответов.

### Testing
- `python -m py_compile app/main.py` — успешно (исправленный модуль синтаксически корректен).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49ca6aac08331b775e608b2daa3fe)