### PR TITLE
Добавить fallback-модель OpenRouter для Grok (новости, аналитика, идеи)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -96,6 +96,17 @@ app = FastAPI(title="AI FOREX SIGNAL PLATFORM", version="htf-context-real-candle
 
 chat_service = ForexChatService()
 
+OPENROUTER_FALLBACK_MODEL = os.getenv("OPENROUTER_FALLBACK_MODEL", "meta-llama/llama-3.1-8b-instruct:free").strip()
+
+
+def _ai_model_sequence(primary_model: str) -> list[str]:
+    models = [str(primary_model or "").strip()]
+    fallback_model = OPENROUTER_FALLBACK_MODEL
+    if fallback_model and fallback_model not in models:
+        models.append(fallback_model)
+    return [model for model in models if model]
+
+
 if STATIC_DIR.exists():
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
@@ -261,40 +272,56 @@ async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = 
             f"MT4 context:\n{json.dumps(mt4_context, ensure_ascii=False)}"
         )
     try:
-        model_name = f"{chat_service.model}:online" if use_fundamental else chat_service.model
-        tools: list[dict[str, Any]] = []
-        if use_fundamental:
-            tools = [{"type": "openrouter:web_search", "max_results": 2}]
-        request_kwargs: dict[str, Any] = {
-            "model": model_name,
-            "messages": [
-                {"role": "system", "content": "Ты профессиональный FX market desk аналитик. Пиши строго на русском языке."},
-                {"role": "user", "content": ai_prompt},
-            ],
-            "temperature": 0.2,
-        }
-        if use_fundamental:
-            request_kwargs["max_tokens"] = 280
-            request_kwargs["tools"] = tools
-            request_kwargs["timeout"] = 15
+        primary_model = f"{chat_service.model}:online" if use_fundamental else chat_service.model
+        model_sequence = _ai_model_sequence(primary_model)
+        tools: list[dict[str, Any]] = [{"type": "openrouter:web_search", "max_results": 2}] if use_fundamental else []
         online_attempted = bool(use_fundamental)
-        ai_status = "ok"
-        response = None
-        try:
-            response = await chat_service.client.chat.completions.create(**request_kwargs)
-        except Exception:
+        ai_status = "failed"
+        ai_model_used = model_sequence[-1] if model_sequence else ""
+        ai_fallback_used = False
+        ai_json: dict[str, Any] = {}
+        for idx, model_name in enumerate(model_sequence):
+            request_kwargs: dict[str, Any] = {
+                "model": model_name,
+                "messages": [
+                    {"role": "system", "content": "Ты профессиональный FX market desk аналитик. Пиши строго на русском языке."},
+                    {"role": "user", "content": ai_prompt},
+                ],
+                "temperature": 0.2,
+                "timeout": 15,
+            }
             if use_fundamental:
-                retry_kwargs = dict(request_kwargs)
-                retry_kwargs.pop("tools", None)
-                response = await chat_service.client.chat.completions.create(**retry_kwargs)
-                ai_status = "ok_retry_no_web"
-            else:
-                raise
-        ai_text = (response.choices[0].message.content or "").strip() if response.choices else ""
-        ai_json = json.loads(ai_text) if ai_text else {}
+                request_kwargs["max_tokens"] = 280
+                request_kwargs["tools"] = tools
+            try:
+                response = await chat_service.client.chat.completions.create(**request_kwargs)
+            except Exception:
+                if use_fundamental:
+                    try:
+                        retry_kwargs = dict(request_kwargs)
+                        retry_kwargs.pop("tools", None)
+                        response = await chat_service.client.chat.completions.create(**retry_kwargs)
+                    except Exception:
+                        continue
+                else:
+                    continue
+            ai_text = (response.choices[0].message.content or "").strip() if response.choices else ""
+            if not ai_text:
+                continue
+            ai_json = json.loads(ai_text) if ai_text else {}
+            if not ai_json:
+                continue
+            ai_model_used = model_name
+            ai_fallback_used = idx > 0
+            ai_status = "ok" if not ai_fallback_used else "ok_fallback_model"
+            break
+        if ai_status.startswith("failed"):
+            raise RuntimeError("all_models_failed")
         return base_response | {
             "ai_provider": "grok",
-            "ai_model": model_name,
+            "ai_model": ai_model_used,
+            "ai_model_used": ai_model_used,
+            "ai_fallback_used": ai_fallback_used,
             "fundamental_used": use_fundamental,
             "online_attempted": online_attempted,
             "candles_sent_to_ai": len(ai_candles),
@@ -336,6 +363,8 @@ async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = 
             "online_attempted": bool(use_fundamental),
             "candles_sent_to_ai": len(ai_candles),
             "search_results_limit": 2 if use_fundamental else 0,
+            "ai_model_used": _ai_model_sequence(f"{chat_service.model}:online" if use_fundamental else chat_service.model)[-1] if _ai_model_sequence(f"{chat_service.model}:online" if use_fundamental else chat_service.model) else "",
+            "ai_fallback_used": True,
         }
 def get_fallback_calendar_events() -> list[dict[str, Any]]:
     return [
@@ -1599,16 +1628,24 @@ def generate_idea_description_ru(
     )
 
     async def _request() -> str:
-        response = await chat_service.client.chat.completions.create(
-            model=chat_service.model,
-            messages=[
-                {"role": "system", "content": "Ты профессиональный FX desk-аналитик. Пиши только на русском."},
-                {"role": "user", "content": prompt},
-            ],
-            temperature=0.3,
-            max_tokens=180,
-        )
-        return (response.choices[0].message.content or "").strip() if response.choices else ""
+        for model_name in _ai_model_sequence(chat_service.model):
+            try:
+                response = await chat_service.client.chat.completions.create(
+                    model=model_name,
+                    messages=[
+                        {"role": "system", "content": "Ты профессиональный FX desk-аналитик. Пиши только на русском."},
+                        {"role": "user", "content": prompt},
+                    ],
+                    temperature=0.3,
+                    max_tokens=180,
+                    timeout=15,
+                )
+                text = (response.choices[0].message.content or "").strip() if response.choices else ""
+                if text:
+                    return text
+            except Exception:
+                continue
+        return ""
 
     try:
         text = asyncio.run(_request())

--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -229,7 +229,8 @@ PUBLIC_RSS_SOURCES = [
 ]
 
 XAI_TIMEOUT_SECONDS = 15
-XAI_MODEL = os.getenv("XAI_MODEL", get_openrouter_model()).strip()
+XAI_MODEL = os.getenv("OPENROUTER_MODEL", os.getenv("XAI_MODEL", get_openrouter_model())).strip()
+XAI_FALLBACK_MODEL = os.getenv("OPENROUTER_FALLBACK_MODEL", "meta-llama/llama-3.1-8b-instruct:free").strip()
 XAI_API_KEY = os.getenv("XAI_API_KEY", "").strip()
 OPENROUTER_API_KEY = (get_openrouter_api_key() or "").strip()
 OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1").strip()
@@ -574,36 +575,44 @@ def rewrite_news_with_xai(title: str, summary: str, source: str, published_at: s
         f"published_at: {published_at or 'unknown'}\n"
         f"content: {strip_html(summary)[:1200]}\n"
     )
-    try:
-        response = requests.post(
-            f"{OPENROUTER_BASE_URL.rstrip('/')}/chat/completions",
-            timeout=XAI_TIMEOUT_SECONDS,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": XAI_MODEL,
-                "temperature": 0.4,
-                "max_tokens": 250,
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": "Ты русскоязычный аналитик forex-новостей. Кратко объясни: что произошло, почему важно и какие активы могут реагировать. "
-                        "Юмор: короткий, лёгкий, в стиле трейдера, не оскорбительный. Никаких новых фактов, только входной текст.",
-                    },
-                    {"role": "user", "content": user_content},
-                ],
-            },
-        )
-        print(f"[news:grok] status_code={response.status_code}")
-        print(f"[news:grok] response_text={response.text[:500]}")
-        response.raise_for_status()
-        payload = response.json()
-        content = payload.get("choices", [{}])[0].get("message", {}).get("content", "")
-        content_text = str(content or "").strip()
-        parsed: dict[str, Any] = {}
-        if content_text:
+    models = [XAI_MODEL]
+    if XAI_FALLBACK_MODEL and XAI_FALLBACK_MODEL not in models:
+        models.append(XAI_FALLBACK_MODEL)
+    last_error = "unknown_error"
+    for idx, model_name in enumerate(models):
+        fallback_used = idx > 0
+        try:
+            response = requests.post(
+                f"{OPENROUTER_BASE_URL.rstrip('/')}/chat/completions",
+                timeout=XAI_TIMEOUT_SECONDS,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model_name,
+                    "temperature": 0.4,
+                    "max_tokens": 250,
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "Ты русскоязычный аналитик forex-новостей. Кратко объясни: что произошло, почему важно и какие активы могут реагировать. "
+                            "Юмор: короткий, лёгкий, в стиле трейдера, не оскорбительный. Никаких новых фактов, только входной текст.",
+                        },
+                        {"role": "user", "content": user_content},
+                    ],
+                },
+            )
+            print(f"[news:grok] model={model_name} status_code={response.status_code}")
+            print(f"[news:grok] response_text={response.text[:500]}")
+            response.raise_for_status()
+            payload = response.json()
+            content = payload.get("choices", [{}])[0].get("message", {}).get("content", "")
+            content_text = str(content or "").strip()
+            if not content_text:
+                last_error = "empty_text"
+                continue
+            parsed: dict[str, Any] = {}
             try:
                 parsed = json.loads(content_text)
             except Exception:
@@ -613,21 +622,45 @@ def rewrite_news_with_xai(title: str, summary: str, source: str, published_at: s
                         parsed = json.loads(json_match.group(0))
                     except Exception:
                         parsed = {}
-        summary_ru = strip_html(str(parsed.get("summary_ru") or "")).strip()
-        impact_ru = strip_html(str(parsed.get("market_impact_ru") or "")).strip()
-        plain_text_summary = strip_html(content_text).strip()
-        cleaned = {
-            "title_ru": strip_html(str(parsed.get("title_ru") or "")).strip() or strip_html(title),
-            "summary_ru": summary_ru or plain_text_summary or "Не удалось обработать новость через Grok.",
-            "market_impact_ru": impact_ru or "Трактовка по влиянию ограничена: модель вернула свободный текст.",
-            "affected_assets": parsed.get("affected_assets") if isinstance(parsed.get("affected_assets"), list) else markets[:4],
-            "sentiment": strip_html(str(parsed.get("sentiment") or "neutral")).strip().lower()[:20] or "neutral",
-            "humor_ru": strip_html(str(parsed.get("humor_ru") or "")).strip() or "Рынок шутит свечами, но без перегиба.",
-        }
-        REWRITE_CACHE[cache_key] = {"ts": time(), "payload": cleaned}
-        return cleaned
-    except Exception:
-        return None
+            summary_ru = strip_html(str(parsed.get("summary_ru") or "")).strip()
+            impact_ru = strip_html(str(parsed.get("market_impact_ru") or "")).strip()
+            plain_text_summary = strip_html(content_text).strip()
+            cleaned = {
+                "title_ru": strip_html(str(parsed.get("title_ru") or "")).strip() or strip_html(title),
+                "summary_ru": summary_ru or plain_text_summary or "Не удалось обработать новость через Grok.",
+                "market_impact_ru": impact_ru or "Трактовка по влиянию ограничена: модель вернула свободный текст.",
+                "affected_assets": parsed.get("affected_assets") if isinstance(parsed.get("affected_assets"), list) else markets[:4],
+                "sentiment": strip_html(str(parsed.get("sentiment") or "neutral")).strip().lower()[:20] or "neutral",
+                "humor_ru": strip_html(str(parsed.get("humor_ru") or "")).strip() or "Рынок шутит свечами, но без перегиба.",
+                "ai_model_used": model_name,
+                "ai_fallback_used": fallback_used,
+                "ai_status": "ok" if not fallback_used else "ok_fallback_model",
+            }
+            REWRITE_CACHE[cache_key] = {"ts": time(), "payload": cleaned}
+            return cleaned
+        except requests.Timeout:
+            last_error = "timeout"
+        except requests.RequestException as req_exc:
+            code = getattr(getattr(req_exc, 'response', None), 'status_code', None)
+            last_error = f"http_{code}" if code else "http_error"
+        except Exception:
+            last_error = "error"
+
+    REWRITE_CACHE[cache_key] = {
+        "ts": time(),
+        "payload": {
+            "title_ru": strip_html(title),
+            "summary_ru": "Не удалось обработать новость через Grok.",
+            "market_impact_ru": "Оценка влияния временно недоступна.",
+            "affected_assets": markets[:4],
+            "sentiment": "neutral",
+            "humor_ru": "Сегодня без фирменной шутки Grok — ждём следующий апдейт.",
+            "ai_model_used": models[-1],
+            "ai_fallback_used": len(models) > 1,
+            "ai_status": f"failed:{last_error}",
+        },
+    }
+    return REWRITE_CACHE[cache_key]["payload"]
 
 
 def _placeholder_svg_for_title(title: str) -> str:


### PR DESCRIPTION
### Motivation
- Обеспечить устойчивую генерацию текстов: сначала использовать Grok (`OPENROUTER_MODEL`), а при ошибках/таймаутах/пустом ответе переключаться на дешёвую/бесплатную модель `OPENROUTER_FALLBACK_MODEL`.
- Сохранить существующие промпты и контракт ответов, добавив диагностические поля для наблюдаемости AI-вызовов.
- Минимально изменить бэкенд (без правок фронтенда, MT4-логики и lifecycle `/ideas`) для совместимости и простого включения через env-переменные.

### Description
- Добавлена новая env-переменная `OPENROUTER_FALLBACK_MODEL` и helper ` _ai_model_sequence(...)` в `app/main.py` для построения последовательности моделей; файлы изменены: `app/main.py`, `app/services/news_service.py`.
- Для MT4-аналитики (`_build_mt4_chat_analytics_response`) реализован цикл попыток по цепочке моделей с таймаутом `15` секунд на каждую попытку и полями диагностики `ai_model_used`, `ai_fallback_used`, `ai_status`, причём исходный prompt/payload не изменён.
- В генерации описаний идей (`generate_idea_description_ru`) добавлен перебор моделей с теми же правилами (таймаут 15s, fallback) и сохранён существующий fallback текст при полном провале.
- В `app/services/news_service.py` (функция `rewrite_news_with_xai`) добавлен порядок попыток: сначала `OPENROUTER_MODEL` (через `XAI_MODEL`), затем `XAI_FALLBACK_MODEL`, обработаны таймауты/ошибки/пустые ответы и в результирующем payload добавлены `ai_model_used`, `ai_fallback_used`, `ai_status`.

### Testing
- Выполнена проверка синтаксиса Python: `python -m py_compile app/main.py app/services/news_service.py`, команда завершилась успешно.
- Логика вызовов сохранена инвариантной для фронтенда и `/ideas`, и при двухэтапном фейле возвращается существующий безопасный текст, как и раньше.
- Никаких дополнительных автоматических тестов не запускалось в этом PR; изменения ограничены серверной логикой и конфигурацией моделей.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cba55f408331bb9385d46db11ecd)