### PR TITLE
Сохранение MT4 OptionsFX на диск и корректная передача options в /ideas

### DIFF
--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -11,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 MT4_OPTIONS_LEVELS_TTL_SECONDS = int(os.getenv("MT4_OPTIONS_LEVELS_TTL_SECONDS", "21600"))
 _OPTIONS_STORE: dict[str, dict[str, Any]] = {}
+_OPTIONS_STORAGE_PATH = Path("signals_data/mt4_options_levels.json")
 
 
 def normalize_symbol(symbol: str) -> str:
@@ -61,8 +64,35 @@ def save_options_levels(payload: dict[str, Any]) -> dict[str, Any]:
     }
     if symbol:
         _OPTIONS_STORE[symbol] = entry
+        _persist_options_store()
     logger.info("MT4 options levels received symbol=%s count=%s", symbol, len(levels))
     return entry
+
+
+def _persist_options_store() -> None:
+    try:
+        _OPTIONS_STORAGE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _OPTIONS_STORAGE_PATH.write_text(json.dumps(_OPTIONS_STORE, ensure_ascii=False), encoding="utf-8")
+    except Exception as exc:
+        logger.warning("mt4_options_levels_persist_failed reason=%s", exc)
+
+
+def _load_options_store_from_disk() -> None:
+    if not _OPTIONS_STORAGE_PATH.exists():
+        return
+    try:
+        payload = json.loads(_OPTIONS_STORAGE_PATH.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("mt4_options_levels_load_failed reason=%s", exc)
+        return
+    if not isinstance(payload, dict):
+        return
+    for key, entry in payload.items():
+        if not isinstance(entry, dict):
+            continue
+        symbol = normalize_symbol(entry.get("symbol") or key)
+        if symbol:
+            _OPTIONS_STORE[symbol] = entry
 
 
 def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
@@ -124,6 +154,9 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
 def get_latest_options_levels(symbol: str) -> dict[str, Any]:
     normalized = normalize_symbol(symbol)
     entry = _OPTIONS_STORE.get(normalized)
+    if not entry:
+        _load_options_store_from_disk()
+        entry = _OPTIONS_STORE.get(normalized)
     if not entry:
         return {"available": False, "reason": "No MT4 option levels received"}
     stale = is_stale(entry.get("timestamp"))

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -603,8 +603,16 @@ class TradeIdeaService:
             )
 
             card = dict(preferred_timeframe_idea)
-            options_source_idea = m15 or h1 or h4 or narrative_source_idea
+            options_candidates = [item for item in (m15, h1, h4, narrative_source_idea) if isinstance(item, dict)]
+            options_source_idea = next((item for item in options_candidates if item.get("options_analysis")), options_candidates[0] if options_candidates else {})
             options_market_context = options_source_idea.get("market_context") if isinstance(options_source_idea.get("market_context"), dict) else {}
+
+            def _first_options_value(field: str) -> Any:
+                for candidate in options_candidates:
+                    value = candidate.get(field)
+                    if value not in (None, "", []):
+                        return value
+                return None
             card.update(
                 {
                     "id": f"{symbol.lower()}-combined",
@@ -651,10 +659,10 @@ class TradeIdeaService:
                     "updated_at": latest_update,
                     "meaningful_updated_at": latest_update,
                     "tags": [symbol, "MTF", final_signal.upper(), *sorted(timeframe_map.keys())],
-                    "options_analysis": options_source_idea.get("options_analysis"),
-                    "options_source": options_source_idea.get("options_source"),
-                    "options_available": options_source_idea.get("options_available"),
-                    "options_summary_ru": options_source_idea.get("options_summary_ru"),
+                    "options_analysis": _first_options_value("options_analysis"),
+                    "options_source": _first_options_value("options_source"),
+                    "options_available": bool(_first_options_value("options_available")),
+                    "options_summary_ru": _first_options_value("options_summary_ru"),
                     "market_context": {
                         **(card.get("market_context") if isinstance(card.get("market_context"), dict) else {}),
                         "optionsAnalysis": options_market_context.get("optionsAnalysis"),

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -2756,18 +2756,19 @@
     function renderOptionsAnalysis(idea) {
       const oa = idea && typeof idea.options_analysis === "object" ? idea.options_analysis : {};
       const mc = idea && typeof idea.market_context === "object" ? idea.market_context : {};
-      const fallbackAnalysis = idea.optionsAnalysis && typeof idea.optionsAnalysis === "object"
-        ? idea.optionsAnalysis
-        : (mc.optionsAnalysis && typeof mc.optionsAnalysis === "object" ? mc.optionsAnalysis : {});
-      const analysis = oa && typeof oa.analysis === "object" ? oa.analysis : (Object.keys(oa).length ? oa : fallbackAnalysis);
-      const available = Boolean(oa.available ?? analysis.available ?? idea.options_available ?? mc.options_available);
+      const directMarketContext = mc.optionsAnalysis && typeof mc.optionsAnalysis === "object" ? mc.optionsAnalysis : {};
+      const legacyOptions = idea.optionsAnalysis && typeof idea.optionsAnalysis === "object" ? idea.optionsAnalysis : {};
+      const analysis = oa.analysis && typeof oa.analysis === "object"
+        ? oa.analysis
+        : (Object.keys(oa).length ? oa : (Object.keys(directMarketContext).length ? directMarketContext : legacyOptions));
+      const available = Boolean(idea.options_available ?? oa.available ?? analysis.available ?? mc.options_available);
       const status = available ? "available" : "unavailable";
       const source = String(oa.source || analysis.source || idea.options_source || mc.options_source || "unavailable");
       const strikesRaw = analysis.keyLevels ?? analysis.keyStrikes ?? idea?.market_context?.options_key_strikes;
       const strikes = Array.isArray(strikesRaw) ? strikesRaw.join(", ") : (strikesRaw || "—");
       const maxPain = analysis.maxPain ?? idea?.market_context?.options_max_pain ?? "—";
       const bias = analysis.bias || idea.options_bias || "—";
-      const summary = analysis.summary_ru || idea.options_summary_ru || (available ? "Данные options layer получены." : "Опционный слой CME сейчас недоступен.");
+      const summary = analysis.summary_ru || idea.options_summary_ru || (available ? "Данные MT4 OptionsFX получены." : "Опционный слой CME сейчас недоступен.");
       return `
       <div class="modal-section-title">Options Analysis</div>
       <div class="box modal-text">


### PR DESCRIPTION
### Motivation
- Устранить потерю MT4 OptionsFX при перезапуске сервиса из-за хранения только в памяти. 
- Обеспечить сохранение и корректную передачу полей опционального слоя в процессе обновления и объединения идей, чтобы frontend показывал реальные MT4 OptionsFX, а не fallback «CME недоступен». 
- Предотвратить падение страницы `/ideas`, если хранилище options пустое или файл JSON битый.

### Description
- В `app/services/mt4_options_bridge.py` добавлено персистентное хранение в `signals_data/mt4_options_levels.json`, реализованы функции `_persist_options_store()` и `_load_options_store_from_disk()`, автосоздание папки `signals_data` и безопасная обработка ошибок чтения/записи; `get_latest_options_levels` теперь смотрит сначала in-memory, затем пытается загрузить с диска. 
- В `app/services/trade_idea_service.py` при сборке MTF-карты идей (`_combine_ideas_by_instrument`) введён приоритетный подбор кандидатов `m15/h1/h4/narrative_source_idea` и функция `_first_options_value()` для копирования полей `options_analysis`, `options_source`, `options_available`, `options_summary_ru` чтобы опционные данные не терялись при объединении. 
- В `app/static/ideas.html` обновлён `renderOptionsAnalysis` для резолва options в порядке: `idea.options_analysis`, `idea.market_context?.optionsAnalysis`, `idea.optionsAnalysis`, и при `options_available===true` показан текст о получении MT4 OptionsFX вместо fallback про CME. 
- Гарантируется, что в legacy-карточке присутствуют `options_analysis`, `options_source`, `options_available`, `options_summary_ru`, `market_context.optionsAnalysis`, `debug_options_source_selected`, `debug_options_available`.

### Testing
- Запущена проверка синтаксиса Python: `python -m py_compile app/services/mt4_options_bridge.py app/services/trade_idea_service.py` — успешно. 
- Изменения зафиксированы коммитом в репозитории (`git commit`) — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6d2c12e8c8331adf8a5590c5904b5)