### PR TITLE
Исправление lifecycle идей, сохранения уровней и fallback-описаний

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -43,6 +43,15 @@ IDEA_STATUS_ARCHIVED = "archived"
 ACTIVE_STATUSES = {IDEA_STATUS_CREATED, IDEA_STATUS_WAITING, IDEA_STATUS_TRIGGERED, IDEA_STATUS_ACTIVE}
 CLOSED_STATUSES = {IDEA_STATUS_TP_HIT, IDEA_STATUS_SL_HIT, IDEA_STATUS_ARCHIVED}
 TERMINAL_STATUSES = {IDEA_STATUS_TP_HIT, IDEA_STATUS_SL_HIT}
+ALLOWED_LIFECYCLE_TRANSITIONS = {
+    IDEA_STATUS_CREATED: {IDEA_STATUS_WAITING},
+    IDEA_STATUS_WAITING: {IDEA_STATUS_TRIGGERED},
+    IDEA_STATUS_TRIGGERED: {IDEA_STATUS_ACTIVE},
+    IDEA_STATUS_ACTIVE: {IDEA_STATUS_TP_HIT, IDEA_STATUS_SL_HIT},
+    IDEA_STATUS_TP_HIT: {IDEA_STATUS_ARCHIVED},
+    IDEA_STATUS_SL_HIT: {IDEA_STATUS_ARCHIVED},
+    IDEA_STATUS_ARCHIVED: set(),
+}
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 OPENROUTER_SYSTEM_PROMPT = "Ты профессиональный трейдинг-аналитик (Forex, SMC, liquidity).\n\nОтвечай ТОЛЬКО JSON массивом без текста."
 OPENROUTER_IDEA_SPECS = [
@@ -90,6 +99,11 @@ GENERIC_NARRATIVE_PHRASES = (
 class TradeIdeaService:
     MEANINGFUL_CONFIDENCE_DELTA = 5
 
+    DESCRIPTION_FALLBACK_TEXT = (
+        "Идея основана на структуре рынка, ликвидности и текущем импульсе. "
+        "Сценарий ожидает подтверждения или обновления рыночных данных."
+    )
+
     def __init__(self, signal_engine: SignalEngine, chart_data_service: ChartDataService | None = None) -> None:
         self.signal_engine = signal_engine
         self.data_provider = DataProvider()
@@ -108,6 +122,17 @@ class TradeIdeaService:
         self._grok_reasoning_cache: dict[str, dict[str, Any]] = {}
         self._refresh_lock = Lock()
         self._refresh_in_progress = False
+
+    @classmethod
+    def preserve_valid_levels(cls, existing_idea: dict[str, Any] | None, new_idea: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(existing_idea, dict):
+            return new_idea
+        for level_key in ("entry", "stop_loss", "take_profit"):
+            new_level = cls._extract_numeric(new_idea.get(level_key))
+            existing_level = cls._extract_numeric(existing_idea.get(level_key))
+            if (new_level is None or new_level == 0.0) and (existing_level is not None and existing_level != 0.0):
+                new_idea[level_key] = existing_level
+        return new_idea
 
     async def generate_or_refresh(self, pairs: list[str] | None = None, *, force: bool = False) -> dict[str, Any]:
         pairs = pairs or self.get_market_symbols()
@@ -1352,11 +1377,13 @@ class TradeIdeaService:
         signal_smart_money_context = signal.get("smart_money_context") if isinstance(signal.get("smart_money_context"), dict) else None
         created_at = existing.get("created_at") if existing else now.isoformat()
         version = int(existing.get("version", 1)) + 1 if existing else 1
+        signal = self.preserve_valid_levels(existing, signal)
         entry_value = self._extract_numeric(signal.get("entry"))
         stop_loss = self._extract_numeric(signal.get("stop_loss"))
         take_profit = self._extract_numeric(signal.get("take_profit"))
         idea_id = existing.get("idea_id") if existing else self._idea_id(symbol, timeframe, setup_type, created_at)
         status = self._status_from_signal(signal, existing=existing)
+        status, lifecycle_guard_note = self._apply_lifecycle_guard(existing=existing, next_status=status)
         latest_close = self._extract_latest_close(signal)
         rationale = signal.get("reason_ru") or signal.get("description_ru") or "Структурное подтверждение сценария ограничено."
         summary_text = signal.get("description_ru") or f"{symbol} {timeframe}: торговая идея обновлена."
@@ -1587,6 +1614,8 @@ class TradeIdeaService:
             close_explanation=close_explanation,
             signal=signal,
         )
+        if lifecycle_guard_note:
+            history = self._append_history_event(history, event_type="guarded_status", note=lifecycle_guard_note, at=now.isoformat())
         updates = self._history_to_updates(history)
         persisted_status = IDEA_STATUS_ARCHIVED if is_terminal else status
         existing_narrative_version = int(existing.get("narrative_version") or 1) if existing else 0
@@ -1673,6 +1702,9 @@ class TradeIdeaService:
             "headline": llm_result.data.get("headline") or f"{symbol} {timeframe}",
             "summary": llm_result.data.get("summary") or short_scenario,
             "summary_ru": short_scenario,
+            "description_ru": str(signal.get("description_ru") or "").strip(),
+            "reason_ru": str(signal.get("reason_ru") or rationale).strip(),
+            "confluence_summary_ru": str(signal.get("confluence_summary_ru") or "").strip(),
             "short_scenario_ru": short_scenario,
             "short_text": short_scenario,
             "full_text": full_text,
@@ -1776,6 +1808,13 @@ class TradeIdeaService:
             symbol=symbol,
             timeframe=timeframe,
         )
+        payload["description_ru"] = self._resolve_idea_description(payload)
+        if not str(payload.get("reason_ru") or "").strip():
+            payload["reason_ru"] = payload["description_ru"]
+        if not str(payload.get("confluence_summary_ru") or "").strip():
+            payload["confluence_summary_ru"] = payload["description_ru"]
+        if not str(payload.get("unified_narrative") or "").strip():
+            payload["unified_narrative"] = payload["description_ru"]
         return self._attach_trade_result_metrics(payload)
 
     @classmethod
@@ -3696,6 +3735,39 @@ class TradeIdeaService:
             return " ".join(parts), total_seconds
         except ValueError:
             return None, None
+
+    @classmethod
+    def _apply_lifecycle_guard(cls, *, existing: dict[str, Any] | None, next_status: str) -> tuple[str, str | None]:
+        if existing is None:
+            return next_status, None
+        current_status = str(existing.get("status") or "").lower()
+        candidate_status = str(next_status or "").lower()
+        if not current_status or current_status == candidate_status:
+            return candidate_status, None
+        if current_status == IDEA_STATUS_ARCHIVED:
+            return IDEA_STATUS_ARCHIVED, None
+        if candidate_status in ALLOWED_LIFECYCLE_TRANSITIONS.get(current_status, set()):
+            return candidate_status, None
+        if current_status in {IDEA_STATUS_ACTIVE, IDEA_STATUS_TRIGGERED} and candidate_status == IDEA_STATUS_WAITING:
+            return current_status, "Новый расчёт временно не подтвердил структуру, но активная идея сохраняется до TP/SL или invalidation."
+        return current_status, None
+
+    @classmethod
+    def _resolve_idea_description(cls, idea: dict[str, Any]) -> str:
+        for key in (
+            "unified_narrative",
+            "full_text",
+            "confluence_summary_ru",
+            "reason_ru",
+            "description_ru",
+            "short_scenario_ru",
+            "rationale",
+            "current_reasoning",
+        ):
+            value = str(idea.get(key) or "").strip()
+            if value:
+                return value
+        return cls.DESCRIPTION_FALLBACK_TEXT
 
     @staticmethod
     def _status_from_signal(signal: dict, existing: dict[str, Any] | None = None) -> str:

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -277,17 +277,23 @@ function renderIdeaCard(idea) {
 
 function resolveVisibleNarrative(idea) {
   const sanitize = (value) => String(value || "").replace(/\(\s*none\s*\)/gi, "").replace(/\bnone\b/gi, "").trim();
-  const thesis = sanitize(idea?.idea_thesis);
-  if (thesis) return thesis;
   const unified = sanitize(idea?.unified_narrative);
   if (unified) return unified;
   const fullText = sanitize(idea?.full_text);
   if (fullText) return fullText;
-  const fallbackNarrative = sanitize(idea?.fallback_narrative);
-  if (fallbackNarrative) return fallbackNarrative;
-  const summary = sanitize(idea?.summary || idea?.short_text);
-  if (summary) return summary;
-  return "Сценарий в режиме fallback: модельный нарратив временно недоступен.";
+  const confluence = sanitize(idea?.confluence_summary_ru);
+  if (confluence) return confluence;
+  const reason = sanitize(idea?.reason_ru);
+  if (reason) return reason;
+  const description = sanitize(idea?.description_ru);
+  if (description) return description;
+  const shortScenario = sanitize(idea?.short_scenario_ru);
+  if (shortScenario) return shortScenario;
+  const rationale = sanitize(idea?.rationale);
+  if (rationale) return rationale;
+  const currentReasoning = sanitize(idea?.current_reasoning);
+  if (currentReasoning) return currentReasoning;
+  return "Идея основана на структуре рынка, ликвидности и текущем импульсе. Сценарий ожидает подтверждения или обновления рыночных данных.";
 }
 
 function renderChartBlock(idea, chartImageUrl) {

--- a/tests/api/test_ideas_api.py
+++ b/tests/api/test_ideas_api.py
@@ -571,3 +571,12 @@ def test_ideas_frontend_fallback_chain_contains_text_fields() -> None:
     assert "idea.description_ru ||" in content
     assert "idea.short_scenario_ru ||" in content
     assert "Описание временно недоступно." in content
+
+
+def test_ideas_frontend_js_uses_extended_fallback_chain() -> None:
+    content = Path("app/static/ideas.js").read_text(encoding="utf-8")
+    assert "idea?.unified_narrative" in content
+    assert "idea?.full_text" in content
+    assert "idea?.confluence_summary_ru" in content
+    assert "idea?.reason_ru" in content
+    assert "idea?.description_ru" in content

--- a/tests/test_idea_update.py
+++ b/tests/test_idea_update.py
@@ -219,3 +219,32 @@ def test_build_narrative_facts_contains_smc_contract() -> None:
     assert facts["location"] == "discount"
     assert facts["target_liquidity"] == "1.12"
     assert "HL" in facts["invalidation_logic"]
+
+
+def test_lifecycle_guards_disallow_waiting_regressions() -> None:
+    assert TradeIdeaService._apply_lifecycle_guard(existing={"status": "active"}, next_status="waiting")[0] == "active"
+    assert TradeIdeaService._apply_lifecycle_guard(existing={"status": "triggered"}, next_status="waiting")[0] == "triggered"
+    assert TradeIdeaService._apply_lifecycle_guard(existing={"status": "archived"}, next_status="active")[0] == "archived"
+
+
+def test_preserve_valid_levels_keeps_existing_values() -> None:
+    existing = {"entry": 1.2, "stop_loss": 1.19, "take_profit": 1.22}
+    updated = TradeIdeaService.preserve_valid_levels(existing, {"entry": 0, "stop_loss": 0, "take_profit": None})
+    assert updated["entry"] == 1.2
+    assert updated["stop_loss"] == 1.19
+    assert updated["take_profit"] == 1.22
+
+
+def test_status_from_signal_buy_sell_tp_sl_conditions() -> None:
+    buy_existing = {"status": "active", "direction": "bullish"}
+    sell_existing = {"status": "active", "direction": "bearish"}
+
+    assert TradeIdeaService._status_from_signal({"entry": 1.1, "stop_loss": 1.09, "take_profit": 1.12, "latest_close": 1.1201}, existing=buy_existing) == "tp_hit"
+    assert TradeIdeaService._status_from_signal({"entry": 1.1, "stop_loss": 1.09, "take_profit": 1.12, "latest_close": 1.0899}, existing=buy_existing) == "sl_hit"
+    assert TradeIdeaService._status_from_signal({"entry": 1.1, "stop_loss": 1.11, "take_profit": 1.08, "latest_close": 1.0799}, existing=sell_existing) == "tp_hit"
+    assert TradeIdeaService._status_from_signal({"entry": 1.1, "stop_loss": 1.11, "take_profit": 1.08, "latest_close": 1.1101}, existing=sell_existing) == "sl_hit"
+
+
+def test_description_fallback_is_always_non_empty() -> None:
+    assert TradeIdeaService._resolve_idea_description({"reason_ru": "Причина"}) == "Причина"
+    assert TradeIdeaService._resolve_idea_description({}) != ""


### PR DESCRIPTION
### Motivation
- Исправить регрессии lifecycle: идеи, которые были в `ACTIVE`/`TRIGGERED`, возвращались в `WAITING`, что ломало согласованную логику обработки сигналов. 
- Предотвратить затирание валидных уровней `entry/stop_loss/take_profit` нулевыми/пустыми значениями от нового расчёта. 
- Гарантировать, что карточка идеи всегда содержит непустое текстовое описание и фронтенд не показывает «Описание идеи отсутствует». 

### Description
- Добавлена явная карта разрешённых переходов `ALLOWED_LIFECYCLE_TRANSITIONS` и реализация guard-а `_apply_lifecycle_guard(...)`, который предотвращает недопустимые регрессии статуса (например `ACTIVE/TRIGGERED → WAITING`) и при попытке деградации добавляет update-событие с объяснением; реализация находится в `app/services/trade_idea_service.py` и применяется при сборке идеи в `_build_idea`. 
- Реализована функция сохранения уровней `preserve_valid_levels` (в коде как `preserve_valid_levels`) и интегрирована перед вычислением уровней, чтобы новые `0`/`null` не перезаписывали ранее валидные `entry/stop_loss/take_profit` (в `app/services/trade_idea_service.py`). 
- Введён централизованный резолвер описания `_resolve_idea_description(...)` и усилены поля в итоговом payload: `description_ru`, `reason_ru`, `confluence_summary_ru`, `unified_narrative` заполняются по fallback-цепочке, чтобы API всегда возвращал непустой текст (реализовано в `app/services/trade_idea_service.py`). 
- Исправлен frontend fallback в `app/static/ideas.js`: `resolveVisibleNarrative` теперь проверяет `unified_narrative`, `full_text`, `confluence_summary_ru`, `reason_ru`, `description_ru`, `short_scenario_ru`, `rationale`, `current_reasoning` и только затем использует резервный текст, чтобы не показывать «Описание идеи отсутствует». 
- Добавлены unit-тесты: lifecycle-guard, сохранение уровней, TP/SL-условия для BUY/SELL, непустое описание и проверка JS fallback-chain (файлы: `tests/test_idea_update.py` и `tests/api/test_ideas_api.py`). 
- Изменённые файлы: `app/services/trade_idea_service.py`, `app/static/ideas.js`, `tests/test_idea_update.py`, `tests/api/test_ideas_api.py`.

### Testing
- Добавленные тесты были запущены локально частично с `pytest` (`tests/test_idea_update.py` и отдельные проверки из `tests/api/test_ideas_api.py`), но запуск завершился ошибками окружения не связанными с внесёнными изменениями; в результате автоматические прогоны упали из-за существующей синтаксической/импортной ошибки в другом модуле (`app/services/chart_snapshot_service.py`) и одного импорта в `app/main.py`. 
- Команды использованные для проверки: `pytest -q tests/test_idea_update.py` и целевые тесты через `pytest -q tests/test_idea_update.py tests/api/test_ideas_api.py::test_ideas_frontend_js_uses_extended_fallback_chain tests/api/test_ideas_api.py::test_ideas_frontend_fallback_chain_contains_text_fields`. 
- Итог: логика lifecycle-guard и сохранения уровней покрыта тестами, но в этом окружении запуск всех тестов завершился с ошибкой окружения (не затронутой этим PR); добавленные тесты компилируются и местные проверки выполнялись до обнаружения внешних import/syntax ошибок. 

Если нужно, могу отдельно подготовить короткую инструкцию «как проверить на сайте»: открыть страницу Ideas (UI) и убедиться, что в карточках отображается текст из `unified_narrative || full_text || confluence_summary_ru || reason_ru || description_ru ...` и что активная идея не откатывается в ожидание при приходе нового WAIT-сигнала (проверяется через инспектор сетевых ответов `/ideas/market` для конкретного `symbol`+`timeframe`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f608a6c84c833187e445116c889441)