### PR TITLE
Fix OptionsFX hydration/propagation for WAIT / combined / legacy ideas

### DIFF
--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -72,7 +72,11 @@ def save_options_levels(payload: dict[str, Any]) -> dict[str, Any]:
 def _persist_options_store() -> None:
     try:
         _OPTIONS_STORAGE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _OPTIONS_STORAGE_PATH.write_text(json.dumps(_OPTIONS_STORE, ensure_ascii=False), encoding="utf-8")
+        payload = {
+            "updated_at_utc": datetime.now(timezone.utc).isoformat(),
+            "symbols": _OPTIONS_STORE,
+        }
+        _OPTIONS_STORAGE_PATH.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     except Exception as exc:
         logger.warning("mt4_options_levels_persist_failed reason=%s", exc)
 
@@ -87,7 +91,10 @@ def _load_options_store_from_disk() -> None:
         return
     if not isinstance(payload, dict):
         return
-    for key, entry in payload.items():
+    symbols_payload = payload.get("symbols") if isinstance(payload.get("symbols"), dict) else payload
+    if not isinstance(symbols_payload, dict):
+        return
+    for key, entry in symbols_payload.items():
         if not isinstance(entry, dict):
             continue
         symbol = normalize_symbol(entry.get("symbol") or key)
@@ -158,7 +165,7 @@ def get_latest_options_levels(symbol: str) -> dict[str, Any]:
         _load_options_store_from_disk()
         entry = _OPTIONS_STORE.get(normalized)
     if not entry:
-        return {"available": False, "reason": "No MT4 option levels received"}
+        return {"available": False, "reason": "No MT4 option levels received", "source": "unavailable"}
     stale = is_stale(entry.get("timestamp"))
     analysis = _build_analysis(entry)
     analysis["stale"] = stale
@@ -166,4 +173,5 @@ def get_latest_options_levels(symbol: str) -> dict[str, Any]:
     if stale:
         analysis["available"] = False
         analysis["reason"] = "No MT4 option levels received"
-    return {**entry, "analysis": analysis, "available": analysis["available"], "stale": stale, "source": "mt4_optionsfx"}
+    source = "mt4_optionsfx" if analysis["available"] else "unavailable"
+    return {**entry, "analysis": analysis, "available": analysis["available"], "stale": stale, "source": source}

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -257,9 +257,9 @@ class TradeIdeaService:
             self.idea_store.write(payload)
         else:
             payload = {"updated_at_utc": payload.get("updated_at_utc"), "ideas": ideas}
-        active_ideas = [idea for idea in payload.get("ideas", []) if idea.get("status") in ACTIVE_STATUSES]
+        ideas = [self._hydrate_live_options(idea) for idea in payload.get("ideas", [])]
+        active_ideas = [idea for idea in ideas if idea.get("status") in ACTIVE_STATUSES]
         archived_ideas = [idea for idea in payload.get("ideas", []) if str(idea.get("status")).lower() in CLOSED_STATUSES]
-        active_ideas = [self._hydrate_live_options(idea) for idea in active_ideas]
         combined_active_ideas = self._combine_ideas_by_instrument(active_ideas)
         combined_active_ideas = self._attach_fundamental_context(combined_active_ideas)
         if not combined_active_ideas and not archived_ideas:
@@ -280,32 +280,36 @@ class TradeIdeaService:
     def _hydrate_live_options(self, idea: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(idea, dict):
             return idea
+        hydrated = dict(idea)
         symbol = str(idea.get("symbol") or "").upper().strip()
+        hydrated["debug_options_symbol_checked"] = symbol
         if not symbol:
-            return idea
-        options_snapshot = get_latest_options_levels(symbol)
+            hydrated["debug_options_available"] = False
+            hydrated["debug_options_source_selected"] = "unavailable"
+            return hydrated
+        try:
+            options_snapshot = get_latest_options_levels(symbol)
+        except Exception:
+            options_snapshot = {"available": False, "source": "unavailable"}
+        mt4_available = bool(options_snapshot.get("available"))
+        mt4_source = str(options_snapshot.get("source") or "unavailable")
+        hydrated["debug_options_available"] = mt4_available
+        hydrated["debug_options_source_selected"] = mt4_source
         if not bool(options_snapshot.get("available")):
-            return idea
+            return hydrated
         analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
         source = str(options_snapshot.get("source") or analysis.get("source") or "mt4_optionsfx")
         if source in {"mt4", "mt4_options"}:
             source = "mt4_optionsfx"
         summary_ru = str(analysis.get("summary_ru") or "").strip()
-        options_payload = {
-            "available": True,
-            "source": source,
-            "analysis": analysis,
-            "summary_ru": summary_ru,
-        }
-        hydrated = dict(idea)
         market_context = hydrated.get("market_context") if isinstance(hydrated.get("market_context"), dict) else {}
-        hydrated["options_analysis"] = options_payload
-        hydrated["options_source"] = source
+        hydrated["options_analysis"] = analysis
+        hydrated["options_source"] = "mt4_optionsfx"
         hydrated["options_available"] = True
         hydrated["options_summary_ru"] = summary_ru
-        market_context["optionsAnalysis"] = options_payload
+        market_context["optionsAnalysis"] = analysis
         market_context["options_available"] = True
-        market_context["options_source"] = source
+        market_context["options_source"] = "mt4_optionsfx"
         hydrated["market_context"] = market_context
         return hydrated
 
@@ -603,7 +607,7 @@ class TradeIdeaService:
             )
 
             card = dict(preferred_timeframe_idea)
-            options_candidates = [item for item in (m15, h1, h4, narrative_source_idea) if isinstance(item, dict)]
+            options_candidates = [item for item in (m15, h1, h4, narrative_source_idea, symbol_ideas[0]) if isinstance(item, dict)]
             options_source_idea = next((item for item in options_candidates if item.get("options_analysis")), options_candidates[0] if options_candidates else {})
             options_market_context = options_source_idea.get("market_context") if isinstance(options_source_idea.get("market_context"), dict) else {}
 
@@ -663,6 +667,9 @@ class TradeIdeaService:
                     "options_source": _first_options_value("options_source"),
                     "options_available": bool(_first_options_value("options_available")),
                     "options_summary_ru": _first_options_value("options_summary_ru"),
+                    "debug_options_source_selected": _first_options_value("debug_options_source_selected"),
+                    "debug_options_available": bool(_first_options_value("debug_options_available")),
+                    "debug_options_symbol_checked": _first_options_value("debug_options_symbol_checked"),
                     "market_context": {
                         **(card.get("market_context") if isinstance(card.get("market_context"), dict) else {}),
                         "optionsAnalysis": options_market_context.get("optionsAnalysis"),
@@ -4540,22 +4547,9 @@ class TradeIdeaService:
         card = dict(idea) if isinstance(idea, dict) else {}
         market_context = card.get("market_context") if isinstance(card.get("market_context"), dict) else {}
         options_analysis = card.get("options_analysis") if isinstance(card.get("options_analysis"), dict) else {}
-        options_available = bool(
-            card.get("options_available")
-            or options_analysis.get("available")
-            or market_context.get("options_available")
-        )
-        options_source = str(
-            card.get("options_source")
-            or options_analysis.get("source")
-            or market_context.get("options_source")
-            or "unavailable"
-        )
-        options_summary = str(
-            card.get("options_summary_ru")
-            or options_analysis.get("summary_ru")
-            or ""
-        )
+        options_available = bool(card.get("options_available"))
+        options_source = str(card.get("options_source") or "unavailable")
+        options_summary = str(card.get("options_summary_ru") or "")
         card["options_analysis"] = options_analysis
         card["optionsSource"] = options_source
         card["options_source"] = options_source
@@ -4570,7 +4564,8 @@ class TradeIdeaService:
         )
         card["market_context"] = market_context
         card["debug_options_source_selected"] = str(card.get("debug_options_source_selected") or options_source)
-        card["debug_options_available"] = bool(card.get("debug_options_available", options_available))
+        card["debug_options_available"] = bool(card.get("debug_options_available"))
+        card["debug_options_symbol_checked"] = str(card.get("debug_options_symbol_checked") or card.get("symbol") or "")
         return card
 
     @staticmethod

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -2761,7 +2761,12 @@
       const analysis = oa.analysis && typeof oa.analysis === "object"
         ? oa.analysis
         : (Object.keys(oa).length ? oa : (Object.keys(directMarketContext).length ? directMarketContext : legacyOptions));
-      const available = Boolean(idea.options_available ?? oa.available ?? analysis.available ?? mc.options_available);
+      const available = Boolean(
+        idea.options_available === true
+        || oa.available === true
+        || analysis.available === true
+        || mc.options_available === true
+      );
       const status = available ? "available" : "unavailable";
       const source = String(oa.source || analysis.source || idea.options_source || mc.options_source || "unavailable");
       const strikesRaw = analysis.keyLevels ?? analysis.keyStrikes ?? idea?.market_context?.options_key_strikes;


### PR DESCRIPTION
### Motivation
- WAIT/combined/legacy карточки не получали MT4 OptionsFX даже при наличии данных, т.к. гидрация опционов выполнялась только для уже отфильтрованных active идей.
- Нужно надёжно пробрасывать флаги доступности и отладочные поля, чтобы фронтенд корректно скрывал CME unavailable при наличии MT4 данных.

### Description
- Гидрация опционных данных теперь выполняется для ВСЕХ идей до фильтрации active/archived в `refresh_market_ideas` (вместо поздней гидрации только для active). (`app/services/trade_idea_service.py`)
- В `_hydrate_live_options` добавлен `try/except` вокруг `get_latest_options_levels(symbol)` и всегда задаются debug-поля `debug_options_symbol_checked`, `debug_options_available`, `debug_options_source_selected`; при недоступности возвращается идея с этими debug-полями. (`app/services/trade_idea_service.py`)
- При доступности MT4 опционные данные теперь записываются в плоском виде: `options_analysis = analysis` (без обёртки), `options_source = "mt4_optionsfx"`, `options_available = True`, `options_summary_ru` из `analysis.summary_ru`, и аналогично в `market_context`. (`app/services/trade_idea_service.py`)
- В `_combine_ideas_by_instrument` добавлен дополнительный кандидат для выбора source опционов (`m15, h1, h4, narrative_source_idea, symbol_ideas[0]`) и в combined-card явно прокидываются `options_analysis`, `options_source`, `options_available`, `options_summary_ru` и debug-поля. (`app/services/trade_idea_service.py`)
- В `_to_legacy_card` убран пересчёт fallback для options — legacy-карточка просто копирует `options_*` и debug-поля из идеи. (`app/services/trade_idea_service.py`)
- Во фронтенде в `app/static/ideas.html` проверка доступности опционов сделана строгой по `true` (только `=== true`), чтобы не показывать CME unavailable при реально доступных MT4 данных. (`app/static/ideas.html`)
- В `app/services/mt4_options_bridge.py` изменён формат хранения на диск на `{ "updated_at_utc": "...", "symbols": {"EURUSD": entry} }` с чтением из `payload["symbols"][symbol]` и возвратом `source: "unavailable"` для недоступных записей. (`app/services/mt4_options_bridge.py`)
- MT4 советник не изменялся (файлы советника оставлены нетронутыми).

### Testing
- Выполнена компиляция изменённых модулей: `python -m py_compile app/services/trade_idea_service.py app/services/mt4_options_bridge.py`, компиляция прошла успешно. 
- Нет автоматических unit-тестов, затронувших эти функции, поэтому дополнительного CI не выполнялось локально.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e4040344833193887857f2bc99a1)