### PR TITLE
Исправление агрегации RSS и fallback-парсинга в news_service

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -4,6 +4,7 @@ import html
 import json
 import os
 import re
+import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from hashlib import sha1
@@ -713,11 +714,30 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
             response = requests.get(source["url"], timeout=RSS_TIMEOUT_SECONDS, headers=RSS_HEADERS)
             response.raise_for_status()
             feed = feedparser.parse(response.content)
-            entries = getattr(feed, "entries", [])[: max(limit, 12)]
+            entries = getattr(feed, "entries", [])
             if not entries:
-                sources_failed.append(source_name)
-                continue
-            source_had_item = False
+                try:
+                    root = ET.fromstring(response.content)
+                    fallback_entries: list[dict[str, Any]] = []
+                    for node in root.findall(".//item"):
+                        title_node = node.find("title")
+                        link_node = node.find("link")
+                        date_node = node.find("pubDate")
+                        fallback_entries.append(
+                            {
+                                "title": (title_node.text if title_node is not None else "") or "",
+                                "link": (link_node.text if link_node is not None else "") or "",
+                                "published": (date_node.text if date_node is not None else "") or "",
+                                "summary": "",
+                                "description": "",
+                            }
+                        )
+                    entries = fallback_entries
+                except Exception:
+                    entries = []
+
+            entries = entries[: max(limit, 12)]
+            parsed_items: list[dict[str, Any]] = []
             for entry in entries:
                 source_url = str(entry.get("link") or "").strip() or None
                 try:
@@ -775,8 +795,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                 sentiment = _build_sentiment_map(f"{title} {summary}", affected_assets)
                 if isinstance(story.get("sentiment"), str):
                     sentiment["MARKET"] = str(story.get("sentiment"))
-                source_had_item = True
-                items.append(
+                parsed_items.append(
                     {
                         "title": title_ru,
                         "source": source_name,
@@ -810,10 +829,12 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                         "long_story_ru": story["full_text_ru"],
                     }
                 )
-            if source_had_item:
-                sources_ok.append(source_name)
-            else:
+            print("[news] source:", source_name, "items:", len(parsed_items))
+            if len(parsed_items) == 0:
                 sources_failed.append(source_name)
+            else:
+                sources_ok.append(source_name)
+                items.extend(parsed_items)
         except requests.Timeout as exc:
             fetch_error = f"timeout: {exc}"
             sources_failed.append(source_name)
@@ -832,9 +853,11 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
         seen.add(key)
         deduped.append(item)
 
-    final_items = deduped[:limit]
-    if not final_items:
+    results = deduped
+    if len(results) == 0:
         final_items = []
+    else:
+        final_items = results[:5]
 
     real_items_count = sum(1 for item in final_items if item.get("is_real_source") is True)
     fallback_items_count = len(final_items) - real_items_count


### PR DESCRIPTION
### Motivation
- После обновления надежности `feedparser` иногда возвращал пустые `entries`, из‑за чего фронтенд показывал fallback и новости не отображались.
- Нужно восстановить агрегирование новостей при наличии хотя бы одного работоспособного RSS-источника и добавить прозрачные логи по каждому источнику.

### Description
- В `app/services/news_service.py` добавлен импорт `xml.etree.ElementTree as ET` и реализован fallback-разбор XML, который извлекает `title`, `link` и `pubDate` для базовой валидации элементов RSS.
- Обработка каждого источника теперь накапливает результаты в локальный список `parsed_items` и выводит отладочный лог `print("[news] source:", source_name, "items:", len(parsed_items))`.
- Если `len(parsed_items) > 0`, элементы добавляются в общий список через `items.extend(parsed_items)`, иначе источник помечается в `sources_failed`.
- Обновлена логика финальной выборки: `results = deduped; if len(results) == 0: final_items = [] else: final_items = results[:5]`, при этом формат ответа API не изменялся и фронтенд не затрагивался.

### Testing
- Синтаксическая проверка: `python -m py_compile app/services/news_service.py` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b6493aa0833195b996e3636698b2)