### PR TITLE
UI: Перевести /analytics на карточки пар (EURUSD, GBPUSD, USDJPY, XAUUSD)

### DIFF
--- a/app/static/analytics.html
+++ b/app/static/analytics.html
@@ -33,6 +33,9 @@ body{background:radial-gradient(circle at 15% 0%, #11254a 0%, #071123 35%, #0307
 .pair-card{border:none;border-radius:22px;padding:18px;cursor:pointer;text-align:left;background:var(--card);border:1px solid rgba(75,183,255,.42);box-shadow:var(--neon);color:var(--text);transition:transform .2s, border-color .2s, box-shadow .2s;min-height:190px;display:grid;gap:10px}
 .pair-card:hover{transform:translateY(-2px);border-color:var(--line-strong);box-shadow:0 0 0 1px rgba(90,205,255,.7),0 24px 46px rgba(1,7,22,.6),0 0 35px rgba(90,205,255,.24)}
 .pair-card.active{border-color:#7addff;box-shadow:0 0 0 1px #5edbff,0 28px 54px rgba(1,7,22,.7),0 0 38px rgba(94,219,255,.3)}
+.pair-card.loading{opacity:.8;pointer-events:none;position:relative}
+.pair-card.loading .pair-action{color:#7addff}
+.pair-card.loading .pair-action::after{content:"..."}
 .pair-name{margin:0;font-size:1.5rem;letter-spacing:.03em}
 .pair-status{display:inline-flex;align-items:center;gap:8px;font-size:.9rem;color:#b5c9e8}
 .pair-status::before{content:"";width:9px;height:9px;border-radius:999px;background:#57e8ff;box-shadow:0 0 12px #57e8ff}
@@ -149,6 +152,23 @@ function setActiveCard(pairName){
   });
 }
 
+function setLoadingCard(pairName){
+  document.querySelectorAll('.pair-card').forEach(card => {
+    const loading = card.dataset.pair === pairName;
+    card.classList.toggle('loading', loading);
+    const action = card.querySelector('.pair-action');
+    if (action) action.textContent = loading ? 'Загрузка аналитики' : 'Открыть аналитику';
+  });
+}
+
+function clearLoadingCards(){
+  document.querySelectorAll('.pair-card').forEach(card => {
+    card.classList.remove('loading');
+    const action = card.querySelector('.pair-action');
+    if (action) action.textContent = 'Открыть аналитику';
+  });
+}
+
 async function requestPairAnalysis(pairName){
   const status = document.getElementById('status');
   const responseBox = document.getElementById('response');
@@ -157,9 +177,10 @@ async function requestPairAnalysis(pairName){
   setActiveCard(pairName);
   subtitle.textContent = `Инструмент: ${pairName}`;
   status.textContent = `Запрос по ${pairName} выполняется...`;
+  setLoadingCard(pairName);
   responseBox.innerHTML = '<p class="notice">Загрузка аналитики...</p>';
 
-  const message = `Сделай структурированный анализ по ${pairName}: тренд, ключевые уровни, риски, сценарии входа и invalidation.`;
+  const message = pairName;
 
   try {
     const r = await fetch('/api/chat', {
@@ -171,7 +192,9 @@ async function requestPairAnalysis(pairName){
     const data = await r.json();
     responseBox.innerHTML = renderReply(data);
     status.textContent = `Ответ по ${pairName} получен`;
+    clearLoadingCards();
   } catch (e) {
+    clearLoadingCards();
     status.textContent = `Ошибка запроса по ${pairName}`;
     responseBox.innerHTML = `<section class="result-section"><h3 class="result-title">Ошибка</h3><p class="result-text">${escapeHtml(e)}</p></section>`;
   }
@@ -184,7 +207,7 @@ function initCards(){
       <h3 class="pair-name">${pair.name}</h3>
       <span class="pair-status">${pair.status}</span>
       <p class="pair-text">${pair.text}</p>
-      <span class="pair-action">Открыть анализ</span>
+      <span class="pair-action">Открыть аналитику</span>
     </button>
   `).join('');
 }


### PR DESCRIPTION
### Motivation
- Упростить интерфейс `/analytics`, убрать основное текстовое поле и предоставить быстрый доступ к анализу через четыре премиальные карточки инструментов. 
- Обеспечить единообразный премиальный dark/glass стиль и сохранить существующую навигацию и бэкенд-маршруты. 

### Description
- Заменён интерфейс выборa аналитики в `app/static/analytics.html` на четыре кликабельные карточки: `EURUSD`, `GBPUSD`, `USDJPY` и `XAUUSD`, сохранив текущий визуальный стиль и верхнее меню. 
- Каждая карточка кликается целиком и содержит имя пары, краткое описание и CTA `Открыть аналитику`. 
- При клике карточки выполняется `POST /api/chat` с телом `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e469d7188331a32e1b20bb2c4937)