### PR TITLE
Добавлен endpoint для MT4 OptionsFX (options-levels) и in-memory storage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.services.cme_scraper import get_cme_market_snapshot
 from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
+from app.services.mt4_options_bridge import get as get_mt4_options_levels, save as save_mt4_options_levels
 from backend.chat_service import ChatRequest, ForexChatService
 
 
@@ -911,6 +912,37 @@ async def api_mt4_push_candles(request: Request):
 
 
 
+
+
+
+@app.post("/api/mt4/options-levels")
+async def api_mt4_options_levels(request: Request):
+    payload = await request.json()
+    symbol = str(payload.get("symbol") or "").strip()
+    if not symbol:
+        return JSONResponse({"error": "symbol is required"}, status_code=400)
+
+    levels = payload.get("levels")
+    if not isinstance(levels, list):
+        levels = []
+    payload["levels"] = levels
+    payload["symbol"] = symbol
+
+    save_mt4_options_levels(payload)
+
+    return {
+        "status": "ok",
+        "symbol": symbol,
+        "levels_received": len(levels),
+    }
+
+
+@app.get("/api/mt4/options-levels/{symbol}")
+def api_mt4_options_levels_get(symbol: str):
+    data = get_mt4_options_levels(symbol)
+    if data is None:
+        return {"available": False, "reason": "no data"}
+    return data
 
 @app.post("/api/mt4/volume-clusters")
 async def api_mt4_volume_clusters(request: Request):

--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+OPTIONS_DATA: dict[str, dict[str, Any]] = {}
+
+
+def save(payload: dict[str, Any]) -> dict[str, Any]:
+    symbol = str(payload["symbol"]).upper()
+    stored_payload = dict(payload)
+    stored_payload["symbol"] = symbol
+    stored_payload["received_at"] = datetime.now(timezone.utc).isoformat()
+    OPTIONS_DATA[symbol] = stored_payload
+    return stored_payload
+
+
+def get(symbol: str) -> dict[str, Any] | None:
+    return OPTIONS_DATA.get(str(symbol).upper())


### PR DESCRIPTION
### Motivation
- Исправить 404 при POST от MT4 bridge на `/api/mt4/options-levels` и обеспечить простое хранение присылаемых данных в памяти.
- Добавить минимальный API для получения последних сохранённых уровней по символу без изменения существующей архитектуры.

### Description
- Добавлен новый файл `app/services/mt4_options_bridge.py` с in-memory хранилищем `OPTIONS_DATA` и функциями `save(payload)` и `get(symbol)`; `save` нормализует `symbol` в uppercase и добавляет `received_at`.
- В `app/main.py` добавлен импорт `from app.services.mt4_options_bridge import get as get_mt4_options_levels, save as save_mt4_options_levels`.
- Реализован `POST /api/mt4/options-levels`, который принимает JSON, возвращает `400` при отсутствии `symbol`, подставляет `levels = []`, если `levels` отсутствует или не список, сохраняет payload через `save_mt4_options_levels(payload)` и возвращает `{ "status": "ok", "symbol": symbol, "levels_received": len(levels) }`.
- Реализован `GET /api/mt4/options-levels/{symbol}`, который возвращает последнее сохранённое значение или `{ "available": false, "reason": "no data" }` при отсутствии данных.

### Testing
- Выполнена статическая проверка синтаксиса: `python -m py_compile app/main.py app/services/mt4_options_bridge.py` — успешно.
- Дополнительные автоматические тесты не запускались в рамках этого изменения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64fbf6c108331acfb0069fba45615)