### PR TITLE
Исправление Ideas: фолбэки текста, очистка options и правки UI

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -2648,26 +2648,33 @@
 
     function pickText(idea) {
       return (
-        idea.idea_thesis ||
         idea.unified_narrative ||
+        idea.confluence_summary_ru ||
+        idea.reason_ru ||
+        idea.description_ru ||
+        idea.short_scenario_ru ||
+        idea.idea_thesis ||
         idea.full_text ||
         idea.fullText ||
         idea.summary_ru ||
         idea.summary ||
         idea.short_text ||
-        idea.description_ru ||
-        "Описание идеи отсутствует."
+        "Описание временно недоступно."
       );
     }
 
     function pickSubtitleText(idea) {
       const shortText = (
+        idea.unified_narrative ||
+        idea.confluence_summary_ru ||
+        idea.reason_ru ||
+        idea.description_ru ||
+        idea.short_scenario_ru ||
         idea.idea_thesis ||
         idea.summary_ru ||
         idea.summary ||
         idea.short_text ||
-        idea.description_ru ||
-        "Описание идеи отсутствует."
+        "Описание временно недоступно."
       );
       return trimToLength(shortText, 170);
     }
@@ -2676,20 +2683,23 @@
       const detailBrief = idea && typeof idea.detail_brief === "object" ? idea.detail_brief : null;
       return (
         idea.unified_narrative ||
+        idea.confluence_summary_ru ||
+        idea.reason_ru ||
+        idea.description_ru ||
+        idea.short_scenario_ru ||
         detailBrief?.summary_narrative ||
         idea.full_text ||
         idea.fullText ||
         idea.summary_ru ||
         idea.summary ||
         idea.short_text ||
-        idea.description_ru ||
-        "Описание идеи отсутствует."
+        "Описание временно недоступно."
       );
     }
 
     function trimToLength(text, maxLength = 170) {
       const normalized = String(text || "").replace(/\s+/g, " ").trim();
-      if (!normalized) return "Описание идеи отсутствует.";
+      if (!normalized) return "Описание временно недоступно.";
       if (normalized.length <= maxLength) return normalized;
       return `${normalized.slice(0, maxLength - 1).trim()}…`;
     }
@@ -2731,6 +2741,7 @@
       const targetReason = String(idea.take_profit_reason_ru || "").trim() || fallback;
       const liqModel = String(idea.liquidity_entry_model || "").trim() || "none";
       const invalidation = String(idea.invalidation_level_reason || idea.invalidation_reasoning || idea.invalidation_ru || "").trim() || fallback;
+      const executionSummary = String(idea.execution_summary_ru || "").trim() || `${entryReason} ${stopReason} ${targetReason}`;
 
       return `
         <div class="modal-section-title">Execution Model</div>
@@ -2741,6 +2752,7 @@
           <div><strong>Target logic:</strong> ${escapeHtml(targetReason)}</div>
           <div><strong>Liquidity model:</strong> ${escapeHtml(liqModel)}</div>
           <div><strong>Invalidation:</strong> ${escapeHtml(invalidation)}</div>
+          <div><strong>Execution summary:</strong> ${escapeHtml(executionSummary)}</div>
         </div>
       `;
     }

--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -13,7 +13,6 @@ from backend.risk_engine import RiskEngine
 from backend.sentiment_provider import build_sentiment_provider
 from app.services.cme_scraper import get_cme_market_snapshot
 from backend.signals import build_trade_levels, default_invalidation_text, has_minimum_confluence, infer_action
-from app.services.cme_scraper import get_cme_market_snapshot
 
 SUPPORTED_TIMEFRAMES = ["M15", "M30", "H1", "H4", "D1", "W1"]
 TIMEFRAME_STACKS = {
@@ -56,7 +55,6 @@ class SignalEngine:
             for symbol in pairs:
                 snapshots_cache: dict[str, dict] = {}
                 sentiment = self.sentiment_provider.get_snapshot(symbol)
-                options_snapshot = await get_cme_market_snapshot(symbol)
                 required_timeframes = self._required_stack_timeframes(requested_timeframes)
                 for stack_timeframe in required_timeframes:
                     snapshots_cache[stack_timeframe] = await self._snapshot_for(symbol, stack_timeframe, snapshots_cache)
@@ -144,11 +142,13 @@ class SignalEngine:
         options_analysis = signal.get("options_analysis") if isinstance(signal.get("options_analysis"), dict) else {}
 
         if not description_ru:
-            description_ru = confluence_summary_ru or reason_ru
+            description_ru = confluence_summary_ru or reason_ru or "Идея основана на структуре рынка, ликвидности и текущем импульсе."
 
         signal["description_ru"] = description_ru
         signal["reason_ru"] = reason_ru
         signal["confluence_summary_ru"] = confluence_summary_ru
+        signal["short_scenario_ru"] = str(signal.get("short_scenario_ru") or "").strip() or confluence_summary_ru or reason_ru
+        signal["unified_narrative"] = str(signal.get("unified_narrative") or "").strip() or description_ru
         signal["market_context"] = market_context
         signal["options_analysis"] = options_analysis
         if not str(market_context.get("confluence_summary_ru") or "").strip():
@@ -450,8 +450,8 @@ class SignalEngine:
         options_applied = self.applyOptionsImpact(
             signal={"action": action, "entry": price, "confidence_percent": confidence, "reason_ru": "", "warning": analysis_contract["warning"]},
             optionsAnalysis=self._resolve_options_analysis(options_snapshot),
+            apply_confidence=False,
         )
-        confidence = int(options_applied["confidence_percent"])
         signal_threshold = PROFESSIONAL_MIN_CONFIDENCE if analysis_mode == "professional" else FALLBACK_MIN_CONFIDENCE
 
         scenario_type = self._resolve_scenario_type(mtf_features)
@@ -584,7 +584,7 @@ class SignalEngine:
             "chart_patterns": mtf_patterns,
             "pattern_summary": mtf_pattern_summary,
             "pattern_signal_impact": pattern_impact,
-            "options_analysis": options_applied.get("options_analysis"),
+            "options_analysis": options_snapshot,
             "options_impact": options_applied.get("options_impact"),
             "options_summary_ru": options_applied.get("options_summary_ru"),
             "confluence_analysis": confluence_analysis,
@@ -599,7 +599,6 @@ class SignalEngine:
             "confluence_flags": confluence_flags,
             "missing_confirmations": missing_confirmations,
             "invalidation_reasoning": invalidation_reasoning,
-            "options_analysis": options_snapshot,
             "market_context": {
                 "htf_trend": htf_features["trend"],
                 "mtf_trend": mtf_features["trend"],
@@ -679,7 +678,7 @@ class SignalEngine:
         }
         return self._ensure_idea_text_fields(signal_payload)
 
-    def applyOptionsImpact(self, signal: dict, optionsAnalysis: dict) -> dict:
+    def applyOptionsImpact(self, signal: dict, optionsAnalysis: dict, apply_confidence: bool = True) -> dict:
         if not optionsAnalysis or optionsAnalysis.get("available") is False:
             signal["options_impact"] = 0
             signal["options_summary_ru"] = "Options data unavailable, analysis based on technicals and volume"
@@ -722,7 +721,8 @@ class SignalEngine:
             impact -= 6
             warnings.append("High probability of price pinning near strike")
         impact = max(-15, min(15, impact))
-        signal["confidence_percent"] = max(0, min(100, int(round(float(signal.get("confidence_percent") or 0) + impact))))
+        if apply_confidence:
+            signal["confidence_percent"] = max(0, min(100, int(round(float(signal.get("confidence_percent") or 0) + impact))))
         signal["options_impact"] = impact
         signal["options_warning"] = " | ".join(warnings) if warnings else None
         signal["options_analysis"] = optionsAnalysis

--- a/tests/api/test_ideas_api.py
+++ b/tests/api/test_ideas_api.py
@@ -548,3 +548,26 @@ def test_api_ideas_contract_keeps_market_price_null_when_unavailable(monkeypatch
     assert row["data_status"] == "unavailable"
     assert row["detail_brief"]["header"]["market_price"] == ""
     assert row["detail_brief"]["header"]["market_context"] == "Нет актуальных рыночных данных."
+
+
+def test_signal_engine_ensures_ideas_text_fields_are_present() -> None:
+    engine = SignalEngine()
+
+    idea = engine._ensure_idea_text_fields({"symbol": "EURUSD"})
+
+    assert idea["description_ru"]
+    assert idea["reason_ru"]
+    assert idea["confluence_summary_ru"]
+    assert idea["short_scenario_ru"]
+    assert idea["unified_narrative"]
+
+
+def test_ideas_frontend_fallback_chain_contains_text_fields() -> None:
+    content = Path("app/static/ideas.html").read_text(encoding="utf-8")
+
+    assert "idea.unified_narrative ||" in content
+    assert "idea.confluence_summary_ru ||" in content
+    assert "idea.reason_ru ||" in content
+    assert "idea.description_ru ||" in content
+    assert "idea.short_scenario_ru ||" in content
+    assert "Описание временно недоступно." in content


### PR DESCRIPTION
### Motivation
- Устранить баги в интеграции Ideas: пустые/непредсказуемые поля описания в UI и дублирование/двойное влияние options на `confidence` в пайплайне. 
- Сохранить совместимость API и улучшить связку backend → frontend без переработки архитектуры.

### Description
- Убраны дубли в `backend/signal_engine.py`: удалён повторный импорт `get_cme_market_snapshot` и лишний вызов `get_cme_market_snapshot(symbol)` (дергается один раз на символ). 
- Приведена в порядок обработка опционов: `options_analysis` теперь в итоговом payload хранит полный `options_snapshot`, а `options_impact` и `options_summary_ru` остаются отдельными полями и не перезаписывают `options_analysis`.
- Устранено двойное изменение `confidence`: функция `applyOptionsImpact` получила аргумент `apply_confidence` и в основном пайплайне вызывается с `apply_confidence=False`, чтобы options влияли на `confidence` только через `ConfluenceEngine`.
- Гарантированы текстовые поля идей в backend через `SignalEngine._ensure_idea_text_fields`: добавлены/fallback для `description_ru`, `reason_ru`, `confluence_summary_ru`, `short_scenario_ru` и `unified_narrative` (включая требуемый fallback текста). 
- Исправлен frontend рендер в `app/static/ideas.html`: приоритет отображения описания теперь `unified_narrative || confluence_summary_ru || reason_ru || description_ru || short_scenario_ru || ...` и финальный fallback изменён на `"Описание временно недоступно."`.
- В Expanded Ideas modal добавлен показ `execution_summary_ru` (сгенерированный fallback, если поле отсутствует). 
- Добавлены тесты в `tests/api/test_ideas_api.py` для проверки наличия обязательных полей и наличия новой fallback-цепочки в frontend-шаблоне.

### Testing
- Добавлены unit tests: проверка `SignalEngine._ensure_idea_text_fields` и проверка наличия fallback-цепочки в `app/static/ideas.html` (файлы закоммичены в `tests/api/test_ideas_api.py`).
- Запущен таргетный pytest (`pytest -q tests/api/test_ideas_api.py -k "ensures_ideas_text_fields or fallback_chain"`), который завершился ошибкой на этапе collection; причина — существующая проблема импорта в тестовой среде (`ImportError: cannot import name 'canonical_market_service' from 'app.main'`), не связанная с внесёнными изменениями.
- Изменения кода сохранены и скоммичены; добавленные тесты готовы к запуску в окружении, где сборка приложения/импорты устраняют текущую проблему коллекции тестов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f603f210588331be87eadaee7b4109)