### PR TITLE
Добавить поддержку MT4 объёмного и кластерного анализа (mt4_volume_cluster_bridge)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.services.htf_context_filter import HtfContextFilter
 from app.services.cme_scraper import get_cme_market_snapshot
 from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
+from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from backend.chat_service import ChatRequest, ForexChatService
 
 
@@ -908,6 +909,22 @@ async def api_mt4_push_candles(request: Request):
     except Exception as exc:
         return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
 
+
+
+
+@app.post("/api/mt4/volume-clusters")
+async def api_mt4_volume_clusters(request: Request):
+    try:
+        payload = await request.json()
+        token = str(payload.get("token") or "").strip()
+        if MT4_BRIDGE_TOKEN and token != MT4_BRIDGE_TOKEN:
+            return JSONResponse(status_code=401, content={"ok": False, "error": "unauthorized"})
+        if not isinstance(payload, dict):
+            return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_payload"})
+        saved = save_volume_cluster_payload(payload)
+        return {"ok": True, "symbol": saved.get("symbol"), "timeframe": saved.get("timeframe"), "updated_at_utc": now_utc()}
+    except Exception as exc:
+        return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
 
 @app.get("/api/mt4/markup/{symbol}")
 def api_mt4_markup(symbol: str, tf: str = "M15"):

--- a/app/services/mt4_volume_cluster_bridge.py
+++ b/app/services/mt4_volume_cluster_bridge.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+MT4_VOLUME_CLUSTER_TTL_SECONDS = int(os.getenv("MT4_VOLUME_CLUSTER_TTL_SECONDS", "1800"))
+_STORE: dict[str, dict[str, Any]] = {}
+
+
+def normalize_broker_symbol(symbol: str) -> str:
+    return str(symbol or "").upper().replace("/", "").replace(".", "").strip()
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc)
+    try:
+        raw = str(value).strip().replace("Z", "+00:00")
+        return datetime.fromisoformat(raw).astimezone(timezone.utc)
+    except Exception:
+        return None
+
+
+def is_stale(timestamp: Any) -> bool:
+    parsed = _parse_timestamp(timestamp)
+    if parsed is None:
+        return True
+    return (datetime.now(timezone.utc) - parsed).total_seconds() > MT4_VOLUME_CLUSTER_TTL_SECONDS
+
+
+def save_volume_cluster_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    symbol = normalize_broker_symbol(payload.get("symbol") or payload.get("broker_symbol"))
+    timeframe = str(payload.get("timeframe") or "H1").upper().strip()
+    record = dict(payload)
+    record["symbol"] = symbol
+    record["timeframe"] = timeframe
+    record["received_at"] = datetime.now(timezone.utc).isoformat()
+    _STORE[f"{symbol}:{timeframe}"] = record
+    _STORE[symbol] = record
+    return record
+
+
+def get_latest_volume_cluster(symbol: str, timeframe: str | None = None) -> dict[str, Any] | None:
+    normalized = normalize_broker_symbol(symbol)
+    key = f"{normalized}:{str(timeframe or '').upper().strip()}" if timeframe else normalized
+    payload = _STORE.get(key)
+    if payload is None and timeframe:
+        payload = _STORE.get(normalized)
+    if not isinstance(payload, dict):
+        return None
+    if is_stale(payload.get("timestamp") or payload.get("received_at")):
+        return None
+    return payload

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -3936,6 +3936,8 @@ class TradeIdeaService:
         proxy_label = "proxy" if signal.get("data_status") in {"unavailable", "delayed"} else "real"
         options_snapshot = signal.get("options_analysis") if isinstance(signal.get("options_analysis"), dict) else {}
         options_analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
+        confluence_analysis = signal.get("confluence_analysis") if isinstance(signal.get("confluence_analysis"), dict) else {}
+        volume_cluster_analysis = confluence_analysis.get("volume_cluster_analysis") if isinstance(confluence_analysis.get("volume_cluster_analysis"), dict) else {}
         options_available = bool(options_snapshot.get("available"))
         options_text = str(signal.get("options_ru") or "").strip()
         if not options_text:
@@ -4369,6 +4371,8 @@ class TradeIdeaService:
         existing_m15_bias = str(existing.get("m15_bias_summary") or "") if isinstance(existing, dict) else ""
         options_snapshot = signal.get("options_analysis") if isinstance(signal.get("options_analysis"), dict) else {}
         options_analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
+        confluence_analysis = signal.get("confluence_analysis") if isinstance(signal.get("confluence_analysis"), dict) else {}
+        volume_cluster_analysis = confluence_analysis.get("volume_cluster_analysis") if isinstance(confluence_analysis.get("volume_cluster_analysis"), dict) else {}
         return {
             "symbol": symbol,
             "timeframe": timeframe,
@@ -4404,6 +4408,16 @@ class TradeIdeaService:
             "divergence_facts": signal.get("divergence_ru"),
             "fundamental_facts": signal.get("fundamental_ru"),
             "confluence_analysis": signal.get("confluence_analysis"),
+            "volume_cluster_analysis": volume_cluster_analysis,
+            "volume_profile": volume_cluster_analysis.get("volume_profile") if isinstance(volume_cluster_analysis, dict) else {},
+            "delta": volume_cluster_analysis.get("delta") if isinstance(volume_cluster_analysis, dict) else {},
+            "clusters": volume_cluster_analysis.get("clusters") if isinstance(volume_cluster_analysis, dict) else [],
+            "absorption": volume_cluster_analysis.get("absorption") if isinstance(volume_cluster_analysis, dict) else {},
+            "imbalance": volume_cluster_analysis.get("imbalance") if isinstance(volume_cluster_analysis, dict) else [],
+            "poc": volume_cluster_analysis.get("poc") if isinstance(volume_cluster_analysis, dict) else None,
+            "vah": volume_cluster_analysis.get("vah") if isinstance(volume_cluster_analysis, dict) else None,
+            "val": volume_cluster_analysis.get("val") if isinstance(volume_cluster_analysis, dict) else None,
+            "divergence": (volume_cluster_analysis.get("delta") or {}).get("divergence") if isinstance(volume_cluster_analysis, dict) else None,
             "confluence_breakdown": signal.get("confluence_breakdown"),
             "confluence_warnings": signal.get("confluence_warnings"),
             "confluence_confirmations": signal.get("confluence_confirmations"),

--- a/backend/analysis/confluence_engine.py
+++ b/backend/analysis/confluence_engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.analysis.volume_cluster_adapter import build_volume_cluster_analysis
+
 
 class ConfluenceEngine:
     def evaluate(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -14,7 +16,7 @@ class ConfluenceEngine:
         sentiment = payload.get("sentiment") or {}
         risk = payload.get("risk") or {}
 
-        breakdown = {"smc": 0, "liquidity": 0, "options": 0, "volume": 0, "sentiment": 0, "risk": 0}
+        breakdown = {"smc": 0, "liquidity": 0, "options": 0, "volume": 0, "volume_cluster": 0, "sentiment": 0, "risk": 0}
         warnings: list[str] = []
         confirmations: list[str] = []
 
@@ -94,6 +96,18 @@ class ConfluenceEngine:
             if oi > 0:
                 breakdown["volume"] += 2
 
+        
+        vc = build_volume_cluster_analysis(
+            symbol=str(payload.get("symbol") or ""),
+            timeframe=str(payload.get("timeframe") or "H1"),
+            action=action,
+            entry=price,
+            price=price,
+        )
+        breakdown["volume_cluster"] = int(vc.get("scoreImpact") or 0)
+        if not vc.get("available"):
+            warnings.append("MT4 volume cluster data is not available")
+
         alignment = str((sentiment.get("alignment") or sentiment.get("signal_alignment") or "neutral")).lower()
         if (action == "BUY" and alignment in {"bullish", "buy"}) or (action == "SELL" and alignment in {"bearish", "sell"}):
             breakdown["sentiment"] += 5
@@ -137,6 +151,7 @@ class ConfluenceEngine:
             "warnings": warnings,
             "confirmations": confirmations,
             "summary_ru": summary_ru,
+            "volume_cluster_analysis": vc,
         }
 
     def _in_zone(self, price: float, zone: dict[str, Any]) -> bool:

--- a/backend/analysis/volume_cluster_adapter.py
+++ b/backend/analysis/volume_cluster_adapter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.mt4_volume_cluster_bridge import get_latest_volume_cluster
+
+
+def build_volume_cluster_analysis(symbol: str, timeframe: str, action: str, entry: float | None, price: float | None) -> dict[str, Any]:
+    payload = get_latest_volume_cluster(symbol, timeframe)
+    if not payload:
+        return {"available": False, "reason": "MT4 volume cluster data is not available", "scoreImpact": 0}
+
+    vp = payload.get("volume_profile") if isinstance(payload.get("volume_profile"), dict) else {}
+    delta = payload.get("delta") if isinstance(payload.get("delta"), dict) else {}
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    clusters = payload.get("clusters") if isinstance(payload.get("clusters"), list) else []
+    current = float(price or payload.get("underlying_price") or 0.0)
+    score = _score(action, entry or current, current, vp, delta, summary)
+
+    return {
+        "available": True,
+        "source": payload.get("source") or "mt4_optionlevels_volume",
+        "poc": vp.get("poc"),
+        "vah": vp.get("vah"),
+        "val": vp.get("val"),
+        "high_volume_nodes": vp.get("high_volume_nodes") or [],
+        "low_volume_nodes": vp.get("low_volume_nodes") or [],
+        "delta": delta,
+        "clusters": clusters,
+        "signals": {
+            "volume_confirmation": "confirmed" if abs(score) >= 6 else "weak",
+            "delta_confirmation": "divergence" if str(delta.get("divergence") or "none") not in {"none", "unknown"} else "confirmed",
+            "absorption": str(summary.get("absorption_side") or "none") if summary.get("absorption_detected") else "none",
+            "cluster_bias": "bullish" if score > 2 else "bearish" if score < -2 else "neutral",
+        },
+        "scoreImpact": score,
+        "summary_ru": f"Кластерный слой: scoreImpact {score}, POC={vp.get('poc')}, divergence={delta.get('divergence')}.",
+        "volume_profile": vp,
+        "absorption": {"detected": bool(summary.get("absorption_detected")), "side": summary.get("absorption_side"), "price": summary.get("absorption_price")},
+        "imbalance": [c for c in clusters if isinstance(c, dict) and c.get("type") == "imbalance"],
+    }
+
+
+def _score(action: str, entry: float, price: float, vp: dict[str, Any], delta: dict[str, Any], summary: dict[str, Any]) -> int:
+    score = 0
+    a = str(action or "WAIT").upper()
+    div = str(delta.get("divergence") or "unknown")
+    trend = str(delta.get("delta_trend") or "unknown")
+    if a == "BUY":
+        if trend == "rising": score += 6
+        if summary.get("aggressive_buying") is True: score += 5
+        if str(summary.get("absorption_side") or "") == "buy": score += 5
+        if isinstance(vp.get("poc"), (int,float)) and price > float(vp["poc"]): score += 4
+        if div == "bearish": score -= 6
+        if str(summary.get("absorption_side") or "") == "sell": score -= 5
+        if summary.get("aggressive_selling") is True: score -= 4
+    elif a == "SELL":
+        if trend == "falling": score += 6
+        if summary.get("aggressive_selling") is True: score += 5
+        if str(summary.get("absorption_side") or "") == "sell": score += 5
+        if isinstance(vp.get("poc"), (int,float)) and price < float(vp["poc"]): score += 4
+        if div == "bullish": score -= 6
+        if str(summary.get("absorption_side") or "") == "buy": score -= 5
+        if summary.get("aggressive_buying") is True: score -= 4
+    return max(-15, min(15, score))

--- a/tests/test_mt4_volume_cluster.py
+++ b/tests/test_mt4_volume_cluster.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timezone
+from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload, get_latest_volume_cluster
+from backend.analysis.confluence_engine import ConfluenceEngine
+
+
+def _payload(**kw):
+    base = {
+        "source": "mt4_optionlevels_volume",
+        "symbol": "EURUSD",
+        "timeframe": "H1",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "underlying_price": 1.17208,
+        "volume_profile": {"poc": 1.1720, "vah": 1.1760, "val": 1.1680, "high_volume_nodes": [1.1720], "low_volume_nodes": [1.1690]},
+        "delta": {"cumulative_delta": -8400, "delta_trend": "falling", "divergence": "none"},
+        "clusters": [],
+        "summary": {"aggressive_buying": False, "aggressive_selling": True, "absorption_detected": True, "absorption_side": "sell", "absorption_price": 1.1745},
+    }
+    base.update(kw)
+    return base
+
+
+def test_valid_volume_cluster_payload_save():
+    save_volume_cluster_payload(_payload())
+    got = get_latest_volume_cluster("EURUSD", "H1")
+    assert got and got["source"] == "mt4_optionlevels_volume"
+
+
+def test_stale_data_no_confidence_boost():
+    save_volume_cluster_payload(_payload(timestamp="2020-01-01T00:00:00Z"))
+    res = ConfluenceEngine().evaluate({"action": "BUY", "price": 1.17, "symbol": "EURUSD", "timeframe": "H1"})
+    assert res["breakdown"]["volume_cluster"] == 0
+
+
+def test_sell_bearish_delta_boosts_confidence():
+    save_volume_cluster_payload(_payload(delta={"delta_trend": "falling", "divergence": "none"}))
+    res = ConfluenceEngine().evaluate({"action": "SELL", "price": 1.171, "symbol": "EURUSD", "timeframe": "H1"})
+    assert res["breakdown"]["volume_cluster"] > 0
+
+
+def test_divergence_reduces_confidence():
+    save_volume_cluster_payload(_payload(delta={"delta_trend": "falling", "divergence": "none"}))
+    base = ConfluenceEngine().evaluate({"action": "SELL", "price": 1.171, "symbol": "EURUSD", "timeframe": "H1"})
+    save_volume_cluster_payload(_payload(delta={"delta_trend": "falling", "divergence": "bullish"}))
+    div = ConfluenceEngine().evaluate({"action": "SELL", "price": 1.171, "symbol": "EURUSD", "timeframe": "H1"})
+    assert div["breakdown"]["volume_cluster"] < base["breakdown"]["volume_cluster"]
+


### PR DESCRIPTION
### Motivation
- Принять и учитывать объёмно-кластерные данные из MT4/OptionLevels bridge для улучшения confluence, идей и narrative, при этом не ломая текущий MT4 candle bridge и options bridge.
- Обеспечить отдельный слой хранения с TTL и безопасный fallback, чтобы отсутствие данных не вызывало ошибок и не приводило к выдумыванию объёмов.

### Description
- Добавлен endpoint `POST /api/mt4/volume-clusters` для приёма payload от MT4/OptionLevels и авторизацией через `MT4_BRIDGE_TOKEN` в `app/main.py`.
- Новый сервис хранения `app/services/mt4_volume_cluster_bridge.py` с функциями `save_volume_cluster_payload`, `get_latest_volume_cluster`, `normalize_broker_symbol` и `is_stale`, и TTL `MT4_VOLUME_CLUSTER_TTL_SECONDS` (по умолчанию `1800`).
- Добавлен адаптер анализа `backend/analysis/volume_cluster_adapter.py`, возвращающий унифицированный контракт (poc/vah/val, delta, clusters, signals, `scoreImpact`) и реализующий scoring по правилам (BUY/SELL) с ограничением `scoreImpact` в диапазоне `[-15, +15]`.
- Интегрировано в `ConfluenceEngine` (`backend/analysis/confluence_engine.py`): добавлен breakdown-пункт `volume_cluster`, учтён `scoreImpact` в расчёте total_score/confidence_delta и добавлена `volume_cluster_analysis` в возвращаемый payload с предупреждением при отсутствии данных.
- Проброшены поля в narrative facts в `app/services/trade_idea_service.py`: `volume_cluster_analysis`, `volume_profile`, `delta`, `clusters`, `absorption`, `imbalance`, `poc/vah/val`, `divergence` с безопасными дефолтами.
- Добавлены unit-тесты `tests/test_mt4_volume_cluster.py`, покрывающие сохранение payload, поведение для устаревших данных, влияние bearish/bullish delta и divergence на вклад в confidence.

### Testing
- Запущено `pytest -q tests/test_mt4_volume_cluster.py`, все тесты прошли (`4 passed`).
- При отсутствии свежих данных адаптер возвращает `{"available": false, "reason": "MT4 volume cluster data is not available"}` без ошибок, что проверено тестами.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6472ecdbc83319fa5ef22607c7e81)