### PR TITLE
Гарантировать непустое `description_ru` в SignalEngine

### DIFF
--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -141,8 +141,55 @@ class SignalEngine:
         market_context = signal.get("market_context") if isinstance(signal.get("market_context"), dict) else {}
         options_analysis = signal.get("options_analysis") if isinstance(signal.get("options_analysis"), dict) else {}
 
+        action = str(signal.get("action") or "WAIT").upper().strip()
+        symbol = str(signal.get("symbol") or "инструмент").strip()
+        confluence_flags = signal.get("confluence_flags") if isinstance(signal.get("confluence_flags"), dict) else {}
+        trend = str(market_context.get("mtf_trend") or market_context.get("htf_trend") or "unknown")
+        bos = str(confluence_flags.get("bos") if confluence_flags.get("bos") is not None else market_context.get("bos") or "unknown")
+        liquidity_sweep = str(
+            confluence_flags.get("liquidity_sweep")
+            if confluence_flags.get("liquidity_sweep") is not None
+            else market_context.get("liquidity_sweep")
+            if market_context.get("liquidity_sweep") is not None
+            else "unknown"
+        )
+        order_block = str(
+            confluence_flags.get("order_block")
+            if confluence_flags.get("order_block") is not None
+            else market_context.get("order_block")
+            if market_context.get("order_block") is not None
+            else "unknown"
+        )
+        fvg = str(
+            confluence_flags.get("fvg")
+            if confluence_flags.get("fvg") is not None
+            else market_context.get("fvg")
+            if market_context.get("fvg") is not None
+            else "unknown"
+        )
+
+        if confluence_summary_ru:
+            description_ru = f"""
+{action} {symbol}
+
+Причины:
+- тренд: {trend}
+- BOS: {bos}
+- ликвидность: {liquidity_sweep}
+- order block: {order_block}
+- FVG: {fvg}
+
+{confluence_summary_ru}
+""".strip()
+
         if not description_ru:
-            description_ru = confluence_summary_ru or reason_ru or "Идея основана на структуре рынка, ликвидности и текущем импульсе."
+            description_ru = confluence_summary_ru
+
+        if not description_ru:
+            description_ru = reason_ru
+
+        if not description_ru:
+            description_ru = f"Сигнал {action} по {symbol} сформирован на основе структуры рынка, ликвидности и текущего импульса."
 
         signal["description_ru"] = description_ru
         signal["reason_ru"] = reason_ru


### PR DESCRIPTION
### Motivation
- Исправить проблему, когда идеи возвращают пустое `description_ru`, и фронтенд показывает «Описание идеи отсутствует». 
- Обеспечить стабильный и информативный текст идеи даже при частично пустых входных полях confluence/reason.

### Description
- Усилен метод `_ensure_idea_text_fields` в `backend/signal_engine.py` для гарантированной цепочки fallback заполнения `description_ru`: сначала формируется подробный текст из `confluence_summary_ru`, затем используется `reason_ru`, и в крайнем случае ставится шаблонный текст с `action` и `symbol`.
- При наличии `confluence_summary_ru` теперь формируется расширенное описание с заголовком `{action} {symbol}` и блоком «Причины» (trend / BOS / liquidity / order block / FVG), после которого добавляется сам `confluence_summary_ru`.
- Сохранена совместимость API: поля `description_ru`, `reason_ru` и `confluence_summary_ru` явно заполняются и возвращаются в payload, а `short_scenario_ru` и `unified_narrative` по-прежнему наследуют значения от `confluence_summary_ru`/`reason_ru`/`description_ru`.
- Не изменялись маршруты API и контракты ответа, изменения ограничены пост-обработкой текста в `signal_engine`.

### Testing
- Запущена проверка синтаксиса: `python -m py_compile backend/signal_engine.py`, результат: успешно.
- Файл сохранён в репозитории и зафиксирован (локальный коммит), сборочных/юнит-тестов дополнительно не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f608da44ac8331a358f8f647e252a1)