### PR TITLE
Интеграция MT4 OptionsFX уровней в signal engine и ideas

### DIFF
--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -5,6 +5,8 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from app.services.options_analysis import analyze_options
+
 logger = logging.getLogger(__name__)
 
 MT4_OPTIONS_LEVELS_TTL_SECONDS = int(os.getenv("MT4_OPTIONS_LEVELS_TTL_SECONDS", "21600"))
@@ -85,7 +87,6 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
 
     support = prices("support") + prices("put")
     resistance = prices("resistance") + prices("call")
-    max_pain = (prices("max_pain") or [None])[0]
     targets = prices("target_volume")
     hedges = prices("hedge_volume")
     key_levels = sorted(set(support + resistance + prices("balance") + prices("gamma_level") + targets + hedges))
@@ -94,22 +95,10 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
         price = float(underlying)
     except (TypeError, ValueError):
         price = None
-    bias = "neutral"
-    if price is not None:
-        below_support = any(level < price for level in support)
-        above_resistance = any(level > price for level in resistance)
-        target_above = any(level > price for level in targets)
-        hedge_above = any(level > price for level in hedges)
-        if (below_support or target_above) and not (above_resistance or hedge_above):
-            bias = "bullish"
-        elif (above_resistance or hedge_above) and not (below_support or target_above):
-            bias = "bearish"
-
-    summary_ru = "Опционные уровни MT4 получены, явного смещения не выявлено."
-    if bias == "bullish":
-        summary_ru = "Опционные уровни MT4 поддерживают сценарий BUY: поддержка/put ниже цены и цели выше."
-    elif bias == "bearish":
-        summary_ru = "Опционные уровни MT4 поддерживают сценарий SELL: сопротивление/call выше цены и защитные уровни давят сверху."
+    options_flow = analyze_options(levels, price)
+    max_pain = options_flow.get("max_pain")
+    bias = str(options_flow.get("bias") or "neutral")
+    summary_ru = str(options_flow.get("summary_ru") or "Опционные уровни MT4 получены, явного смещения не выявлено.")
 
     return {
         "available": bool(levels),
@@ -123,6 +112,10 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
         "summary_ru": summary_ru,
         "targetLevels": targets,
         "hedgeLevels": hedges,
+        "targets_above": options_flow.get("targets_above") or [],
+        "targets_below": options_flow.get("targets_below") or [],
+        "hedge_above": options_flow.get("hedge_above") or [],
+        "hedge_below": options_flow.get("hedge_below") or [],
         "stale": False,
         "last_updated": entry.get("received_at"),
     }

--- a/app/services/options_analysis.py
+++ b/app/services/options_analysis.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def analyze_options(levels: list[dict[str, Any]] | None, price: float | int | None) -> dict[str, Any]:
+    rows = levels if isinstance(levels, list) else []
+    parsed_price: float | None
+    try:
+        parsed_price = float(price) if price is not None else None
+    except (TypeError, ValueError):
+        parsed_price = None
+
+    max_pain: float | None = None
+    targets_above: list[float] = []
+    targets_below: list[float] = []
+    hedge_above: list[float] = []
+    hedge_below: list[float] = []
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        level_type = str(row.get("type") or "").strip().lower()
+        try:
+            level_price = float(row.get("price"))
+        except (TypeError, ValueError):
+            continue
+
+        if level_type == "max_pain" and max_pain is None:
+            max_pain = level_price
+        if parsed_price is None:
+            continue
+        if level_type == "target_volume":
+            (targets_above if level_price > parsed_price else targets_below).append(level_price)
+        elif level_type == "hedge_volume":
+            (hedge_above if level_price > parsed_price else hedge_below).append(level_price)
+
+    score = 0
+    if parsed_price is not None:
+        if targets_above:
+            score += 1
+        if hedge_below:
+            score += 1
+        if isinstance(max_pain, (int, float)) and max_pain > parsed_price:
+            score += 1
+
+        if targets_below:
+            score -= 1
+        if hedge_above:
+            score -= 1
+        if isinstance(max_pain, (int, float)) and max_pain < parsed_price:
+            score -= 1
+
+    bias = "neutral"
+    if score > 0:
+        bias = "bullish"
+    elif score < 0:
+        bias = "bearish"
+
+    if not rows:
+        summary_ru = "Опционные уровни MT4 недоступны: сценарий рассчитан без options layer."
+    elif parsed_price is None:
+        summary_ru = "Опционные уровни MT4 получены, но текущая цена отсутствует для оценки смещения."
+    else:
+        summary_ru = (
+            f"Опционные уровни указывают на {bias} смещение. "
+            f"Max Pain выступает ориентиром на уровне {max_pain if max_pain is not None else 'n/a'}. "
+            f"Хеджирующие уровни ограничивают движение: выше цены {len(hedge_above)}, ниже цены {len(hedge_below)}."
+        )
+
+    return {
+        "available": bool(rows),
+        "max_pain": max_pain,
+        "targets_above": sorted(targets_above),
+        "targets_below": sorted(targets_below),
+        "hedge_above": sorted(hedge_above),
+        "hedge_below": sorted(hedge_below),
+        "bias": bias,
+        "summary_ru": summary_ru,
+    }

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -3945,11 +3945,20 @@ class TradeIdeaService:
                 pcr = options_analysis.get("putCallRatio")
                 strikes = options_analysis.get("keyStrikes") or []
                 max_pain = options_analysis.get("maxPain")
+                targets_up = options_analysis.get("targets_above") or []
+                targets_down = options_analysis.get("targets_below") or []
+                hedge_up = options_analysis.get("hedge_above") or []
+                hedge_down = options_analysis.get("hedge_below") or []
+                bias = options_analysis.get("bias") or "neutral"
                 options_text = (
-                    f"CME options (реальные данные, возможна задержка): PCR={pcr}, key strikes={strikes}, max pain={max_pain}."
+                    "Опционные уровни указывают на "
+                    f"{bias} смещение. Max Pain выступает ориентиром: {max_pain}. "
+                    f"Target levels выше цены: {targets_up}, ниже цены: {targets_down}. "
+                    f"Хеджирующие уровни ограничивают движение: сверху {hedge_up}, снизу {hedge_down}. "
+                    f"(source: {options_snapshot.get('source')}, PCR={pcr}, key strikes={strikes})"
                 )
             else:
-                options_text = "Опционный слой недоступен (реальные CME options не получены)."
+                options_text = "Опционный слой недоступен (available=false): анализ построен без options layer."
 
         return {
             "smc": str(signal.get("smc_ru") or market_context.get("smcRu") or rationale),

--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -494,11 +494,15 @@ class SignalEngine:
         )
         confidence += sentiment_delta
         confidence = max(20, min(confidence, 92))
+        resolved_options = self._resolve_options_analysis(options_snapshot)
         options_applied = self.applyOptionsImpact(
             signal={"action": action, "entry": price, "confidence_percent": confidence, "reason_ru": "", "warning": analysis_contract["warning"]},
-            optionsAnalysis=self._resolve_options_analysis(options_snapshot),
+            optionsAnalysis=resolved_options,
             apply_confidence=False,
         )
+        options_direction_delta = self._options_direction_delta(action, resolved_options)
+        confidence += options_direction_delta
+        confidence = max(20, min(confidence, 92))
         signal_threshold = PROFESSIONAL_MIN_CONFIDENCE if analysis_mode == "professional" else FALLBACK_MIN_CONFIDENCE
 
         scenario_type = self._resolve_scenario_type(mtf_features)
@@ -633,6 +637,7 @@ class SignalEngine:
             "pattern_signal_impact": pattern_impact,
             "options_analysis": options_snapshot,
             "options_impact": options_applied.get("options_impact"),
+            "options_direction_delta": options_direction_delta,
             "options_summary_ru": options_applied.get("options_summary_ru"),
             "confluence_analysis": confluence_analysis,
             "confluence_breakdown": confluence_analysis.get("breakdown", {}),
@@ -689,6 +694,10 @@ class SignalEngine:
                 "options_put_call_ratio": options_analysis.get("putCallRatio"),
                 "options_key_strikes": options_analysis.get("keyStrikes") or [],
                 "options_max_pain": options_analysis.get("maxPain"),
+                "options_targets_above": options_analysis.get("targets_above") or [],
+                "options_targets_below": options_analysis.get("targets_below") or [],
+                "options_hedge_above": options_analysis.get("hedge_above") or [],
+                "options_hedge_below": options_analysis.get("hedge_below") or [],
                 "confluence_total_score": confluence_analysis.get("total_score"),
                 "confluence_grade": confluence_analysis.get("grade"),
             },
@@ -700,6 +709,23 @@ class SignalEngine:
             },
         }
         return self._ensure_idea_text_fields(signal_payload)
+
+    @staticmethod
+    def _options_direction_delta(action: str, options_analysis: dict) -> int:
+        if not isinstance(options_analysis, dict) or options_analysis.get("available") is False:
+            return 0
+        bias = str(options_analysis.get("bias") or "neutral").lower()
+        if action == "BUY":
+            if bias == "bullish":
+                return 5
+            if bias == "bearish":
+                return -5
+        if action == "SELL":
+            if bias == "bearish":
+                return 5
+            if bias == "bullish":
+                return -5
+        return 0
 
     def _resolve_options_analysis(self, options_snapshot: dict | None) -> dict:
         analysis = (options_snapshot or {}).get("analysis") if isinstance(options_snapshot, dict) else {}


### PR DESCRIPTION
### Motivation
- Включить данные MT4 OptionsFX (levels: {price,type,strength}) в анализ сигналов и генерацию идей для более информированного bias и confidence.
- Использовать существующий мост MT4 и endpoint без ломки текущей структуры данных и ценовых мостов.
- Обеспечить безопасный fallback при отсутствии опционных данных (`available=false`).

### Description
- Добавлен сервис `app/services/options_analysis.py` с функцией `analyze_options(levels, price)`, возвращающей `max_pain`, `targets_above`, `targets_below`, `hedge_above`, `hedge_below`, `bias` и `summary_ru` по заданному контракту.
- Модернизирован `app/services/mt4_options_bridge.py` для использования `analyze_options` и добавления в `analysis` полей `targets_above/targets_below`, `hedge_above/hedge_below`, `bias`, `maxPain`, `summary_ru` при сохранении обратной совместимости с `keyStrikes`, `targetLevels`, `hedgeLevels` и `barrierZones`.
- В `backend/signal_engine.py` добавлена логика направленной опционной дельты `options_direction_delta` (+5 / -5) в расчёт `confidence` в отдельном шаге, и это значение включено в итоговый payload как `options_direction_delta`; опционные уровни также прокинуты в `market_context` (`options_targets_above`, `options_targets_below`, `options_hedge_above`, `options_hedge_below`).
- В `app/services/trade_idea_service.py` расширен текст идей для передачи опционного контекста: в `options_ru` и `options_meta` теперь попадают `max_pain`, target/hedge уровни выше/ниже цены и `bias`, с понятными русскоязычными формулировками; при отсутствии данных возвращается явный `available=false` текст.

### Testing
- Запущены автоматические тесты `tests/test_mt4_options_bridge.py` и `tests/signals/test_options_impact.py`, обе группы тестов прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65df6155c833198b6066c576de1af)