### PR TITLE
Интеграция optionsAnalysis в генерацию сигналов, идей и AI-сводку

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -269,6 +269,13 @@ async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = 
     if not chat_service.client:
         return base_response | {"ai_status": "fallback", "warning": "Grok временно недоступен"}
 
+    cme_context_for_ai = {
+        "available": cme_available,
+        "analysis": (cme_data.get("analysis") if isinstance(cme_data.get("analysis"), dict) else {}),
+        "futures": (cme_data.get("futures") if isinstance(cme_data.get("futures"), dict) else {}),
+        "disclaimer": cme_disclaimer,
+    }
+
     if use_fundamental:
         ai_prompt = (
             "Сформируй ОДНУ компактную статью на русском по MT4 OHLC и web search (если есть данные). "
@@ -278,7 +285,8 @@ async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = 
             "Верни строго JSON без markdown и лишнего текста. Сохрани существующие поля и заполни: "
             "summary_ru, htf_bias_ru, liquidity_ru, risk_ru, invalidation_ru, scenario_ru, journalistic_summary_ru, why_moves_ru, "
             "smart_money_ru, ict_ru, patterns_ru, harmonic_ru, wave_ru, divergence_ru, volume_ru, options_ru, forecast_ru, article_ru.\n\n"
-            f"MT4 context:\n{json.dumps(mt4_context, ensure_ascii=False)}"
+            f"MT4 context:\n{json.dumps(mt4_context, ensure_ascii=False)}\n\n"
+            f"CME optionsAnalysis context (используй только если available=true):\n{json.dumps(cme_context_for_ai, ensure_ascii=False)}"
         )
     else:
         ai_prompt = (
@@ -291,7 +299,8 @@ async def _build_mt4_chat_analytics_response(pair: str, use_fundamental: bool = 
             "Сохрани существующие поля и обязательно заполни поля:\n"
             "summary_ru, htf_bias_ru, liquidity_ru, risk_ru, invalidation_ru, scenario_ru,\n"
             "journalistic_summary_ru, why_moves_ru, smart_money_ru, ict_ru, patterns_ru, harmonic_ru, wave_ru, divergence_ru, volume_ru, options_ru, forecast_ru, article_ru.\n\n"
-            f"MT4 context:\n{json.dumps(mt4_context, ensure_ascii=False)}"
+            f"MT4 context:\n{json.dumps(mt4_context, ensure_ascii=False)}\n\n"
+            f"CME optionsAnalysis context (если available=false, явно напиши что опционный слой недоступен):\n{json.dumps(cme_context_for_ai, ensure_ascii=False)}"
         )
     try:
         primary_model = f"{chat_service.model}:online" if use_fundamental else chat_service.model

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -3743,6 +3743,21 @@ class TradeIdeaService:
     def _build_structured_analysis(*, signal: dict[str, Any], bias: str, rationale: str) -> dict[str, Any]:
         market_context = signal.get("market_context") if isinstance(signal.get("market_context"), dict) else {}
         proxy_label = "proxy" if signal.get("data_status") in {"unavailable", "delayed"} else "real"
+        options_snapshot = signal.get("options_analysis") if isinstance(signal.get("options_analysis"), dict) else {}
+        options_analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
+        options_available = bool(options_snapshot.get("available"))
+        options_text = str(signal.get("options_ru") or "").strip()
+        if not options_text:
+            if options_available:
+                pcr = options_analysis.get("putCallRatio")
+                strikes = options_analysis.get("keyStrikes") or []
+                max_pain = options_analysis.get("maxPain")
+                options_text = (
+                    f"CME options (реальные данные, возможна задержка): PCR={pcr}, key strikes={strikes}, max pain={max_pain}."
+                )
+            else:
+                options_text = "Опционный слой недоступен (реальные CME options не получены)."
+
         return {
             "smc": str(signal.get("smc_ru") or market_context.get("smcRu") or rationale),
             "ict": str(signal.get("ict_ru") or market_context.get("ictRu") or "ICT-контекст подтверждает приоритет работы от ликвидностной зоны."),
@@ -3763,6 +3778,12 @@ class TradeIdeaService:
             "divergence_ru": str(signal.get("divergence_ru") or ""),
             "cumdelta_ru": str(signal.get("cumdelta_ru") or signal.get("cumulative_delta_ru") or ""),
             "harmonic_ru": str(signal.get("harmonic_ru") or ""),
+            "options_ru": options_text,
+            "options_meta": {
+                "available": options_available,
+                "source": options_snapshot.get("source") if options_available else None,
+                "kind": "real_market_metric" if options_available else "unavailable_real_metric",
+            },
         }
 
     def _build_weighted_decision(self, *, signal: dict[str, Any], analysis: dict[str, Any], bias: str) -> dict[str, Any]:

--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -10,6 +10,7 @@ from backend.analysis.feature_builder import FeatureBuilder
 from backend.pattern_detector import PatternDetector
 from backend.risk_engine import RiskEngine
 from backend.sentiment_provider import build_sentiment_provider
+from app.services.cme_scraper import get_cme_market_snapshot
 from backend.signals import build_trade_levels, default_invalidation_text, has_minimum_confluence, infer_action
 
 SUPPORTED_TIMEFRAMES = ["M15", "M30", "H1", "H4", "D1", "W1"]
@@ -52,6 +53,7 @@ class SignalEngine:
                 required_timeframes = self._required_stack_timeframes(requested_timeframes)
                 for stack_timeframe in required_timeframes:
                     snapshots_cache[stack_timeframe] = await self._snapshot_for(symbol, stack_timeframe, snapshots_cache)
+                options_snapshot = await get_cme_market_snapshot(symbol)
                 for timeframe in requested_timeframes:
                     try:
                         stack = TIMEFRAME_STACKS[timeframe]
@@ -91,6 +93,7 @@ class SignalEngine:
                             mtf_features,
                             ltf_features,
                             sentiment.model_dump(mode="json"),
+                            options_snapshot,
                         )
                     except Exception as exc:
                         logger.exception(
@@ -164,8 +167,12 @@ class SignalEngine:
         mtf_features: dict,
         ltf_features: dict,
         sentiment: dict,
+        options_snapshot: dict | None,
     ) -> dict:
         analysis_contract = self._resolve_analysis_contract(htf=htf, mtf=mtf, ltf=ltf)
+        options_snapshot = options_snapshot if isinstance(options_snapshot, dict) else {}
+        options_analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
+        options_available = bool(options_snapshot.get("available"))
         data_quality = analysis_contract["data_quality"]
         analysis_mode = analysis_contract["analysis_mode"]
         is_fallback_mode = analysis_mode == "directional_fallback"
@@ -476,6 +483,7 @@ class SignalEngine:
             "confluence_flags": confluence_flags,
             "missing_confirmations": missing_confirmations,
             "invalidation_reasoning": invalidation_reasoning,
+            "options_analysis": options_snapshot,
             "market_context": {
                 "htf_trend": htf_features["trend"],
                 "mtf_trend": mtf_features["trend"],
@@ -512,6 +520,10 @@ class SignalEngine:
                 "invalidation_reasoning": invalidation_reasoning,
                 "fallback_used": is_fallback_mode,
                 "signal_threshold": signal_threshold,
+                "options_available": options_available,
+                "options_put_call_ratio": options_analysis.get("putCallRatio"),
+                "options_key_strikes": options_analysis.get("keyStrikes") or [],
+                "options_max_pain": options_analysis.get("maxPain"),
             },
             "pipeline_debug": {
                 "candles_count": len(mtf.get("candles", [])),


### PR DESCRIPTION
### Motivation
- Обеспечить единый опционный слой (CME `optionsAnalysis`) в pipeline для сигналов, генерации идей и AI-сводки чтобы модель и UI могли опираться на реальные опционные метрики при их доступности.

### Description
- Добавлена загрузка CME snapshot через `get_cme_market_snapshot` в `backend/signal_engine.py` и `options_snapshot` прокидывается в `_build_signal` и включается в итоговый сигнал как `options_analysis`.
- В `market_context` сигнала добавлены поля `options_available`, `options_put_call_ratio`, `options_key_strikes` и `options_max_pain` для явного экспорта ключевых метрик опционного анализа.
- В `app/services/trade_idea_service.py` расширен метод `_build_structured_analysis`: извлекается `signal.options_analysis`, строится человеко-читаемый `options_ru` при наличии реальных данных и добавляется `options_meta` с флагом доступности и типом метрики (`real_market_metric` / `unavailable_real_metric`).
- В `app/main.py` добавлен `cme_context_for_ai`, который включается в prompt LLM (в ветках с `use_fundamental` и без) чтобы AI summary мог использовать опционный контекст и явно указывать его недоступность.

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile app/main.py backend/signal_engine.py app/services/trade_idea_service.py` — успешно.
- Запущен `pytest -q tests/test_idea_update.py` — сборка тестов прервана из-за существующей синтаксической ошибки в `app/services/chart_snapshot_service.py` (`from **future** import annotations`), которая не связана с этим PR; тесты, зависящие от этого файла, не прошли по этой причине.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fa6190d48331937a4bf84b04adf1)