### PR TITLE
Переработка /analytics: премиальная панель с карточками инструментов и структурированным выводом

### DIFF
--- a/app/static/analytics.html
+++ b/app/static/analytics.html
@@ -6,32 +6,50 @@
 <title>AI Аналитика</title>
 <link rel="stylesheet" href="/static/styles.css" />
 <style>
-.analytics-shell{width:min(1280px,calc(100% - 32px));margin:0 auto;padding:28px 0 40px;display:grid;gap:18px}
-.analytics-header,.analytics-panel{backdrop-filter:blur(16px);background:rgba(10,21,39,.92);border:1px solid rgba(104,143,191,.18);box-shadow:0 28px 80px rgba(2,6,23,.45)}
-.analytics-header{border-radius:28px;padding:28px;display:grid;gap:18px}
-.analytics-headline{display:grid;gap:10px}
-.analytics-headline h1{margin:0;font-size:clamp(1.9rem,4vw,3rem)}
-.analytics-headline p{margin:0;color:#90a4c3;line-height:1.6;max-width:760px}
-.eyebrow{margin:0;text-transform:uppercase;letter-spacing:.22em;font-size:.72rem;color:#4cc9f0}
-.analytics-grid{display:grid;grid-template-columns:2fr 1fr;gap:18px}
-.analytics-panel{padding:24px;border-radius:28px}
+:root{
+  --bg:#040915;
+  --bg-soft:#0a1427;
+  --text:#e8f1ff;
+  --muted:#90a4c3;
+  --line:rgba(92, 170, 255, .36);
+  --line-strong:rgba(79, 197, 255, .9);
+  --glass:linear-gradient(155deg,rgba(9,19,36,.95),rgba(10,30,53,.86));
+  --card:linear-gradient(140deg,rgba(22,42,79,.68),rgba(11,23,47,.88));
+  --neon:0 0 0 1px rgba(72,180,255,.42),0 18px 42px rgba(2,8,25,.52),0 0 25px rgba(72,180,255,.16);
+}
+*{box-sizing:border-box}
+body{background:radial-gradient(circle at 15% 0%, #11254a 0%, #071123 35%, #030711 100%);color:var(--text)}
+.analytics-shell{width:min(1320px,calc(100% - 32px));margin:0 auto;padding:28px 0 44px;display:grid;gap:18px}
+.analytics-header,.analytics-panel{backdrop-filter:blur(18px);background:var(--glass);border:1px solid var(--line);border-radius:28px;box-shadow:var(--neon)}
+.analytics-header{padding:28px;display:grid;gap:16px}
+.analytics-headline h1{margin:0;font-size:clamp(1.8rem,3.5vw,2.8rem)}
+.analytics-headline p{margin:8px 0 0;color:var(--muted);max-width:820px;line-height:1.6}
+.eyebrow{margin:0;text-transform:uppercase;letter-spacing:.22em;font-size:.72rem;color:#56d8ff}
+.analytics-grid{display:grid;grid-template-columns:1.12fr 1fr;gap:18px}
+.analytics-panel{padding:22px}
 .panel-title{margin:0 0 8px;font-size:1.35rem}
-.panel-subtitle{margin:0 0 20px;color:#90a4c3}
-.query-box{display:grid;gap:12px}
-textarea{width:100%;min-height:140px;background:rgba(7,17,31,.9);border:1px solid rgba(76,201,240,.24);border-radius:16px;color:#e8eef8;padding:14px 16px;resize:vertical;font:inherit;outline:none;transition:border-color .2s, box-shadow .2s}
-textarea:focus{border-color:rgba(76,201,240,.65);box-shadow:0 0 0 3px rgba(76,201,240,.12)}
-.controls{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
-button{padding:11px 18px;border-radius:12px;border:1px solid rgba(76,201,240,.4);background:linear-gradient(135deg,rgba(76,201,240,.25),rgba(139,92,246,.24));color:#eaf4ff;font-weight:700;cursor:pointer;transition:transform .15s,border-color .2s}
-button:hover{transform:translateY(-1px);border-color:rgba(76,201,240,.75)}
-.status{font-size:.9rem;color:#90a4c3}
-.response{margin-top:8px;background:rgba(7,17,31,.75);border:1px solid rgba(104,143,191,.16);border-radius:16px;padding:16px;white-space:pre-wrap;line-height:1.6;min-height:180px}
-.meta-grid{display:grid;gap:12px}
-.meta-card{background:rgba(12,24,42,.88);border:1px solid rgba(76,201,240,.2);border-radius:18px;padding:14px}
-.meta-card h3{margin:0 0 8px;font-size:.95rem;color:#b7cced}
-.meta-card p{margin:0;color:#e8eef8}
-.meta-card small{display:block;margin-top:8px;color:#90a4c3}
-.neon-line{height:2px;background:linear-gradient(90deg,rgba(76,201,240,.8),rgba(139,92,246,.7),transparent);border-radius:999px;margin:2px 0 8px}
-@media (max-width:980px){.analytics-grid{grid-template-columns:1fr}.analytics-shell{padding-top:18px}}
+.panel-subtitle{margin:0 0 20px;color:var(--muted)}
+.cards-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}
+.pair-card{border:none;border-radius:22px;padding:18px;cursor:pointer;text-align:left;background:var(--card);border:1px solid rgba(75,183,255,.42);box-shadow:var(--neon);color:var(--text);transition:transform .2s, border-color .2s, box-shadow .2s;min-height:190px;display:grid;gap:10px}
+.pair-card:hover{transform:translateY(-2px);border-color:var(--line-strong);box-shadow:0 0 0 1px rgba(90,205,255,.7),0 24px 46px rgba(1,7,22,.6),0 0 35px rgba(90,205,255,.24)}
+.pair-card.active{border-color:#7addff;box-shadow:0 0 0 1px #5edbff,0 28px 54px rgba(1,7,22,.7),0 0 38px rgba(94,219,255,.3)}
+.pair-name{margin:0;font-size:1.5rem;letter-spacing:.03em}
+.pair-status{display:inline-flex;align-items:center;gap:8px;font-size:.9rem;color:#b5c9e8}
+.pair-status::before{content:"";width:9px;height:9px;border-radius:999px;background:#57e8ff;box-shadow:0 0 12px #57e8ff}
+.pair-text{margin:0;color:#98acd0;line-height:1.45}
+.pair-action{margin-top:auto;font-weight:700;color:#bfefff;display:inline-flex;align-items:center;gap:8px}
+.pair-action::after{content:"→"}
+.status{font-size:.95rem;color:var(--muted)}
+.response{margin-top:12px;border-radius:18px;background:rgba(6,15,30,.82);border:1px solid rgba(103,157,219,.28);padding:16px;min-height:340px;max-height:62vh;overflow:auto}
+.result-section{padding:12px 0;border-bottom:1px solid rgba(94,151,214,.2)}
+.result-section:last-child{border-bottom:none}
+.result-title{margin:0 0 8px;color:#75ddff;font-size:1rem}
+.result-list{margin:0;padding-left:18px;color:#d7e6ff}
+.result-list li{margin:4px 0}
+.result-text{margin:0;color:#d7e6ff;white-space:pre-wrap;line-height:1.55}
+.notice{color:#9fb5d6}
+@media (max-width:1024px){.analytics-grid{grid-template-columns:1fr}.response{max-height:none}}
+@media (max-width:680px){.cards-grid{grid-template-columns:1fr}.analytics-shell{width:min(1320px,calc(100% - 20px));padding-top:16px}}
 </style>
 </head>
 <body>
@@ -39,8 +57,8 @@ button:hover{transform:translateY(-1px);border-color:rgba(76,201,240,.75)}
   <header class="analytics-header">
     <div class="analytics-headline">
       <p class="eyebrow">Аналитический терминал</p>
-      <h1>📊 AI Аналитика рынка</h1>
-      <p>Институциональный интерфейс для быстрого запроса рыночного сценария, оценки контекста ликвидности и подготовки торгового плана.</p>
+      <h1>📊 Премиальная AI-панель аналитики</h1>
+      <p>Выберите инструмент и получите структурированный разбор через текущий API-маршрут платформы без изменения backend-логики.</p>
     </div>
     <nav class="top-nav">
       <a href="/">Главная</a>
@@ -54,64 +72,124 @@ button:hover{transform:translateY(-1px);border-color:rgba(76,201,240,.75)}
 
   <div class="analytics-grid">
     <section class="analytics-panel">
-      <h2 class="panel-title">Запрос анализа</h2>
-      <p class="panel-subtitle">Сформулируйте запрос по инструменту, сценарию или уровню. Ответ поступает через текущий API-маршрут платформы.</p>
-      <div class="query-box">
-        <textarea id="question" placeholder="Например: дай анализ EURUSD с акцентом на уровни ликвидности и риски для intraday"></textarea>
-        <div class="controls">
-          <button onclick="send()">Запросить анализ</button>
-          <span id="status" class="status">Готов к запросу</span>
-        </div>
-        <div class="response" id="response">Здесь появится ответ AI-аналитика.</div>
-      </div>
+      <h2 class="panel-title">Выбор инструмента</h2>
+      <p class="panel-subtitle">Кликните карточку, чтобы отправить запрос в <code>/api/chat</code> и открыть разбор.</p>
+      <div class="cards-grid" id="pairCards"></div>
     </section>
 
     <aside class="analytics-panel">
-      <h2 class="panel-title">Контекст рынка</h2>
-      <div class="neon-line"></div>
-      <div class="meta-grid">
-        <article class="meta-card">
-          <h3>Объём и глубина</h3>
-          <p>Оценка выполняется на основе текста запроса и ответа модели.</p>
-          <small>Прокси-метрика: не является прямыми биржевыми данными.</small>
-        </article>
-        <article class="meta-card">
-          <h3>Риск-профиль</h3>
-          <p>Уточняйте таймфрейм, уровень стопа и допустимую просадку.</p>
-          <small>Чем точнее входные параметры, тем полезнее сценарий.</small>
-        </article>
-        <article class="meta-card">
-          <h3>Структура ответа</h3>
-          <p>Рекомендуется: bias, ключевые уровни, invalidation и план действий.</p>
-          <small>Формулируйте задачу как для институционального desk-плана.</small>
-        </article>
+      <h2 class="panel-title">Результат анализа</h2>
+      <p class="panel-subtitle" id="resultSubtitle">Ожидание выбора инструмента.</p>
+      <div id="status" class="status">Готово к запросу</div>
+      <div class="response" id="response">
+        <p class="notice">Выберите одну из карточек: EURUSD, GBPUSD, USDJPY, XAUUSD.</p>
       </div>
     </aside>
   </div>
 </div>
+
 <script src="/static/nav.js"></script>
 <script>
-async function send(){
-  const q=document.getElementById('question').value.trim();
-  const resBox=document.getElementById('response');
-  const status=document.getElementById('status');
-  if(!q){
-    status.innerText='Введите запрос для анализа';
-    resBox.innerText='Укажите инструмент и задачу, например: «EURUSD intraday с уровнями и рисками».\n';
-    return;
+const pairs = [
+  { name: 'EURUSD', status: 'MT4 data / waiting', text: 'Европейская сессия, оценка зон ликвидности и сценариев intraday.' },
+  { name: 'GBPUSD', status: 'MT4 data / waiting', text: 'Волатильный мажор: контроль импульса, коррекции и риск-профиля.' },
+  { name: 'USDJPY', status: 'MT4 data / waiting', text: 'Баланс доходностей и сила доллара, акцент на трендовую структуру.' },
+  { name: 'XAUUSD', status: 'MT4 data / waiting', text: 'Золото: защита капитала, ключевые уровни и чувствительность к риску.' }
+];
+
+function escapeHtml(value){
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatKey(key){
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function renderValue(key, value){
+  if (Array.isArray(value)) {
+    const items = value.map(item => `<li>${escapeHtml(typeof item === 'object' ? JSON.stringify(item) : item)}</li>`).join('');
+    return `<section class="result-section"><h3 class="result-title">${escapeHtml(formatKey(key))}</h3><ul class="result-list">${items || '<li>Нет данных</li>'}</ul></section>`;
   }
-  status.innerText='Запрос выполняется...';
-  resBox.innerText='Загрузка...';
-  try{
-    const r=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:q})});
-    const data=await r.json();
-    resBox.innerText=data.reply || JSON.stringify(data,null,2);
-    status.innerText='Ответ получен';
-  }catch(e){
-    status.innerText='Ошибка запроса';
-    resBox.innerText='Ошибка: '+e;
+  if (value && typeof value === 'object') {
+    const inner = Object.entries(value).map(([k,v]) => renderValue(k, v)).join('');
+    return `<section class="result-section"><h3 class="result-title">${escapeHtml(formatKey(key))}</h3>${inner || '<p class="result-text">Нет данных</p>'}</section>`;
+  }
+  return `<section class="result-section"><h3 class="result-title">${escapeHtml(formatKey(key))}</h3><p class="result-text">${escapeHtml(value ?? 'Нет данных')}</p></section>`;
+}
+
+function renderReply(data){
+  if (!data || typeof data !== 'object') {
+    return `<section class="result-section"><h3 class="result-title">Ответ</h3><p class="result-text">${escapeHtml(data || 'Пустой ответ')}</p></section>`;
+  }
+
+  if (data.reply && typeof data.reply === 'string') {
+    try {
+      const parsedReply = JSON.parse(data.reply);
+      return Object.entries(parsedReply).map(([k,v]) => renderValue(k, v)).join('');
+    } catch (_) {
+      // Ответ не JSON-строка, отображаем как текст ниже
+    }
+  }
+
+  if (data.reply && typeof data.reply === 'object') {
+    return Object.entries(data.reply).map(([k,v]) => renderValue(k, v)).join('');
+  }
+
+  return Object.entries(data).map(([k,v]) => renderValue(k, v)).join('');
+}
+
+function setActiveCard(pairName){
+  document.querySelectorAll('.pair-card').forEach(card => {
+    card.classList.toggle('active', card.dataset.pair === pairName);
+  });
+}
+
+async function requestPairAnalysis(pairName){
+  const status = document.getElementById('status');
+  const responseBox = document.getElementById('response');
+  const subtitle = document.getElementById('resultSubtitle');
+
+  setActiveCard(pairName);
+  subtitle.textContent = `Инструмент: ${pairName}`;
+  status.textContent = `Запрос по ${pairName} выполняется...`;
+  responseBox.innerHTML = '<p class="notice">Загрузка аналитики...</p>';
+
+  const message = `Сделай структурированный анализ по ${pairName}: тренд, ключевые уровни, риски, сценарии входа и invalidation.`;
+
+  try {
+    const r = await fetch('/api/chat', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ message })
+    });
+
+    const data = await r.json();
+    responseBox.innerHTML = renderReply(data);
+    status.textContent = `Ответ по ${pairName} получен`;
+  } catch (e) {
+    status.textContent = `Ошибка запроса по ${pairName}`;
+    responseBox.innerHTML = `<section class="result-section"><h3 class="result-title">Ошибка</h3><p class="result-text">${escapeHtml(e)}</p></section>`;
   }
 }
+
+function initCards(){
+  const box = document.getElementById('pairCards');
+  box.innerHTML = pairs.map(pair => `
+    <button class="pair-card" data-pair="${pair.name}" onclick="requestPairAnalysis('${pair.name}')">
+      <h3 class="pair-name">${pair.name}</h3>
+      <span class="pair-status">${pair.status}</span>
+      <p class="pair-text">${pair.text}</p>
+      <span class="pair-action">Открыть анализ</span>
+    </button>
+  `).join('');
+}
+
+initCards();
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Обновить пользовательский интерфейс страницы `/analytics` до профессионального темного дашборда в едином стиле сайта и сделать выбор инструментов удобным и визуально премиальным.
- Оставить backend и существующий маршрут `POST /api/chat` без изменений и реализовать всю логику на фронтенде.
- Обеспечить удобное чтение иерархических ответов API — не показывать сырой JSON, а форматировать поля в понятные русскоязычные секции.

### Description
- Полностью заменён файл `app/static/analytics.html` с новой темной gradient-glass эстетикой, неоновыми синими границами, мягкими тенями и адаптивной сеткой.
- Добавлены четыре крупные кликабельные карточки: `EURUSD`, `GBPUSD`, `USDJPY`, `XAUUSD`, каждая с названием, статусом `MT4 data / waiting`, кратким описанием и CTA `Открыть анализ`.
- По клику на карточку отправляется существующий запрос `POST /api/chat` с сообщением, содержащим выбранную пару, и результат показывается в правой панели без изменения backend-кода.
- Реализовано форматирование ответа: `renderReply` и `renderValue` преобразуют вложенные объекты и массивы в читаемые русские секции; добавлены `escapeHtml`, подсветка активной карточки и состояния загрузки/ошибки.

### Testing
- Выполнены команды проверки и просмотра файлов: `rg --files -g 'AGENTS.md'` — успешно выполнено.
- Просмотр исходного `AGENTS.md` и начала предыдущего файла: `cat AGENTS.md && sed -n '1,260p' app/static/analytics.html` — успешно выполнено.
- Добавление и фиксация изменений в репозитории: `git add app/static/analytics.html && git commit -m "Redesign analytics page with pair cards and structured chat output"` — успешно выполнено.
- Проверка содержимого итогового файла: `nl -ba app/static/analytics.html | sed -n '1,320p'` — успешно выполнено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4def2a1048331af5db2f6b3b2f99d)