### PR TITLE
Инициализация `logger` в `app/main.py` для исправления NameError в /ideas

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import lzma
+import logging
 import os
 import struct
 import time
@@ -23,6 +24,8 @@ from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
 from backend.chat_service import ChatRequest, ForexChatService
+
+logger = logging.getLogger(__name__)
 
 
 BASE_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
### Motivation
- Исправить HTTP 500 в `/ideas`, вызванный `NameError: name 'logger' is not defined` при попытке вызвать `logger.exception(...)` в обработчике идей.

### Description
- Добавлены `import logging` и модульная инициализация `logger = logging.getLogger(__name__)` в начале `app/main.py` до определения endpoint'ов, без изменения логики маршрута `/ideas`.

### Testing
- Запущена автоматическая компиляция Python файла командой `python -m py_compile app/main.py` и успешно завершилась без ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6cb844090833185db94900ffc2290)