### PR TITLE
Улучшена обработка новостей: перевод, разбор, влияние и сентимент

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -441,6 +441,7 @@ def _local_writer_payload(title: str, summary: str, markets: list[str], tone: st
     market_impact = paragraphs[3] if len(paragraphs) > 3 else paragraphs[-1]
     humor = "Лёгкий рыночный юмор встроен в основной текст без отдельного блока."
     return {
+        "title_ru": clean_title,
         "preview_ru": f"{clean_title}. {clean_summary[:130]}",
         "full_text_ru": full_text,
         "what_happened_ru": what_happened,
@@ -448,6 +449,30 @@ def _local_writer_payload(title: str, summary: str, markets: list[str], tone: st
         "market_impact_ru": market_impact,
         "humor_ru": humor,
     }
+
+
+def _build_sentiment_map(text: str, assets: list[str]) -> dict[str, str]:
+    lowered = text.lower()
+    if any(x in lowered for x in ["hot", "higher", "above forecast", "hawkish", "rate hike", "inflation up"]):
+        usd_sentiment = "bullish"
+        xau_sentiment = "bearish"
+    elif any(x in lowered for x in ["cooling", "below forecast", "dovish", "rate cut", "slowdown"]):
+        usd_sentiment = "bearish"
+        xau_sentiment = "bullish"
+    else:
+        usd_sentiment = "neutral"
+        xau_sentiment = "neutral"
+
+    sentiment: dict[str, str] = {"USD": usd_sentiment, "XAUUSD": xau_sentiment}
+    for code in ("EUR", "GBP", "JPY"):
+        sentiment[code] = "neutral"
+    if any(asset == "EURUSD" for asset in assets):
+        sentiment["EUR"] = "bearish" if usd_sentiment == "bullish" else "bullish" if usd_sentiment == "bearish" else "neutral"
+    if any(asset == "GBPUSD" for asset in assets):
+        sentiment["GBP"] = "bearish" if usd_sentiment == "bullish" else "bullish" if usd_sentiment == "bearish" else "neutral"
+    if any(asset == "USDJPY" for asset in assets):
+        sentiment["JPY"] = "bearish" if usd_sentiment == "bullish" else "bullish" if usd_sentiment == "bearish" else "neutral"
+    return sentiment
 
 
 def build_market_explanation(title: str, summary: str) -> dict[str, Any]:
@@ -586,6 +611,7 @@ def rewrite_news_with_xai(title: str, summary: str, markets: list[str]) -> dict[
         elif len(full_text) < 1200:
             return None
         cleaned = {
+            "title_ru": strip_html(str(parsed.get("title_ru") or "")).strip(),
             "preview_ru": strip_html(str(parsed.get("preview_ru") or "")).strip()[:160],
             "full_text_ru": full_text,
             "what_happened_ru": strip_html(str(parsed.get("what_happened_ru") or "")).strip(),
@@ -713,8 +739,8 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     image_alt = f"{strip_html(title)[:110] or 'Иллюстрация новости'} — иллюстрация новости"
                     rewrite = rewrite_news_with_xai(title=title, summary=summary, markets=enriched["markets"])
                     story = rewrite or _local_writer_payload(title=title, summary=summary, markets=enriched["markets"], tone=enriched["tone"])
-                    title_ru = strip_html(title)
-                    summary_ru = story["preview_ru"]
+                    title_ru = strip_html(story.get("title_ru") or title)
+                    summary_ru = story["preview_ru"] if len(strip_html(summary)) > 20 else f"{story['preview_ru']} Интерпретация ограничена: исходный текст слишком короткий."
                     writer = "grok" if rewrite else "local_fallback"
                     if rewrite:
                         diagnostics["grok_used_count"] += 1
@@ -727,9 +753,11 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     image_source = "placeholder"
                     image_alt = "Иллюстрация новости"
                     story = _local_writer_payload(title=title, summary=summary, markets=enriched["markets"], tone=enriched["tone"])
-                    title_ru = strip_html(title)
-                    summary_ru = story["preview_ru"]
+                    title_ru = strip_html(story.get("title_ru") or title)
+                    summary_ru = story["preview_ru"] if len(strip_html(summary)) > 20 else f"{story['preview_ru']} Интерпретация ограничена: исходный текст слишком короткий."
                     writer = "local_fallback"
+                affected_assets = enriched["markets"]
+                sentiment = _build_sentiment_map(f"{title} {summary}", affected_assets)
                 source_had_item = True
                 items.append(
                     {
@@ -739,7 +767,8 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                         "published_at": published_iso,
                         "summary": summary_ru,
                         "impact": enriched["impact"],
-                        "markets": enriched["markets"],
+                        "markets": affected_assets,
+                        "affected_assets": affected_assets,
                         "tone": enriched["tone"],
                         "image_url": safe_image_url,
                         "image_source": image_source,
@@ -758,6 +787,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                         "why_it_matters_ru": story["why_it_matters_ru"],
                         "market_impact_ru": story["market_impact_ru"],
                         "humor_ru": story["humor_ru"],
+                        "sentiment": sentiment,
                         "what_next_ru": "Следим за следующими релизами и реакцией долгового рынка.",
                         "grok_style_comment_ru": story["humor_ru"],
                         "long_story_ru": story["full_text_ru"],
@@ -796,6 +826,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     "summary": enriched["summary"],
                     "impact": enriched["impact"],
                     "markets": enriched["markets"],
+                    "affected_assets": enriched["markets"],
                     "tone": enriched["tone"],
                     "image_url": pick_fallback_news_image(title=title, summary=summary, markets=enriched["markets"]),
                     "image_source": "placeholder",
@@ -813,6 +844,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     "what_happened_ru": f"Что случилось: {summary}",
                     "why_it_matters_ru": "Почему это важно: без подтверждённых новостей нельзя делать выводы о направлении рынка.",
                     "market_impact_ru": enriched["impact"],
+                    "sentiment": _build_sentiment_map(f"{title} {summary}", enriched["markets"]),
                     "humor_ru": "Юмор с оговоркой: это резервный текст до восстановления источников.",
                     "what_next_ru": "К чему может привести: дождитесь публикаций из реальных источников RSS.",
                     "grok_style_comment_ru": "Комментарий: это fallback-контент, а не подтверждённая новость.",

--- a/app/static/news.html
+++ b/app/static/news.html
@@ -83,6 +83,14 @@
         return list.map((item) => `<span class="news-chip">${escapeHtml(item)}</span>`).join("");
       }
 
+      function buildSentiment(sentiment) {
+        const entries = sentiment && typeof sentiment === "object" ? Object.entries(sentiment) : [];
+        if (!entries.length) return '<span class="news-chip news-chip--muted">Сентимент: н/д</span>';
+        return entries
+          .map(([asset, mood]) => `<span class="news-chip">${escapeHtml(asset)}: ${escapeHtml(mood || "neutral")}</span>`)
+          .join("");
+      }
+
       function imageHtml(item, big = false) {
         const wrapClass = big ? "news-image-wrap news-image-wrap--big" : "news-image-wrap";
         return `
@@ -104,7 +112,11 @@
           ${imageHtml(item, true)}
           <p class="news-card__eyebrow">Источник: ${escapeHtml(item.source || "Источник")} · ${formatDate(item.published_at)}</p>
           <h3 class="news-card__title">${escapeHtml(title)}</h3>
+          <section class="news-detail-box"><h4>Оригинальный заголовок</h4><p class="news-card__text">${escapeHtml(item.title_original || "—")}</p></section>
           <div class="news-chip-row">${buildMarkets(item.markets || item.assets)}</div>
+          <section class="news-detail-box"><h4>Влияние на рынок</h4><p class="news-card__text">${escapeHtml(item.market_impact_ru || "Оценка влияния ограничена.")}</p></section>
+          <section class="news-detail-box"><h4>Сентимент</h4><div class="news-chip-row">${buildSentiment(item.sentiment)}</div></section>
+          <section class="news-detail-box"><h4>Заметка с улыбкой</h4><p class="news-card__text">${escapeHtml(item.humor_ru || "Рынок сегодня без шуток, но с волатильностью.")}</p></section>
           <section class="news-modal__body"><p class="news-modal__story">${escapeHtml(fullText)}</p></section>
           <div class="news-card__footer">
             ${item.source_url ? `<a class="news-link-button" href="${escapeHtml(item.source_url)}" target="_blank" rel="noopener noreferrer">Открыть источник</a>` : '<span class="news-link-button news-link-button--disabled">Ссылка недоступна</span>'}
@@ -145,10 +157,12 @@
               <h3 class="news-card__title">${escapeHtml(item.title_ru || item.title || "Новость без заголовка")}</h3>
             </div>
             <section class="news-detail-box"><h4>Коротко</h4><p class="news-card__text">${escapeHtml(item.preview_ru || item.summary || "Описание недоступно.")}</p></section>
+            <section class="news-detail-box"><h4>Влияние на рынок</h4><p class="news-card__text">${escapeHtml(item.market_impact_ru || "Оценка влияния ограничена.")}</p></section>
             <div class="news-card__assets">
               <span class="news-label">Рынки под прицелом</span>
-              <div class="news-chip-row">${buildMarkets(item.markets)}</div>
+              <div class="news-chip-row">${buildMarkets(item.affected_assets || item.markets)}</div>
             </div>
+            <section class="news-detail-box"><h4>Немного юмора</h4><p class="news-card__text">${escapeHtml(item.humor_ru || "Рынок шутит свечами, мы — аккуратно словами.")}</p></section>
             <div class="news-card__footer">
               <button class="news-link-button" type="button">Читать разбор</button>
             </div>


### PR DESCRIPTION
### Motivation
- Сделать страницу новостей полезной для трейдера: не показывать сырые заголовки, а переводить и объяснять каждую новость по‑русски с рыночной интерпретацией и лёгкой шуткой.
- Внести минимальные и безопасные изменения, ограниченные в новостном пайплайне и UI, не затрагивая `/ideas`, `/analytics` и MT4‑логику.

### Description
- Добавлена функция `_build_sentiment_map(...)`, возвращающая базовый сентимент (`bullish`/`bearish`/`neutral`) для `USD`, `EUR`, `GBP`, `JPY`, `XAUUSD` и связанного списка активов; файл: `app/services/news_service.py`.
- Расширен локальный fallback‑райтер `_local_writer_payload(...)`, теперь возвращает `title_ru` и сохраняет `preview_ru`, `full_text_ru`, `what_happened_ru`, `why_it_matters_ru`, `market_impact_ru`, `humor_ru` (файл: `app/services/news_service.py`).
- В `fetch_public_news(...)` используется `title_ru` из AI/локального переписывания, добавлены поля `affected_assets` и `sentiment`, и при слишком коротком исходном тексте добавляется явная пометка об ограниченной интерпретации (файл: `app/services/news_service.py`).
- Обновлён fallback для ситуации отсутствия RSS, чтобы возвращаемая структура включала `affected_assets` и `sentiment` и соответствовала основному контракту API (файл: `app/services/news_service.py`).
- Обновлён фронтенд `app/static/news.html` для отображения русского заголовка, оригинального заголовка, `summary_ru`/`preview_ru`, `market_impact_ru`, `affected_assets`, `sentiment` и `humor_ru` в карточках и модальном окне без изменения общего стиля страницы.
- Сохранена совместимость API: старые поля не удалялись, только дополнились новые поля для фронтенда.

### Testing
- Выполнена проверка компиляции Python с помощью `python -m py_compile app/main.py app/services/news_service.py`, проверка завершилась успешно.
- Локальная проверка загрузки и отображения полей в `news.html` через существующий JS‑шаблон (визуальная проверка компонентов страницы) проведена без ошибок на этапе разработки.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58a498c7083318ff4bbef0cbc2eba)