### PR TITLE
Приоритет MT4 OptionsFX для options_analysis (Ideas)

### DIFF
--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -2755,24 +2755,23 @@
 
     function renderOptionsAnalysis(idea) {
       const oa = idea && typeof idea.options_analysis === "object" ? idea.options_analysis : {};
-      const analysis = oa && typeof oa.analysis === "object" ? oa.analysis : {};
+      const analysis = oa && typeof oa.analysis === "object" ? oa.analysis : oa;
       const available = Boolean(oa.available ?? idea.options_available);
       const status = available ? "available" : "unavailable";
-      const pcr = analysis.putCallRatio ?? idea?.market_context?.options_put_call_ratio ?? "—";
-      const strikes = Array.isArray(analysis.keyStrikes) ? analysis.keyStrikes.join(", ") : (idea?.market_context?.options_key_strikes || "—");
+      const source = String(oa.source || analysis.source || idea.options_source || "unavailable");
+      const strikesRaw = analysis.keyLevels ?? analysis.keyStrikes ?? idea?.market_context?.options_key_strikes;
+      const strikes = Array.isArray(strikesRaw) ? strikesRaw.join(", ") : (strikesRaw || "—");
       const maxPain = analysis.maxPain ?? idea?.market_context?.options_max_pain ?? "—";
       const bias = analysis.bias || idea.options_bias || "—";
-      const impact = idea.options_impact || idea?.options_analysis?.impact || "—";
-      const summary = idea.options_summary_ru || oa.summary_ru || (available ? "Данные options layer получены." : "Опционный слой сейчас недоступен, поэтому идея рассчитана без подтверждения options layer.");
+      const summary = analysis.summary_ru || idea.options_summary_ru || (available ? "Данные options layer получены." : "Опционный слой сейчас недоступен, поэтому идея рассчитана без подтверждения options layer.");
       return `
       <div class="modal-section-title">Options Analysis</div>
       <div class="box modal-text">
+        <div><strong>Source:</strong> ${escapeHtml(source)}</div>
         <div><strong>Status:</strong> ${escapeHtml(status)}</div>
-        <div><strong>Put/Call ratio:</strong> ${escapeHtml(String(pcr))}</div>
-        <div><strong>Key strikes:</strong> ${escapeHtml(String(strikes))}</div>
+        <div><strong>Key levels:</strong> ${escapeHtml(String(strikes))}</div>
         <div><strong>Max pain:</strong> ${escapeHtml(String(maxPain))}</div>
         <div><strong>Options bias:</strong> ${escapeHtml(String(bias))}</div>
-        <div><strong>Options impact:</strong> ${escapeHtml(String(impact))}</div>
         <div><strong>Summary:</strong> ${escapeHtml(String(summary))}</div>
       </div>`;
     }

--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -60,7 +60,11 @@ class SignalEngine:
                 required_timeframes = self._required_stack_timeframes(requested_timeframes)
                 for stack_timeframe in required_timeframes:
                     snapshots_cache[stack_timeframe] = await self._snapshot_for(symbol, stack_timeframe, snapshots_cache)
-                options_snapshot = await get_cme_market_snapshot(symbol)
+                mt4_options = get_latest_options_levels(symbol)
+                if mt4_options.get("available"):
+                    options_snapshot = mt4_options
+                else:
+                    options_snapshot = await get_cme_market_snapshot(symbol)
                 for timeframe in requested_timeframes:
                     try:
                         stack = TIMEFRAME_STACKS[timeframe]
@@ -746,7 +750,7 @@ class SignalEngine:
                 selected = cme_analysis
                 source = "cme"
 
-        logger.info("Options source selected %s", source)
+        logger.info("Options source selected: %s", source)
         if not selected:
             return {"available": False, "source": "unavailable"}
 


### PR DESCRIPTION
### Motivation
- Исправить ситуацию, когда в Ideas показывается статус `unavailable` и текст про недоступность CME, несмотря на наличие данных от MT4 OptionsFX.
- Обеспечить использование реальных MT4 данных перед fallback'ом на CME, чтобы UI и логика сигналов корректно учитывали `mt4_optionsfx` источник.

### Description
- В `backend/signal_engine.py` изменена логика формирования `options_snapshot` в `generate_live_signals`: теперь сначала вызывается `get_latest_options_levels(symbol)` и при `available=true` используется MT4 snapshot, иначе вызывается `get_cme_market_snapshot(symbol)`.
- В `_resolve_options_analysis` сохранён выбор приоритета MT4 и добавлен лог в формате `Options source selected: %s` для явного трекинга выбранного источника.
- В `app/static/ideas.html` обновлён `renderOptionsAnalysis` так, чтобы корректно читать как вложенный объект `options_analysis.analysis`, так и плоский `options_analysis`, и отображать `source`, `status`, `key levels`, `max pain`, `bias` и `summary` (приоритет `analysis.summary_ru` перед fallback-текстом).
- Не показывается сообщение о недоступности CME, когда доступны MT4 данные; добавлена строка вывода `Source` в modal для прозрачности.

### Testing
- `python -m py_compile backend/signal_engine.py` — успешно, ошибок синтаксиса нет.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b9b84da88331accede9a295719e3)