### PR TITLE
Обновить страницу аналитики до институционального тёмного UI

### DIFF
--- a/app/static/analytics.html
+++ b/app/static/analytics.html
@@ -4,35 +4,113 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>AI Аналитика</title>
+<link rel="stylesheet" href="/static/styles.css" />
 <style>
-body{margin:0;font-family:Inter;background:#050b18;color:#e6f0ff}
-.container{max-width:1200px;margin:0 auto;padding:30px}
-h1{font-size:32px;margin-bottom:10px}
-.panel{background:rgba(10,20,40,.8);border:1px solid rgba(100,150,255,.2);border-radius:16px;padding:20px;margin-top:20px}
-textarea{width:100%;height:120px;background:#0b1a30;border:1px solid #1e3a5f;color:#fff;border-radius:10px;padding:10px}
-button{margin-top:10px;padding:10px 16px;border-radius:10px;border:none;background:#3b82f6;color:#fff;font-weight:bold;cursor:pointer}
-.response{white-space:pre-wrap;margin-top:15px}
+.analytics-shell{width:min(1280px,calc(100% - 32px));margin:0 auto;padding:28px 0 40px;display:grid;gap:18px}
+.analytics-header,.analytics-panel{backdrop-filter:blur(16px);background:rgba(10,21,39,.92);border:1px solid rgba(104,143,191,.18);box-shadow:0 28px 80px rgba(2,6,23,.45)}
+.analytics-header{border-radius:28px;padding:28px;display:grid;gap:18px}
+.analytics-headline{display:grid;gap:10px}
+.analytics-headline h1{margin:0;font-size:clamp(1.9rem,4vw,3rem)}
+.analytics-headline p{margin:0;color:#90a4c3;line-height:1.6;max-width:760px}
+.eyebrow{margin:0;text-transform:uppercase;letter-spacing:.22em;font-size:.72rem;color:#4cc9f0}
+.analytics-grid{display:grid;grid-template-columns:2fr 1fr;gap:18px}
+.analytics-panel{padding:24px;border-radius:28px}
+.panel-title{margin:0 0 8px;font-size:1.35rem}
+.panel-subtitle{margin:0 0 20px;color:#90a4c3}
+.query-box{display:grid;gap:12px}
+textarea{width:100%;min-height:140px;background:rgba(7,17,31,.9);border:1px solid rgba(76,201,240,.24);border-radius:16px;color:#e8eef8;padding:14px 16px;resize:vertical;font:inherit;outline:none;transition:border-color .2s, box-shadow .2s}
+textarea:focus{border-color:rgba(76,201,240,.65);box-shadow:0 0 0 3px rgba(76,201,240,.12)}
+.controls{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+button{padding:11px 18px;border-radius:12px;border:1px solid rgba(76,201,240,.4);background:linear-gradient(135deg,rgba(76,201,240,.25),rgba(139,92,246,.24));color:#eaf4ff;font-weight:700;cursor:pointer;transition:transform .15s,border-color .2s}
+button:hover{transform:translateY(-1px);border-color:rgba(76,201,240,.75)}
+.status{font-size:.9rem;color:#90a4c3}
+.response{margin-top:8px;background:rgba(7,17,31,.75);border:1px solid rgba(104,143,191,.16);border-radius:16px;padding:16px;white-space:pre-wrap;line-height:1.6;min-height:180px}
+.meta-grid{display:grid;gap:12px}
+.meta-card{background:rgba(12,24,42,.88);border:1px solid rgba(76,201,240,.2);border-radius:18px;padding:14px}
+.meta-card h3{margin:0 0 8px;font-size:.95rem;color:#b7cced}
+.meta-card p{margin:0;color:#e8eef8}
+.meta-card small{display:block;margin-top:8px;color:#90a4c3}
+.neon-line{height:2px;background:linear-gradient(90deg,rgba(76,201,240,.8),rgba(139,92,246,.7),transparent);border-radius:999px;margin:2px 0 8px}
+@media (max-width:980px){.analytics-grid{grid-template-columns:1fr}.analytics-shell{padding-top:18px}}
 </style>
 </head>
 <body>
-<div class="container">
-<h1>📊 AI Аналитика рынка</h1>
-<div class="panel">
-<textarea id="question" placeholder="Например: дай анализ EURUSD"></textarea>
-<button onclick="send()">Запросить анализ</button>
-<div class="response" id="response"></div>
+<div class="analytics-shell">
+  <header class="analytics-header">
+    <div class="analytics-headline">
+      <p class="eyebrow">Аналитический терминал</p>
+      <h1>📊 AI Аналитика рынка</h1>
+      <p>Институциональный интерфейс для быстрого запроса рыночного сценария, оценки контекста ликвидности и подготовки торгового плана.</p>
+    </div>
+    <nav class="top-nav">
+      <a href="/">Главная</a>
+      <a href="/ideas">Идеи</a>
+      <a href="/analytics">Аналитика</a>
+      <a href="/news">Новости</a>
+      <a href="/calendar">Календарь</a>
+      <a href="/heatmap/page">Тепловая карта</a>
+    </nav>
+  </header>
+
+  <div class="analytics-grid">
+    <section class="analytics-panel">
+      <h2 class="panel-title">Запрос анализа</h2>
+      <p class="panel-subtitle">Сформулируйте запрос по инструменту, сценарию или уровню. Ответ поступает через текущий API-маршрут платформы.</p>
+      <div class="query-box">
+        <textarea id="question" placeholder="Например: дай анализ EURUSD с акцентом на уровни ликвидности и риски для intraday"></textarea>
+        <div class="controls">
+          <button onclick="send()">Запросить анализ</button>
+          <span id="status" class="status">Готов к запросу</span>
+        </div>
+        <div class="response" id="response">Здесь появится ответ AI-аналитика.</div>
+      </div>
+    </section>
+
+    <aside class="analytics-panel">
+      <h2 class="panel-title">Контекст рынка</h2>
+      <div class="neon-line"></div>
+      <div class="meta-grid">
+        <article class="meta-card">
+          <h3>Объём и глубина</h3>
+          <p>Оценка выполняется на основе текста запроса и ответа модели.</p>
+          <small>Прокси-метрика: не является прямыми биржевыми данными.</small>
+        </article>
+        <article class="meta-card">
+          <h3>Риск-профиль</h3>
+          <p>Уточняйте таймфрейм, уровень стопа и допустимую просадку.</p>
+          <small>Чем точнее входные параметры, тем полезнее сценарий.</small>
+        </article>
+        <article class="meta-card">
+          <h3>Структура ответа</h3>
+          <p>Рекомендуется: bias, ключевые уровни, invalidation и план действий.</p>
+          <small>Формулируйте задачу как для институционального desk-плана.</small>
+        </article>
+      </div>
+    </aside>
+  </div>
 </div>
-</div>
+<script src="/static/nav.js"></script>
 <script>
 async function send(){
-const q=document.getElementById('question').value;
-const resBox=document.getElementById('response');
-resBox.innerText='Загрузка...';
-try{
-const r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:q})});
-const data=await r.json();
-resBox.innerText=data.reply || JSON.stringify(data,null,2);
-}catch(e){resBox.innerText='Ошибка: '+e}
+  const q=document.getElementById('question').value.trim();
+  const resBox=document.getElementById('response');
+  const status=document.getElementById('status');
+  if(!q){
+    status.innerText='Введите запрос для анализа';
+    resBox.innerText='Укажите инструмент и задачу, например: «EURUSD intraday с уровнями и рисками».\n';
+    return;
+  }
+  status.innerText='Запрос выполняется...';
+  resBox.innerText='Загрузка...';
+  try{
+    const r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:q})});
+    const data=await r.json();
+    resBox.innerText=data.reply || JSON.stringify(data,null,2);
+    status.innerText='Ответ получен';
+  }catch(e){
+    status.innerText='Ошибка запроса';
+    resBox.innerText='Ошибка: '+e;
+  }
 }
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- Сделать страницу `/analytics` визуально согласованной с остальной платформой и предоставить более профессиональный интерфейс для быстрых запросов AI‑аналитики. 
- Заменить устаревший textarea-only макет на структурированный institutional layout с акцентом на оценку ликвидности, объёма и риск‑профиль.

### Description
- Полностью переработан файл `app/static/analytics.html` в тёмном премиальном стиле с градиентным фоном, glass‑панелями и неоновыми акцентами, включая адаптивную сетку и заголовок в стиле платформы. 
- Добавлен header с навигацией (используется существующий `nav.js`) и новая двухколоночная структура: основная панель «Запрос анализа» и боковая панель «Контекст рынка» с карточками метрик. 
- Интерфейс сохраняет существующий фронтенд‑контракт и отправляет запросы на `POST /api/chat` с телом `{ message }`, при этом backend и другие разделы не изменялись. 
- Все изменения ограничены фронтендом и затронули только `app/static/analytics.html` (страница подключает также существующий `/static/styles.css` и `/static/nav.js`).

### Testing
- Просмотр содержимого и валидация файла выполнены через `nl -ba app/static/analytics.html | sed -n '1,260p'` и вывод `sed`, что подтвердило ожидаемую разметку, и завершились успешно. 
- Проверка статуса рабочей директории выполнена через `git status --short` и показала изменённый файл, что прошло успешно. 
- Изменения были зафиксированы с помощью `git add app/static/analytics.html && git commit -m "Upgrade analytics page to institutional dark UI"`, коммит прошёл успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4db85a3888331b52237c229b80d08)