### PR TITLE
Добавить «Фундаментальный режим» в /analytics (frontend + backend)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -148,9 +148,10 @@ def analytics_page():
 
 @app.post("/api/chat")
 async def api_chat(payload: ChatRequest):
+    use_fundamental = bool(getattr(payload, "context", {}).get("use_fundamental", False))
     analytics_pair = _extract_analytics_pair(payload.message)
     if analytics_pair:
-        return JSONResponse(await _build_mt4_chat_analytics_response(analytics_pair))
+        return JSONResponse(await _build_mt4_chat_analytics_response(analytics_pair, use_fundamental))
     return await chat_service.chat(payload)
 
 
@@ -164,7 +165,7 @@ def _extract_analytics_pair(message: str) -> str | None:
     return None
 
 
-async def _build_mt4_chat_analytics_response(pair: str) -> dict[str, Any]:
+async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = False) -> dict[str, Any]:
     normalized_pair = (pair or "").upper().strip()
     store_key = f"{normalized_pair}:M15"
     snapshot = MT4_CANDLE_STORE.get(store_key) or {}
@@ -178,6 +179,8 @@ async def _build_mt4_chat_analytics_response(pair: str) -> dict[str, Any]:
             "candles_count": 0,
             "summary": "Нет свежих MT4-свечей для этой пары",
             "confidence": 0,
+            "fundamental_used": use_fundamental,
+            "article_ru": "Нет свежих MT4-свечей для этой пары",
         }
 
     recent_candles = candles[-80:]
@@ -198,6 +201,8 @@ async def _build_mt4_chat_analytics_response(pair: str) -> dict[str, Any]:
         "bias": bias,
         "summary": f"M15 MT4: {len(recent_candles)} свечей по {normalized_pair}, смещение {bias}.",
         "confidence": 0.8,
+        "fundamental_used": use_fundamental,
+        "article_ru": f"M15 MT4: {len(recent_candles)} свечей по {normalized_pair}, смещение {bias}.",
     }
 
     mt4_context = {
@@ -222,9 +227,18 @@ async def _build_mt4_chat_analytics_response(pair: str) -> dict[str, Any]:
     if not chat_service.client:
         return base_response | {"ai_status": "fallback", "warning": "Grok временно недоступен"}
 
+    if use_fundamental:
+        fundamentals_rule = (
+            "Используй актуальные новости и макроэкономический контекст, если они найдены через web search. "
+            "Если релевантные новости не найдены, прямо укажи, что значимых новостных драйверов не обнаружено.\n"
+        )
+    else:
+        fundamentals_rule = "Не использовать внешние новости и макроэкономические события. Анализ только по данным MT4.\n"
+
     ai_prompt = (
         "Подготовь один цельный профессиональный рыночный материал на русском языке в стиле деловой журналистики.\n"
         "Используй только данные из переданного MT4 OHLC-контекста. Нельзя выдумывать новости, макро-события, опционные потоки, объёмы или индикаторы.\n"
+        f"{fundamentals_rule}"
         "Важно: описывай причинно-следственную логику (cause → effect) и разделяй наблюдение vs гипотеза.\n"
         "Если каких-то данных нет, прямо и явно укажи ограничения.\n\n"
         "В статье обязательно раскрой:\n"
@@ -247,19 +261,29 @@ async def _build_mt4_chat_analytics_response(pair: str) -> dict[str, Any]:
         f"MT4 context:\n{json.dumps(mt4_context, ensure_ascii=False)}"
     )
     try:
-        response = await chat_service.client.chat.completions.create(
-            model=chat_service.model,
-            messages=[
+        model_name = f"{chat_service.model}:online" if use_fundamental else chat_service.model
+        tools: list[dict[str, Any]] = []
+        if use_fundamental:
+            tools = [{"type": "openrouter:web_search", "max_results": 3}]
+        request_kwargs: dict[str, Any] = {
+            "model": model_name,
+            "messages": [
                 {"role": "system", "content": "Ты профессиональный FX market desk аналитик. Пиши строго на русском языке."},
                 {"role": "user", "content": ai_prompt},
             ],
-            temperature=0.2,
-        )
+            "temperature": 0.2,
+        }
+        if use_fundamental:
+            request_kwargs["max_tokens"] = 400
+            request_kwargs["tools"] = tools
+
+        response = await chat_service.client.chat.completions.create(**request_kwargs)
         ai_text = (response.choices[0].message.content or "").strip() if response.choices else ""
         ai_json = json.loads(ai_text) if ai_text else {}
         return base_response | {
             "ai_provider": "grok",
-            "ai_model": chat_service.model,
+            "ai_model": model_name,
+            "fundamental_used": use_fundamental,
             "summary_ru": str(ai_json.get("summary_ru") or base_response["summary"]),
             "htf_bias_ru": str(ai_json.get("htf_bias_ru") or f"Текущее направление: {bias}."),
             "liquidity_ru": str(ai_json.get("liquidity_ru") or "Оценка ликвидности ограничена данными M15 MT4."),
@@ -286,7 +310,11 @@ async def _build_mt4_chat_analytics_response(pair: str) -> dict[str, Any]:
             "ai_status": "ok",
         }
     except Exception:
-        return base_response | {"ai_status": "fallback", "warning": "Grok временно недоступен"}
+        return base_response | {
+            "ai_status": "fallback",
+            "warning": "Grok временно недоступен",
+            "fundamental_used": use_fundamental,
+        }
 def get_fallback_calendar_events() -> list[dict[str, Any]]:
     return [
         {

--- a/app/static/analytics.html
+++ b/app/static/analytics.html
@@ -30,6 +30,14 @@ body{background:radial-gradient(circle at 15% 0%, #11254a 0%, #071123 35%, #0307
 .panel-title{margin:0 0 8px;font-size:1.35rem}
 .panel-subtitle{margin:0 0 20px;color:var(--muted)}
 .cards-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
+.fundamental-toggle{display:flex;align-items:center;justify-content:space-between;gap:12px;margin:0 0 14px;padding:10px 14px;border:1px solid rgba(77,177,255,.36);border-radius:14px;background:rgba(7,18,36,.68)}
+.toggle-label{font-size:.92rem;color:#c8ddff}
+.toggle-switch{position:relative;display:inline-flex;align-items:center;width:52px;height:30px;border-radius:999px;border:1px solid rgba(95,182,255,.45);background:rgba(20,35,58,.9);box-shadow:0 0 12px rgba(72,180,255,.2);cursor:pointer;transition:all .2s}
+.toggle-switch .knob{position:absolute;left:4px;width:20px;height:20px;border-radius:999px;background:#9ccfff;box-shadow:0 0 10px rgba(156,207,255,.55);transition:all .2s}
+.toggle-switch.active{background:rgba(18,70,108,.9);border-color:#6eddff;box-shadow:0 0 18px rgba(91,220,255,.4)}
+.toggle-switch.active .knob{left:26px;background:#76f2ff;box-shadow:0 0 14px rgba(118,242,255,.8)}
+.toggle-state{font-size:.78rem;color:#99b5de;min-width:34px;text-align:right}
+.fundamental-badge{display:inline-flex;align-items:center;gap:6px;margin-left:10px;padding:4px 10px;border-radius:999px;border:1px solid rgba(95,224,255,.45);background:rgba(9,48,66,.45);color:#bff7ff;font-size:.78rem;box-shadow:0 0 15px rgba(95,224,255,.24)}
 .pair-card{border:none;border-radius:16px;padding:12px;cursor:pointer;text-align:left;background:var(--card);border:1px solid rgba(75,183,255,.42);box-shadow:var(--neon);color:var(--text);transition:transform .2s, border-color .2s, box-shadow .2s;min-height:108px;display:grid;gap:6px}
 .pair-card:hover{transform:translateY(-2px);border-color:var(--line-strong);box-shadow:0 0 0 1px rgba(90,205,255,.7),0 24px 46px rgba(1,7,22,.6),0 0 35px rgba(90,205,255,.24)}
 .pair-card.active{border-color:#7addff;box-shadow:0 0 0 1px #5edbff,0 28px 54px rgba(1,7,22,.7),0 0 38px rgba(94,219,255,.3)}
@@ -72,6 +80,13 @@ body{background:radial-gradient(circle at 15% 0%, #11254a 0%, #071123 35%, #0307
     <section class="analytics-panel">
       <h2 class="panel-title">Выбор инструмента</h2>
       <p class="panel-subtitle">Кликните карточку, чтобы отправить запрос в <code>/api/chat</code> и открыть разбор.</p>
+      <div class="fundamental-toggle">
+        <span class="toggle-label">Фундаментальный режим</span>
+        <button id="fundamentalToggle" class="toggle-switch" type="button" aria-pressed="false" onclick="toggleFundamentalMode()">
+          <span class="knob"></span>
+        </button>
+        <span id="fundamentalState" class="toggle-state">OFF</span>
+      </div>
       <div class="cards-grid" id="pairCards"></div>
     </section>
 
@@ -94,6 +109,7 @@ const pairs = [
   { name: 'USDJPY', status: 'MT4 data / waiting', text: 'Баланс доходностей и сила доллара, акцент на трендовую структуру.' },
   { name: 'XAUUSD', status: 'MT4 data / waiting', text: 'Золото: защита капитала, ключевые уровни и чувствительность к риску.' }
 ];
+let useFundamentalMode = false;
 
 function escapeHtml(value){
   return String(value)
@@ -158,7 +174,7 @@ async function requestPairAnalysis(pairName){
   const subtitle = document.getElementById('resultSubtitle');
 
   setActiveCard(pairName);
-  subtitle.textContent = `Инструмент: ${pairName}`;
+  subtitle.innerHTML = `Инструмент: ${escapeHtml(pairName)}`;
   status.textContent = `Запрос по ${pairName} выполняется...`;
   setLoadingCard(pairName);
   responseBox.innerHTML = '<p class="notice">Загрузка аналитики...</p>';
@@ -169,10 +185,12 @@ async function requestPairAnalysis(pairName){
     const r = await fetch('/api/chat', {
       method:'POST',
       headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ message })
+      body: JSON.stringify({ message, context: { use_fundamental: useFundamentalMode } })
     });
 
     const data = await r.json();
+    const fundamentalBadge = data && data.fundamental_used ? '<span class="fundamental-badge">🌐 С учетом новостей</span>' : '';
+    subtitle.innerHTML = `Инструмент: ${escapeHtml(pairName)}${fundamentalBadge}`;
     responseBox.innerHTML = renderReply(data);
     status.textContent = `Ответ по ${pairName} получен`;
     clearLoadingCards();
@@ -181,6 +199,15 @@ async function requestPairAnalysis(pairName){
     status.textContent = `Ошибка запроса по ${pairName}`;
     responseBox.innerHTML = `<p class="result-article">${escapeHtml(`Ошибка: ${e}`)}</p>`;
   }
+}
+
+function toggleFundamentalMode(){
+  useFundamentalMode = !useFundamentalMode;
+  const toggle = document.getElementById('fundamentalToggle');
+  const state = document.getElementById('fundamentalState');
+  toggle.classList.toggle('active', useFundamentalMode);
+  toggle.setAttribute('aria-pressed', useFundamentalMode ? 'true' : 'false');
+  state.textContent = useFundamentalMode ? 'ON' : 'OFF';
 }
 
 function initCards(){


### PR DESCRIPTION
### Motivation
- Добавить опциональный режим фундаментального анализа для страницы `/analytics`, позволяющий включать интернет-поиск/онлайн‑режим модели без нарушения текущего поведения и контрактов.

### Description
- В `app/static/analytics.html` добавлен неоновый переключатель «Фундаментальный режим» (OFF по умолчанию) и отправка флага в `context` запроса: `context.use_fundamental`.
- В `app/main.py` минимально добавлено чтение флага через `use_fundamental = bool(getattr(payload, "context", {}).get("use_fundamental", False))` и прокидка его только в аналитическую ветку вызова `_build_mt4_chat_analytics_response`.
- При `use_fundamental = true` для аналитики модель переключается на `OPENROUTER_MODEL:online`, добавляется инструмент `openrouter:web_search` с `max_results=3` и ограничение `max_tokens=400`, а промпт разрешает использование найденных новостей; при `false` внешние новости явно запрещены.
- Ответ аналитики гарантированно содержит поля `fundamental_used` и `article_ru` (включая fallback-ветки), при включённом режиме frontend отображает бейдж `🌐 С учетом новостей`.

### Testing
- Автоматически выполнена проверка компиляции: `python -m py_compile app/main.py` — успешно.
- Изменения зафиксированы в коммите (см. сообщение коммита) — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f29f9a7c833196e1b3507b33267c)