### PR TITLE
Исправить нормализацию символов MT4: удаление суффиксов брокера и логирование

### DIFF
--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -17,7 +17,15 @@ _OPTIONS_STORAGE_PATH = Path("signals_data/mt4_options_levels.json")
 
 
 def normalize_symbol(symbol: str) -> str:
-    return str(symbol or "").upper().strip().replace("/", "")
+    original = symbol
+    s = str(symbol or "").upper().strip()
+
+    if "." in s:
+        s = s.split(".")[0]
+
+    s = s.replace("/", "")
+    logger.info("Normalized symbol: raw=%s → normalized=%s", original, s)
+    return s
 
 
 def is_stale(timestamp: datetime | str | None) -> bool:


### PR DESCRIPTION
### Motivation
- MT4 может присылать символы с брокерскими суффиксами типа `EURUSD.cs`, что не совпадает с форматом, ожидаемым frontend (`EURUSD`), из‑за чего опционные уровни не находятся.

### Description
- Обновлён `normalize_symbol` в `app/services/mt4_options_bridge.py` для приведения к верхнему регистру, удаления суффикса после точки и удаления слэшей с сохранением предыдущего формата хранения.
- Добавлен лог с помощью `logger.info("Normalized symbol: raw=%s → normalized=%s", original, s)` для отладки нормализации входных символов.
- Нормализация применяется при `save_options_levels` и при `get_latest_options_levels`, формат `signals_data/mt4_options_levels.json`, frontend и советник не менялись.

### Testing
- Выполнена компиляция файла командой `python -m compileall app/services/mt4_options_bridge.py` и она завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ee6533a08331bf3d8d55cf1b0a37)