### PR TITLE
Добавлена поддержка MT4 OptionsFX bridge (endpoints, storage, интеграция)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.services.cme_scraper import get_cme_market_snapshot
 from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
+from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
 from backend.chat_service import ChatRequest, ForexChatService
 
 
@@ -925,6 +926,35 @@ async def api_mt4_volume_clusters(request: Request):
         return {"ok": True, "symbol": saved.get("symbol"), "timeframe": saved.get("timeframe"), "updated_at_utc": now_utc()}
     except Exception as exc:
         return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
+
+
+@app.post("/api/mt4/options-levels")
+async def api_mt4_options_levels(request: Request):
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"status": "error", "error": "invalid_json"})
+    if not isinstance(payload, dict):
+        return JSONResponse(status_code=400, content={"status": "error", "error": "invalid_payload"})
+    symbol = str(payload.get("symbol") or "").strip()
+    levels = payload.get("levels")
+    if not symbol:
+        return JSONResponse(status_code=400, content={"status": "error", "error": "symbol_required"})
+    if levels is None or not isinstance(levels, list):
+        return JSONResponse(status_code=400, content={"status": "error", "error": "levels_required"})
+    saved = save_options_levels(payload)
+    return {"status": "ok", "symbol": saved.get("symbol"), "levels_received": len(saved.get("levels") or [])}
+
+
+@app.get("/api/mt4/options-levels/{symbol}")
+def api_mt4_options_levels_symbol(symbol: str):
+    payload = get_latest_options_levels(symbol)
+    if not payload.get("available"):
+        response = {"available": False, "reason": payload.get("reason") or "No MT4 option levels received"}
+        if payload.get("stale"):
+            response["stale"] = True
+        return response
+    return payload
 
 @app.get("/api/mt4/markup/{symbol}")
 def api_mt4_markup(symbol: str, tf: str = "M15"):

--- a/app/services/cme_scraper.py
+++ b/app/services/cme_scraper.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
+from app.services.mt4_options_bridge import get_latest_options_levels
 
 PAIR_MAPPING: dict[str, dict[str, str]] = {
     "EURUSD": {"slug": "euro-fx", "code": "6E"},
@@ -116,8 +117,24 @@ def _analyze_options(options: dict[str, list[Any]]) -> dict[str, Any]:
 
 async def get_cme_market_snapshot(pair: str) -> dict[str, Any]:
     normalized = (pair or "").upper().strip()
+    mt4_snapshot = get_latest_options_levels(normalized)
+    mt4_analysis = mt4_snapshot.get("analysis") if isinstance(mt4_snapshot.get("analysis"), dict) else {}
+    if mt4_snapshot.get("available") and mt4_analysis.get("available"):
+        return {
+            "available": True,
+            "source": "mt4_optionsfx",
+            "source_priority": 1,
+            "symbol": normalized,
+            "analysis": mt4_analysis,
+            "options": {"levels": mt4_snapshot.get("levels") or []},
+            "last_updated": mt4_analysis.get("last_updated"),
+            "stale": bool(mt4_analysis.get("stale")),
+        }
+
     mapping = PAIR_MAPPING.get(normalized)
     if not mapping:
+        if mt4_snapshot.get("stale"):
+            return {"available": False, "reason": "No MT4 option levels received", "stale": True, "source": "mt4_optionsfx"}
         return {"available": False, "reason": "CME scraping failed"}
 
     cache_key = f"cme:{normalized}"
@@ -152,6 +169,7 @@ async def get_cme_market_snapshot(pair: str) -> dict[str, Any]:
         payload = {
             "available": True,
             "source": "cme_scraping",
+            "source_priority": 2,
             "symbol": mapping["code"],
             "futures": {
                 "volume": int(volume),
@@ -170,6 +188,6 @@ async def get_cme_market_snapshot(pair: str) -> dict[str, Any]:
         _CACHE.set(cache_key, payload)
         return payload
     except Exception:
-        fallback = {"available": False, "reason": "CME scraping failed"}
+        fallback = {"available": False, "reason": "CME scraping failed", "source_priority": 2}
         _CACHE.set(cache_key, fallback)
         return fallback

--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+MT4_OPTIONS_LEVELS_TTL_SECONDS = int(os.getenv("MT4_OPTIONS_LEVELS_TTL_SECONDS", "21600"))
+_OPTIONS_STORE: dict[str, dict[str, Any]] = {}
+
+
+def normalize_symbol(symbol: str) -> str:
+    return str(symbol or "").upper().strip().replace("/", "")
+
+
+def is_stale(timestamp: datetime | str | None) -> bool:
+    if isinstance(timestamp, str):
+        try:
+            timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            return True
+    if not isinstance(timestamp, datetime):
+        return True
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    ttl = timedelta(seconds=MT4_OPTIONS_LEVELS_TTL_SECONDS)
+    return (datetime.now(timezone.utc) - timestamp) > ttl
+
+
+def save_options_levels(payload: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {"available": False, "reason": "Invalid payload"}
+
+    symbol = normalize_symbol(payload.get("symbol"))
+    raw_levels = payload.get("levels")
+    levels = raw_levels if isinstance(raw_levels, list) else []
+
+    source_timestamp = payload.get("timestamp")
+    if isinstance(source_timestamp, str):
+        try:
+            source_timestamp = datetime.fromisoformat(source_timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            source_timestamp = None
+    if isinstance(source_timestamp, datetime) and source_timestamp.tzinfo is None:
+        source_timestamp = source_timestamp.replace(tzinfo=timezone.utc)
+
+    now = datetime.now(timezone.utc)
+    entry = {
+        "symbol": symbol,
+        "timestamp": (source_timestamp or now).isoformat(),
+        "received_at": now.isoformat(),
+        "underlying_price": payload.get("underlying_price"),
+        "levels": levels,
+        "summary": payload.get("summary"),
+        "metadata": payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
+        "source": payload.get("source") or "mt4_optionsfx",
+    }
+    if symbol:
+        _OPTIONS_STORE[symbol] = entry
+    logger.info("MT4 options levels received symbol=%s count=%s", symbol, len(levels))
+    return entry
+
+
+def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
+    levels = entry.get("levels") if isinstance(entry.get("levels"), list) else []
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for item in levels:
+        if not isinstance(item, dict):
+            continue
+        level_type = str(item.get("type") or "").lower().strip()
+        if not level_type:
+            continue
+        by_type.setdefault(level_type, []).append(item)
+
+    def prices(level_type: str) -> list[float]:
+        out: list[float] = []
+        for row in by_type.get(level_type, []):
+            try:
+                out.append(float(row.get("price")))
+            except (TypeError, ValueError):
+                continue
+        return out
+
+    support = prices("support") + prices("put")
+    resistance = prices("resistance") + prices("call")
+    max_pain = (prices("max_pain") or [None])[0]
+    targets = prices("target_volume")
+    hedges = prices("hedge_volume")
+    key_levels = sorted(set(support + resistance + prices("balance") + prices("gamma_level") + targets + hedges))
+    underlying = entry.get("underlying_price")
+    try:
+        price = float(underlying)
+    except (TypeError, ValueError):
+        price = None
+    bias = "neutral"
+    if price is not None:
+        below_support = any(level < price for level in support)
+        above_resistance = any(level > price for level in resistance)
+        target_above = any(level > price for level in targets)
+        hedge_above = any(level > price for level in hedges)
+        if (below_support or target_above) and not (above_resistance or hedge_above):
+            bias = "bullish"
+        elif (above_resistance or hedge_above) and not (below_support or target_above):
+            bias = "bearish"
+
+    summary_ru = "Опционные уровни MT4 получены, явного смещения не выявлено."
+    if bias == "bullish":
+        summary_ru = "Опционные уровни MT4 поддерживают сценарий BUY: поддержка/put ниже цены и цели выше."
+    elif bias == "bearish":
+        summary_ru = "Опционные уровни MT4 поддерживают сценарий SELL: сопротивление/call выше цены и защитные уровни давят сверху."
+
+    return {
+        "available": bool(levels),
+        "source": "mt4_optionsfx",
+        "source_priority": 1,
+        "keyLevels": key_levels,
+        "keyStrikes": key_levels,
+        "maxPain": max_pain,
+        "barrierZones": {"support": support, "resistance": resistance},
+        "bias": bias,
+        "summary_ru": summary_ru,
+        "targetLevels": targets,
+        "hedgeLevels": hedges,
+        "stale": False,
+        "last_updated": entry.get("received_at"),
+    }
+
+
+def get_latest_options_levels(symbol: str) -> dict[str, Any]:
+    normalized = normalize_symbol(symbol)
+    entry = _OPTIONS_STORE.get(normalized)
+    if not entry:
+        return {"available": False, "reason": "No MT4 option levels received"}
+    stale = is_stale(entry.get("timestamp"))
+    analysis = _build_analysis(entry)
+    analysis["stale"] = stale
+    analysis["last_updated"] = entry.get("received_at")
+    if stale:
+        analysis["available"] = False
+        analysis["reason"] = "No MT4 option levels received"
+    return {**entry, "analysis": analysis, "available": analysis["available"], "stale": stale, "source": "mt4_optionsfx"}

--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -705,25 +705,36 @@ class SignalEngine:
         analysis = (options_snapshot or {}).get("analysis") if isinstance(options_snapshot, dict) else {}
         if not isinstance(analysis, dict) or not options_snapshot or not options_snapshot.get("available"):
             return {"available": False}
+        if analysis.get("stale"):
+            return {"available": False, "stale": True, "source": analysis.get("source") or options_snapshot.get("source")}
         put_call = analysis.get("putCallRatio")
         max_pain = analysis.get("maxPain")
-        key_strikes = analysis.get("keyStrikes") or []
-        bias = "neutral"
-        if isinstance(put_call, (int, float)):
+        key_strikes = analysis.get("keyStrikes") or analysis.get("keyLevels") or []
+        bias = str(analysis.get("bias") or "neutral").lower()
+        if bias not in {"bullish", "bearish", "neutral"}:
+            bias = "neutral"
+        if bias == "neutral" and isinstance(put_call, (int, float)):
             if put_call < 0.9:
                 bias = "bullish"
             elif put_call > 1.1:
                 bias = "bearish"
         pinning = "high" if max_pain in key_strikes else "low"
-        signal_payload = {
+        return {
             "available": True,
             "putCallRatio": put_call,
             "bias": bias,
             "keyStrikes": key_strikes,
+            "keyLevels": analysis.get("keyLevels") or key_strikes,
             "maxPain": max_pain,
             "pinningRisk": pinning,
+            "barrierZones": analysis.get("barrierZones") or {},
+            "targetLevels": analysis.get("targetLevels") or [],
+            "hedgeLevels": analysis.get("hedgeLevels") or [],
+            "source": analysis.get("source") or options_snapshot.get("source"),
+            "source_priority": analysis.get("source_priority") or options_snapshot.get("source_priority"),
+            "stale": bool(analysis.get("stale")),
+            "last_updated": analysis.get("last_updated") or options_snapshot.get("last_updated"),
         }
-        return self._ensure_idea_text_fields(signal_payload)
 
     def applyOptionsImpact(self, signal: dict, optionsAnalysis: dict, apply_confidence: bool = True) -> dict:
         if not optionsAnalysis or optionsAnalysis.get("available") is False:
@@ -735,9 +746,14 @@ class SignalEngine:
         price = float(signal.get("entry") or 0.0)
         bias = str(optionsAnalysis.get("bias") or "neutral").lower()
         put_call = optionsAnalysis.get("putCallRatio")
-        key_strikes = [float(v) for v in (optionsAnalysis.get("keyStrikes") or []) if isinstance(v, (int, float))]
+        key_strikes = [float(v) for v in (optionsAnalysis.get("keyStrikes") or optionsAnalysis.get("keyLevels") or []) if isinstance(v, (int, float))]
         max_pain = optionsAnalysis.get("maxPain")
         pinning = str(optionsAnalysis.get("pinningRisk") or "low").lower()
+        barriers = optionsAnalysis.get("barrierZones") if isinstance(optionsAnalysis.get("barrierZones"), dict) else {}
+        support = [float(v) for v in (barriers.get("support") or []) if isinstance(v, (int, float))]
+        resistance = [float(v) for v in (barriers.get("resistance") or []) if isinstance(v, (int, float))]
+        target_levels = [float(v) for v in (optionsAnalysis.get("targetLevels") or []) if isinstance(v, (int, float))]
+        hedge_levels = [float(v) for v in (optionsAnalysis.get("hedgeLevels") or []) if isinstance(v, (int, float))]
         impact = 0
         warnings: list[str] = []
         if action == "BUY":
@@ -752,6 +768,14 @@ class SignalEngine:
             if bias == "bearish":
                 impact -= 10
                 warnings.append("Options market conflicts with BUY signal")
+            if any(s < price for s in support):
+                impact += 3
+            if any(t > price for t in target_levels):
+                impact += 3
+            if any(h > price for h in hedge_levels):
+                impact -= 4
+            if any(r >= price for r in resistance):
+                impact -= 3
         if action == "SELL":
             if bias == "bearish":
                 impact += 8
@@ -764,6 +788,14 @@ class SignalEngine:
             if bias == "bullish":
                 impact -= 10
                 warnings.append("Options market conflicts with SELL signal")
+            if any(r > price for r in resistance):
+                impact += 3
+            if any(h < price for h in hedge_levels):
+                impact += 3
+            if any(t < price for t in target_levels):
+                impact -= 4
+            if any(s <= price for s in support):
+                impact -= 3
         if pinning == "high":
             impact -= 6
             warnings.append("High probability of price pinning near strike")

--- a/tests/test_mt4_options_bridge.py
+++ b/tests/test_mt4_options_bridge.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta, timezone
+
+from app.main import api_mt4_options_levels_symbol
+from app.services.cme_scraper import get_cme_market_snapshot
+from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
+
+
+def test_save_and_get_options_levels():
+    save_options_levels({
+        "symbol": "eurusd",
+        "levels": [{"type": "put", "price": 1.08}, {"type": "max_pain", "price": 1.09}],
+        "underlying_price": 1.085,
+    })
+    payload = get_latest_options_levels("EURUSD")
+    assert payload["available"] is True
+    assert payload["analysis"]["source"] == "mt4_optionsfx"
+    assert payload["analysis"]["maxPain"] == 1.09
+
+
+def test_get_endpoint_unavailable_for_unknown_symbol():
+    payload = api_mt4_options_levels_symbol("UNKNOWNPAIR")
+    assert payload["available"] is False
+
+
+def test_stale_detection():
+    save_options_levels({
+        "symbol": "GBPUSD",
+        "levels": [{"type": "call", "price": 1.3}],
+        "timestamp": (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat(),
+    })
+    payload = get_latest_options_levels("GBPUSD")
+    assert payload["stale"] is True
+
+
+def test_mt4_priority_over_cme():
+    save_options_levels({
+        "symbol": "USDJPY",
+        "levels": [{"type": "support", "price": 155.0}],
+        "underlying_price": 156.0,
+    })
+    snapshot = __import__("asyncio").run(get_cme_market_snapshot("USDJPY"))
+    assert snapshot["source"] == "mt4_optionsfx"
+    assert snapshot["source_priority"] == 1
+
+
+def test_empty_levels_are_safe():
+    save_options_levels({"symbol": "AUDUSD", "levels": []})
+    payload = get_latest_options_levels("AUDUSD")
+    assert payload["available"] is False


### PR DESCRIPTION
### Motivation
- Добавить полноценный приём и хранение опционных уровней от MT4 OptionsFX bridge по адресу `POST /api/mt4/options-levels` и сделать их доступными для аналитики и генерации идей. 
- Обеспечить приоритет источника MT4 перед существующим CME scraping и не ломать текущую архитектуру, API и логику `signal_engine`. 

### Description
- Добавлен новый сервис `app/services/mt4_options_bridge.py` с in-memory хранилищем, функциями `save_options_levels`, `get_latest_options_levels`, `normalize_symbol`, `is_stale` и TTL `MT4_OPTIONS_LEVELS_TTL_SECONDS = 21600`. 
- Добавлены API-эндпоинты `POST /api/mt4/options-levels` (валидация `symbol` и `levels`, безопасный парсинг, логирование) и `GET /api/mt4/options-levels/{symbol}` (возврат последнего снимка или `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64f83c7a08331b330540721563cf9)