### PR TITLE
Исправить контент новостей: русские заголовки, извлечение статьи и кликабельные карточки

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -292,6 +292,24 @@ def extract_news_image(entry: dict) -> str | None:
     return None
 
 
+def extract_article_text(url: str) -> str:
+    if not url:
+        return ""
+    try:
+        resp = requests.get(url, timeout=8, headers={"User-Agent": "Mozilla/5.0"})
+        if not resp.ok:
+            return ""
+        html_text = resp.text
+        og = re.search(r'<meta[^>]+property=["\']og:description["\'][^>]+content=["\']([^"\']+)["\']', html_text, flags=re.I)
+        md = re.search(r'<meta[^>]+name=["\']description["\'][^>]+content=["\']([^"\']+)["\']', html_text, flags=re.I)
+        base = html.unescape((og.group(1) if og else '') or (md.group(1) if md else ''))
+        text = strip_html(html_text)
+        tail = text[:1500]
+        combined = f"{base} {tail}".strip()
+        return combined[:1500]
+    except Exception:
+        return ""
+
 def extract_article_page_image(url: str) -> str | None:
     try:
         resp = requests.get(url, timeout=8, headers={"User-Agent": "Mozilla/5.0"})
@@ -568,6 +586,7 @@ def rewrite_news_with_xai(title: str, summary: str, source: str, published_at: s
         "- summary_ru\n"
         "- market_impact_ru\n"
         "- affected_assets\n"
+        "- article_ru\n"
         "- sentiment\n"
         "- humor_ru\n\n"
         "Используй только переданные данные, без новых фактов.\n"
@@ -631,9 +650,11 @@ def rewrite_news_with_xai(title: str, summary: str, source: str, published_at: s
             summary_ru = strip_html(str(parsed.get("summary_ru") or "")).strip()
             impact_ru = strip_html(str(parsed.get("market_impact_ru") or "")).strip()
             plain_text_summary = strip_html(content_text).strip()
+            article_ru = strip_html(str(parsed.get("article_ru") or "")).strip()
             cleaned = {
                 "title_ru": strip_html(str(parsed.get("title_ru") or "")).strip() or strip_html(title),
                 "summary_ru": summary_ru or plain_text_summary or "Не удалось обработать новость через Grok.",
+                "article_ru": article_ru or summary_ru or plain_text_summary,
                 "market_impact_ru": impact_ru or "Трактовка по влиянию ограничена: модель вернула свободный текст.",
                 "affected_assets": parsed.get("affected_assets") if isinstance(parsed.get("affected_assets"), list) else markets[:4],
                 "sentiment": strip_html(str(parsed.get("sentiment") or "neutral")).strip().lower()[:20] or "neutral",
@@ -658,6 +679,7 @@ def rewrite_news_with_xai(title: str, summary: str, source: str, published_at: s
             "title_ru": strip_html(title),
             "summary_ru": "Не удалось обработать новость через Grok.",
             "market_impact_ru": "Оценка влияния временно недоступна.",
+            "article_ru": strip_html(summary)[:1200] or strip_html(title),
             "affected_assets": markets[:4],
             "sentiment": "neutral",
             "humor_ru": "Сегодня без фирменной шутки Grok — ждём следующий апдейт.",
@@ -784,7 +806,12 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     published_iso, _ = parse_entry_datetime(entry=entry, fallback=now_utc)
                     image_entry = entry
 
-                enriched = build_market_explanation(title=title, summary=summary)
+                summary_original = strip_html(summary)[:1500]
+                article_original = summary_original
+                if source_url and not summary_original:
+                    article_original = extract_article_text(source_url)
+                    summary_original = article_original[:420]
+                enriched = build_market_explanation(title=title, summary=summary_original)
                 safe_image_url, image_source = _resolve_news_image(
                     title=title,
                     summary=summary,
@@ -797,7 +824,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                 if (OPENROUTER_API_KEY or XAI_API_KEY) and grok_processed < grok_limit:
                     rewrite = rewrite_news_with_xai(
                         title=title,
-                        summary=summary,
+                        summary=article_original or summary_original,
                         source=source_name,
                         published_at=published_iso,
                         markets=enriched["markets"],
@@ -807,6 +834,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     "title_ru": strip_html(title),
                     "summary_ru": "Новость получена, но AI-обработка временно недоступна.",
                     "market_impact_ru": "Оценка влияния будет доступна после восстановления AI-обработки.",
+                    "article_ru": summary_original or strip_html(title),
                     "affected_assets": enriched["markets"],
                     "sentiment": "neutral",
                     "humor_ru": "Сегодня без фирменной шутки Grok — ждём следующий апдейт.",
@@ -821,7 +849,7 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     "source": source_name,
                     "url": source_url,
                     "published_at": published_iso,
-                    "summary": story.get("summary_ru") or strip_html(summary)[:280],
+                    "summary": story.get("summary_ru") or summary_original[:280],
                     "impact": enriched["impact"],
                     "markets": enriched["markets"],
                     "affected_assets": story.get("affected_assets") if isinstance(story.get("affected_assets"), list) else enriched["markets"],
@@ -832,8 +860,10 @@ def fetch_public_news(limit: int = 12) -> dict[str, Any]:
                     "title_original": strip_html(title),
                     "title_ru": strip_html(story.get("title_ru") or title),
                     "source_url": source_url,
-                    "summary_source": strip_html(summary)[:1200],
-                    "summary_original": strip_html(summary)[:1200],
+                    "summary_source": summary_original,
+                    "summary_original": summary_original,
+                    "article_original": article_original,
+                    "article_ru": story.get("article_ru") or story.get("summary_ru") or summary_original,
                     "summary_ru": story.get("summary_ru") or "Новость получена, но AI-обработка временно недоступна.",
                     "market_impact_ru": story.get("market_impact_ru") or "Оценка влияния будет доступна после восстановления AI-обработки.",
                     "humor_ru": story.get("humor_ru") or "",

--- a/app/static/news.html
+++ b/app/static/news.html
@@ -18,22 +18,28 @@
             <div><h2>Лента в стиле Bloomberg Desk</h2><p class="section-text" id="deskMeta">—</p></div>
             <button class="news-link-button" id="refreshNewsButton" type="button">Обновить</button>
           </div>
-          <div id="fallbackBox"></div>
-          <div id="leadStory"></div>
-          <div class="news-list" id="newsList"></div>
+          <div id="fallbackBox"></div><div id="leadStory"></div><div class="news-list" id="newsList"></div>
         </section>
       </main>
     </div>
 <script>
-const newsList=document.getElementById('newsList'); const leadStory=document.getElementById('leadStory'); const fallbackBox=document.getElementById('fallbackBox'); const deskMeta=document.getElementById('deskMeta');
+const newsList=document.getElementById('newsList'),leadStory=document.getElementById('leadStory'),fallbackBox=document.getElementById('fallbackBox'),deskMeta=document.getElementById('deskMeta');
 const esc=(v)=>String(v||'').replace(/[&<>"']/g,s=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[s]));
 const dt=(v)=>{const d=new Date(v); return Number.isNaN(d.getTime())?'—':d.toLocaleString('ru-RU',{timeZone:'UTC'})+' UTC'};
-const chips=(a)=> (Array.isArray(a)&&a.length?a:['N/A']).map(x=>`<span class="news-chip">${esc(x)}</span>`).join('');
-const img=(item,big=false)=> item.image_url?`<div class="news-image-wrap ${big?'news-image-wrap--big':''}"><img src="${esc(item.image_url)}" loading="lazy" onerror="this.parentElement.classList.add('is-fallback'); this.remove();"></div>`:`<div class="news-image-wrap ${big?'news-image-wrap--big':''} is-fallback"></div>`;
+const chips=(a)=> (Array.isArray(a)&&a.length?a:[]).map(x=>`<span class="news-chip">${esc(x)}</span>`).join('');
+const img=(item,big=false)=> item.image_url?`<div class="news-image-wrap ${big?'news-image-wrap--big':''}"><img src="${esc(item.image_url)}" loading="lazy"></div>`:'';
+function row(label,val){return val?`<p class="news-card__text"><strong>${label}:</strong> ${esc(val)}</p>`:''}
+function openModal(item){
+ const body=`<article class="news-card">${img(item,true)}<h3 class="news-card__title">${esc(item.title_ru||item.title_original||'Новость')}</h3><p class="news-card__text" style="opacity:.75">${esc(item.title_original||'')}</p>${row('Источник',(item.source||'—')+' · '+dt(item.published_at))}${row('Объяснение',item.article_ru||item.summary_ru)}${row('Влияние',item.market_impact_ru)}${chips(item.affected_assets)?`<div class="news-chip-row">${chips(item.affected_assets)}</div>`:''}${item.source_url?`<p><a class="news-link-button" href="${esc(item.source_url)}" target="_blank" rel="noopener">Открыть источник</a></p>`:''}</article>`;
+ const modal=document.createElement('div'); modal.style='position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:9999;padding:24px;overflow:auto';
+ modal.innerHTML=`<div style="max-width:900px;margin:0 auto"><button class="news-link-button" id="closeModal">Закрыть</button>${body}</div>`;
+ modal.addEventListener('click',(e)=>{if(e.target===modal) modal.remove();}); document.body.appendChild(modal); document.getElementById('closeModal').onclick=()=>modal.remove();
+}
 function renderFallback(msg){leadStory.innerHTML=''; newsList.innerHTML=''; fallbackBox.innerHTML=`<article class="news-card news-card--empty"><h3 class="news-card__title">⚠️ Системный режим</h3><p class="news-card__text">${esc(msg)}</p></article>`;}
-function card(item,isLead=false){return `<article class="news-card ${isLead?'':'news-card--compact'}">${img(item,isLead)}<p class="news-card__eyebrow">${esc(item.source||'Источник')} · ${dt(item.published_at)}</p><h3 class="news-card__title">${esc(item.title_ru||item.title||'Новость')}</h3><p class="news-card__text">${esc(item.summary_ru||item.summary||'')}</p><p class="news-card__text"><strong>Влияние:</strong> ${esc(item.market_impact_ru||item.impact||'')}</p><div class="news-chip-row">${chips(item.affected_assets)}</div>${item.humor_ru?`<p class="news-card__text"><em>${esc(item.humor_ru)}</em></p>`:''}<div class="news-card__footer">${item.url?`<a class="news-link-button" href="${esc(item.url)}" target="_blank" rel="noopener">Открыть источник</a>`:''}</div></article>`}
+function card(item,isLead=false){const text=item.summary_ru||item.article_ru||''; return `<article class="news-card ${isLead?'':'news-card--compact'}" data-item='${esc(JSON.stringify(item))}' style="cursor:pointer">${img(item,isLead)}<p class="news-card__eyebrow">${esc(item.source||'Источник')} · ${dt(item.published_at)}</p><h3 class="news-card__title">${esc(item.title_ru||item.title_original||'Новость')}</h3><p class="news-card__text" style="opacity:.75">${esc(item.title_original||'')}</p>${text?`<p class="news-card__text">${esc(text.slice(0,260))}</p>`:''}${item.market_impact_ru?`<p class="news-card__text"><strong>Влияние:</strong> ${esc(item.market_impact_ru)}</p>`:''}${chips(item.affected_assets)?`<div class="news-chip-row">${chips(item.affected_assets)}</div>`:''}</article>`}
 async function loadNews(){fallbackBox.innerHTML=''; leadStory.innerHTML=''; newsList.innerHTML='<article class="news-card news-card--empty"><p>Загрузка...</p></article>'; const r=await fetch('/api/news?limit=8',{cache:'no-store'}); const p=await r.json(); deskMeta.textContent=`Статус: ${p.data_status||'—'} · Источники: ${(p.sources_attempted||[]).join(', ')} · Реальных: ${p.real_items_count||0} · Grok: ${p.grok_processed_count||0} · Cache: ${p.cache_hit?'hit':'miss'}`;
-if(p.data_status==='fallback'){renderFallback(p.message_ru||'Новостные источники временно недоступны'); return;} const items=Array.isArray(p.items)?p.items:[]; if(!items.length){renderFallback('Нет подтверждённых новостей.'); return;} leadStory.innerHTML=card(items[0],true); newsList.innerHTML=items.slice(1).map(x=>card(x,false)).join('');}
+if(p.data_status==='fallback'){renderFallback(p.message_ru||'Новостные источники временно недоступны'); return;} const items=Array.isArray(p.items)?p.items:[]; if(!items.length){renderFallback('Нет подтверждённых новостей.'); return;} leadStory.innerHTML=card(items[0],true); newsList.innerHTML=items.slice(1).map(x=>card(x,false)).join('');
+[...document.querySelectorAll('.news-card[data-item]')].forEach(el=>el.onclick=()=>openModal(JSON.parse(el.dataset.item)));}
 document.getElementById('refreshNewsButton').addEventListener('click',loadNews); loadNews();
 </script>
 <script src="/static/nav.js"></script>

--- a/backend/news_provider.py
+++ b/backend/news_provider.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from typing import Iterable
+from urllib.parse import urljoin
 from xml.etree import ElementTree
 
 import feedparser
@@ -166,12 +167,20 @@ class MarketNewsProvider:
 
         clean_title = self._normalize_title(raw_title, source)
         clean_summary = self._clean_description(raw_description, clean_title)
+        image_url = self._extract_image_url(raw_description, raw_link)
+        article_text = ""
+        if not clean_summary and raw_link:
+            fetched_summary, fetched_image, article_text = self._fetch_article_details(raw_link)
+            clean_summary = self._clean_description(fetched_summary, clean_title)
+            image_url = image_url or fetched_image
         return {
             "title_original": clean_title,
             "summary_original": clean_summary,
             "source": source,
             "source_url": raw_link or None,
             "published_at": published_at.isoformat() if published_at else None,
+            "image_url": image_url,
+            "article_original": article_text[:1500],
         }
 
     def _parse_feed_item(self, item: ElementTree.Element, feed_name: str) -> dict | None:
@@ -190,13 +199,56 @@ class MarketNewsProvider:
 
         clean_title = self._normalize_title(raw_title, source)
         clean_summary = self._clean_description(raw_description, clean_title)
+        image_url = self._extract_image_url(raw_description, raw_link)
+        article_text = ""
+        if not clean_summary and raw_link:
+            fetched_summary, fetched_image, article_text = self._fetch_article_details(raw_link)
+            clean_summary = self._clean_description(fetched_summary, clean_title)
+            image_url = image_url or fetched_image
         return {
             "title_original": clean_title,
             "summary_original": clean_summary,
             "source": source,
             "source_url": raw_link or None,
             "published_at": published_at.isoformat() if published_at else None,
+            "image_url": image_url,
+            "article_original": article_text[:1500],
         }
+
+
+    def _extract_image_url(self, raw_description: str, link: str) -> str | None:
+        if not raw_description:
+            return None
+        soup = BeautifulSoup(raw_description, "html.parser")
+        tag = soup.find("img")
+        if not tag:
+            return None
+        src = (tag.get("src") or "").strip()
+        if not src:
+            return None
+        return urljoin(link, src) if link else src
+
+    def _fetch_article_details(self, link: str) -> tuple[str, str | None, str | None]:
+        if not link:
+            return "", None, None
+        try:
+            response = self._session.get(link, timeout=self._request_timeout_seconds, headers={"User-Agent": "Mozilla/5.0"})
+            response.raise_for_status()
+        except requests.RequestException:
+            return "", None, None
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        og_desc = (soup.find("meta", attrs={"property": "og:description"}) or {}).get("content", "").strip()
+        meta_desc = (soup.find("meta", attrs={"name": "description"}) or {}).get("content", "").strip()
+        article_text = ""
+        paragraphs = [p.get_text(" ", strip=True) for p in soup.find_all("p")]
+        joined = " ".join(x for x in paragraphs if x)
+        if joined:
+            article_text = joined[:1500]
+        image_tag = soup.find("meta", attrs={"property": "og:image"})
+        image_url = image_tag.get("content", "").strip() if image_tag else None
+        summary = og_desc or meta_desc or article_text
+        return summary, image_url or None, article_text
 
     def _attach_signal_relations(self, payload: dict, active_signals: list[dict]) -> dict:
         items = [self._intelligence.enrich(item, active_signals) for item in payload.get("news", [])]


### PR DESCRIPTION
### Motivation
- Нужна корректная поддержка реального RSS: сохранять оригинальные поля и показывать перевод/объяснение на русском, даже если Grok/AI падает.
- Пользовательский интерфейс должен отображать русские заголовки и позволять раскрывать полную статью по клику карточки.

### Description
- В `backend/news_provider.py` добавлены безопасные извлечения: `image_url`, `article_original` и логика фетча страницы источника для `og:description`, `meta description` и первых параграфов (до 1500 символов). Также добавлен helper для извлечения изображений из HTML и аккуратное объединение результатов.
- В `app/services/news_service.py` расширена логика XAI/ OpenRouter: в запрос передаётся более полный контент, ожидается `article_ru`, и добавлены надёжные fallback-ы, которые гарантируют заполнение `title_ru`, `summary_ru`, `article_ru`, `market_impact_ru` и связанных полей даже при некорректном или свободном ответе модели.
- В `app/static/news.html` карточки обновлены для фронтенда: основной заголовок теперь `title_ru`, `title_original` показан как вторичная строка, вся карточка кликабельна и открывает modal с полным содержимым (русский/оригинальный заголовок, источник/время, изображение, `article_ru` или `summary_ru`, `market_impact_ru`, `affected_assets` и кнопка на источник), а пустые секции не рендерятся.
- Изменения ограничены и не трогают `/ideas`, `/analytics`, MT4 и маршрут `/news`.

### Testing
- Выполнена компиляция Python-файлов: `python -m py_compile app/services/news_service.py backend/news_provider.py` — успешно.
- Локальная проверка стейтуса репозитория и фиксация изменений через `git commit` — успешно.
- Нет дополнительных автоматизированных unit-тестов в этом изменении; изменения покрыты статической проверкой синтаксиса (см. первый пункт).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e8b40eec833184e69b9b988cd991)