### PR TITLE
Добавить бесплатный CME scraping layer с кэшированием и интеграцией в аналитику

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.services.htf_context_filter import HtfContextFilter
+from app.services.cme_scraper import get_cme_market_snapshot
 from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from backend.chat_service import ChatRequest, ForexChatService
@@ -243,6 +244,27 @@ async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = 
             for candle in ai_candles
         ],
     }
+    cme_data = await get_cme_market_snapshot(normalized_pair)
+    cme_available = bool(cme_data.get("available"))
+    volume_source = "cme_scraping" if cme_available else "mt4_tick_volume"
+    cme_disclaimer = "Data sourced from publicly available CME pages. Not real-time and may be delayed."
+    if cme_available:
+        futures = cme_data.get("futures") or {}
+        analysis = cme_data.get("analysis") or {}
+        base_response["cme"] = cme_data
+        base_response["volume_source"] = volume_source
+        base_response["volume_ru"] = (
+            f"CME ({cme_data.get('symbol')}) объём фьючерса: {futures.get('volume')}, "
+            f"open interest: {futures.get('openInterest')}. Источник: cme_scraping. {cme_disclaimer}"
+        )
+        base_response["options_ru"] = (
+            f"Ключевые страйки: {analysis.get('keyStrikes') or []}. "
+            f"Put/Call bias (PCR): {analysis.get('putCallRatio')}. Max Pain: {analysis.get('maxPain')}. "
+            f"{cme_disclaimer}"
+        )
+    else:
+        base_response["volume_source"] = volume_source
+        base_response["cme"] = cme_data
 
     if not chat_service.client:
         return base_response | {"ai_status": "fallback", "warning": "Grok временно недоступен"}
@@ -350,6 +372,9 @@ async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = 
                 or base_response["summary"]
             ),
             "ai_status": ai_status,
+            "volume_source": volume_source,
+            "cme": cme_data,
+            "cme_disclaimer": cme_disclaimer if cme_available else None,
         }
     except Exception:
         return base_response | {

--- a/app/services/cme_scraper.py
+++ b/app/services/cme_scraper.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+PAIR_MAPPING: dict[str, dict[str, str]] = {
+    "EURUSD": {"slug": "euro-fx", "code": "6E"},
+    "GBPUSD": {"slug": "british-pound", "code": "6B"},
+    "USDJPY": {"slug": "japanese-yen", "code": "6J"},
+    "AUDUSD": {"slug": "australian-dollar", "code": "6A"},
+}
+
+
+@dataclass
+class CacheEntry:
+    value: Any
+    expires_at: datetime
+
+
+class CmeCache:
+    def __init__(self, ttl_seconds: int = 3600) -> None:
+        self.ttl = timedelta(seconds=ttl_seconds)
+        self._store: dict[str, CacheEntry] = {}
+
+    def get(self, key: str) -> Any | None:
+        item = self._store.get(key)
+        if not item:
+            return None
+        if datetime.now(timezone.utc) >= item.expires_at:
+            self._store.pop(key, None)
+            return None
+        return item.value
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = CacheEntry(value=value, expires_at=datetime.now(timezone.utc) + self.ttl)
+
+
+_CACHE = CmeCache(ttl_seconds=3600)
+
+
+def _extract_number(text: str, key: str) -> int | None:
+    patterns = [
+        rf'"{key}"\s*:\s*"?([0-9,]+)"?',
+        rf'>{key}<[^0-9]*([0-9,]+)',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            try:
+                return int(match.group(1).replace(",", ""))
+            except ValueError:
+                continue
+    return None
+
+
+def _extract_options_arrays(text: str) -> dict[str, list[Any]]:
+    result: dict[str, list[Any]] = {"strikes": [], "callOI": [], "putOI": [], "expirations": []}
+
+    data_match = re.search(r"(\{\s*\"quotes\"\s*:\s*\[.*?\]\s*\})", text, flags=re.DOTALL)
+    if data_match:
+        try:
+            blob = json.loads(data_match.group(1))
+            quotes = blob.get("quotes") or []
+            for row in quotes:
+                strike = row.get("strikePrice")
+                call_oi = row.get("callOpenInterest")
+                put_oi = row.get("putOpenInterest")
+                exp = row.get("expirationDate")
+                if strike is not None and call_oi is not None and put_oi is not None:
+                    result["strikes"].append(float(str(strike).replace(",", "")))
+                    result["callOI"].append(int(float(str(call_oi).replace(",", ""))))
+                    result["putOI"].append(int(float(str(put_oi).replace(",", ""))))
+                    if exp:
+                        result["expirations"].append(str(exp))
+        except Exception:
+            pass
+
+    return result
+
+
+def _analyze_options(options: dict[str, list[Any]]) -> dict[str, Any]:
+    strikes = options.get("strikes") or []
+    call_oi = options.get("callOI") or []
+    put_oi = options.get("putOI") or []
+    if not strikes or len(strikes) != len(call_oi) or len(strikes) != len(put_oi):
+        return {"putCallRatio": None, "keyStrikes": [], "barrierZones": [], "maxPain": None}
+
+    total_call = sum(call_oi)
+    total_put = sum(put_oi)
+    ratio = round((total_put / total_call), 4) if total_call else None
+
+    combined = sorted(zip(strikes, call_oi, put_oi), key=lambda row: (row[1] + row[2]), reverse=True)
+    key_strikes = [float(item[0]) for item in combined[:3]]
+    barrier = [{"strike": float(item[0]), "oi": int(item[1] + item[2])} for item in combined[:3]]
+
+    pain_points: list[tuple[float, float]] = []
+    for test_strike in strikes:
+        call_pain = sum(max(0.0, test_strike - s) * oi for s, oi in zip(strikes, call_oi))
+        put_pain = sum(max(0.0, s - test_strike) * oi for s, oi in zip(strikes, put_oi))
+        pain_points.append((test_strike, call_pain + put_pain))
+    max_pain = min(pain_points, key=lambda p: p[1])[0] if pain_points else None
+
+    return {
+        "putCallRatio": ratio,
+        "keyStrikes": key_strikes,
+        "barrierZones": barrier,
+        "maxPain": max_pain,
+    }
+
+
+async def get_cme_market_snapshot(pair: str) -> dict[str, Any]:
+    normalized = (pair or "").upper().strip()
+    mapping = PAIR_MAPPING.get(normalized)
+    if not mapping:
+        return {"available": False, "reason": "CME scraping failed"}
+
+    cache_key = f"cme:{normalized}"
+    cached = _CACHE.get(cache_key)
+    if cached:
+        return cached
+
+    slug = mapping["slug"]
+    futures_url = f"https://www.cmegroup.com/markets/fx/g10/{slug}.html"
+    options_url = f"https://www.cmegroup.com/markets/fx/g10/{slug}.options.html"
+
+    headers = {"User-Agent": "Mozilla/5.0 (compatible; FXSignalPlatform/1.0)"}
+    timeout = httpx.Timeout(10.0, connect=5.0)
+
+    try:
+        async with httpx.AsyncClient(headers=headers, timeout=timeout, follow_redirects=True) as client:
+            futures_resp, options_resp = await asyncio.gather(client.get(futures_url), client.get(options_url))
+        futures_resp.raise_for_status()
+        options_resp.raise_for_status()
+
+        futures_html = futures_resp.text
+        options_html = options_resp.text
+
+        volume = _extract_number(futures_html, "volume")
+        oi = _extract_number(futures_html, "openInterest")
+        options_data = _extract_options_arrays(options_html)
+        options_analysis = _analyze_options(options_data)
+
+        if volume is None or oi is None:
+            raise ValueError("missing futures fields")
+
+        payload = {
+            "available": True,
+            "source": "cme_scraping",
+            "symbol": mapping["code"],
+            "futures": {
+                "volume": int(volume),
+                "openInterest": int(oi),
+                "lastUpdated": datetime.now(timezone.utc).isoformat(),
+            },
+            "options": {
+                "strikes": options_data.get("strikes") or [],
+                "callOI": options_data.get("callOI") or [],
+                "putOI": options_data.get("putOI") or [],
+                "expirations": sorted(list(set(options_data.get("expirations") or [])))[:12],
+            },
+            "analysis": options_analysis,
+            "disclaimer": "Data sourced from publicly available CME pages. Not real-time and may be delayed.",
+        }
+        _CACHE.set(cache_key, payload)
+        return payload
+    except Exception:
+        fallback = {"available": False, "reason": "CME scraping failed"}
+        _CACHE.set(cache_key, fallback)
+        return fallback

--- a/app/static/analytics.html
+++ b/app/static/analytics.html
@@ -142,7 +142,21 @@ function renderReply(data){
   }
 
   if (typeof data.article_ru === 'string' && data.article_ru.trim()) {
-    return `<p class="result-article">${escapeHtml(data.article_ru.trim())}</p>`;
+    let cmeBlock = '';
+    if (data.cme && data.cme.available) {
+      const futures = data.cme.futures || {};
+      const analysis = data.cme.analysis || {};
+      cmeBlock = `<div class="notice" style="margin-bottom:12px">
+        <strong>CME объёмы и опционы</strong><br>
+        Futures volume: ${escapeHtml(String(futures.volume ?? 'n/a'))}<br>
+        Open interest: ${escapeHtml(String(futures.openInterest ?? 'n/a'))}<br>
+        Key strikes: ${escapeHtml(JSON.stringify(analysis.keyStrikes || []))}<br>
+        Put/Call bias: ${escapeHtml(String(analysis.putCallRatio ?? 'n/a'))}<br>
+        Max pain: ${escapeHtml(String(analysis.maxPain ?? 'n/a'))}<br>
+        <small>${escapeHtml(data.cme.disclaimer || "Data sourced from publicly available CME pages. Not real-time and may be delayed.")}</small>
+      </div>`;
+    }
+    return `${cmeBlock}<p class="result-article">${escapeHtml(data.article_ru.trim())}</p>`;
   }
 
   const fallbackFields = [

--- a/services/cmeScraper/cmeCache.ts
+++ b/services/cmeScraper/cmeCache.ts
@@ -1,0 +1,24 @@
+export type CacheValue<T> = { value: T; expiresAt: number };
+
+export class CmeCache {
+  private readonly ttlMs: number;
+  private readonly store = new Map<string, CacheValue<unknown>>();
+
+  constructor(ttlMs = 60 * 60 * 1000) {
+    this.ttlMs = ttlMs;
+  }
+
+  get<T>(key: string): T | null {
+    const item = this.store.get(key);
+    if (!item) return null;
+    if (Date.now() > item.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return item.value as T;
+  }
+
+  set<T>(key: string, value: T): void {
+    this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+  }
+}

--- a/services/cmeScraper/cmeFuturesScraper.ts
+++ b/services/cmeScraper/cmeFuturesScraper.ts
@@ -1,0 +1,23 @@
+import { CmeCache } from "./cmeCache";
+
+const cache = new CmeCache();
+
+export async function fetchCmeFutures(url: string) {
+  const cached = cache.get<any>(url);
+  if (cached) return cached;
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": "FXSignalPlatform/1.0" } });
+    const html = await res.text();
+    const volumeMatch = html.match(/"volume"\s*:\s*"?([0-9,]+)"?/i);
+    const oiMatch = html.match(/"openInterest"\s*:\s*"?([0-9,]+)"?/i);
+    const payload = {
+      volume: Number((volumeMatch?.[1] || "0").replace(/,/g, "")),
+      openInterest: Number((oiMatch?.[1] || "0").replace(/,/g, "")),
+      lastUpdated: new Date().toISOString(),
+    };
+    cache.set(url, payload);
+    return payload;
+  } catch {
+    return { available: false, reason: "CME scraping failed" };
+  }
+}

--- a/services/cmeScraper/cmeOptionsScraper.ts
+++ b/services/cmeScraper/cmeOptionsScraper.ts
@@ -1,0 +1,30 @@
+import { CmeCache } from "./cmeCache";
+import { topKeyStrikes } from "./cmeParser";
+
+const cache = new CmeCache();
+
+export async function fetchCmeOptions(url: string) {
+  const cached = cache.get<any>(url);
+  if (cached) return cached;
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": "FXSignalPlatform/1.0" } });
+    const html = await res.text();
+    const strikes: number[] = [];
+    const callOI: number[] = [];
+    const putOI: number[] = [];
+    const expirations: string[] = [];
+
+    const analysis = {
+      putCallRatio: callOI.length ? putOI.reduce((a, b) => a + b, 0) / callOI.reduce((a, b) => a + b, 0) : null,
+      keyStrikes: topKeyStrikes(strikes, callOI, putOI).map((x) => x.strike),
+      barrierZones: topKeyStrikes(strikes, callOI, putOI),
+      maxPain: strikes[0] ?? null,
+    };
+
+    const payload = { strikes, callOI, putOI, expirations, analysis };
+    cache.set(url, payload);
+    return payload;
+  } catch {
+    return { available: false, reason: "CME scraping failed" };
+  }
+}

--- a/services/cmeScraper/cmeParser.ts
+++ b/services/cmeScraper/cmeParser.ts
@@ -1,0 +1,13 @@
+export function parseNumber(raw: string): number | null {
+  const match = raw.match(/([0-9][0-9,]*)/);
+  if (!match) return null;
+  const num = Number(match[1].replace(/,/g, ""));
+  return Number.isFinite(num) ? num : null;
+}
+
+export function topKeyStrikes(strikes: number[], callOI: number[], putOI: number[]) {
+  return strikes
+    .map((strike, i) => ({ strike, oi: (callOI[i] ?? 0) + (putOI[i] ?? 0) }))
+    .sort((a, b) => b.oi - a.oi)
+    .slice(0, 3);
+}


### PR DESCRIPTION
### Motivation
- Добавить источник деривативных данных (фьючерсы и опционы) из публичных страниц CME для улучшения объёмного и опционного слоя аналитики без платного API. 
- Обеспечить безопасный и отказоустойчивый сбор данных с обязательным кэшированием и явным указанием источника/ограничений данных.

### Description
- Добавлен Python-сервис `app/services/cme_scraper.py` с функцией `get_cme_market_snapshot` и in-memory кэшем TTL=1 час для безопасного асинхронного scraping'а страниц CME. 
- Реализован mapping инструментов (`EURUSD -> euro-fx (6E)`, `GBPUSD -> british-pound (6B)`, `USDJPY -> japanese-yen (6J)`, `AUDUSD -> australian-dollar (6A)`) и парсинг фьючерсов (поле `volume`, `openInterest`) и опционов (`strikes`, `callOI`, `putOI`, `expirations`).
- Выполнён базовый анализ опционного стакана с расчётом `putCallRatio`, `keyStrikes` (топ OI), `barrierZones` и `maxPain`, и возвращением структуры с полями `futures`, `options`, `analysis`, `disclaimer` или fallback-ответа `{ available: false, reason: "CME scraping failed" }` при ошибках.
- Интегрировано в pipeline аналитики в `app/main.py`: добавлены вызов `get_cme_market_snapshot`, поле `volume_source` (значения `cme_scraping` или `mt4_tick_volume`), поля ответа `cme`, `volume_ru`, `options_ru` и `cme_disclaimer` для отображения в API-ответе.
- Обновлён frontend `app/static/analytics.html` для отображения блока с `futures volume`, `open interest`, `key strikes`, `put/call bias`, `max pain` и обязательной заметкой о том, что данные взяты с публичных страниц и могут быть с задержкой.
- Добавлены вспомогательные TypeScript-модули в `services/cmeScraper/`: `cmeCache.ts`, `cmeFuturesScraper.ts`, `cmeOptionsScraper.ts`, `cmeParser.ts` как заготовки/утилиты для возможного фронтенд/инструментального использования.

### Testing
- Запуск компиляции Python-файлов командой `python -m py_compile app/main.py app/services/cme_scraper.py` — успешно.
- При ошибке scraping предусмотрен мягкий fallback и кэширование (поведение заложено в коде и покрыто ручной проверкой логики обработки исключений).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5efeb8d008331a13ff110093b2ed9)