### PR TITLE
Добавить ingest/diagnostics опционных уровней и отобразить опционный анализ в /ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,3 +369,29 @@ TWELVEDATA_OUTPUTSIZE=50
 - В `TradeIdeaService` добавлена единая оркестрация для идеи: свечи нормализуются один раз и затем переиспользуются в SMC/overlay/chart/narrative этапах.
 - Диагностика расширена полями `candles_count_sent`, `candles_count_used`, `data_provider`, `analysis_mode`, `data_quality`, `fallback_used`, `chart_overlays_present`, `chart_snapshot_status`, `chartImageUrl`.
 - Рендер карточек `/ideas` переведён в режим «чистого рендера»: приоритет текста `idea_thesis -> unified_narrative -> full_text -> summary`, а при отсутствии PNG используется fallback-линейный chart по свечам из API.
+
+## Проверка ingest опционных уровней для /ideas
+
+Endpoint `POST /api/options/levels` позволяет загрузить реальные/ручные/MT4 уровни опционного слоя в Ideas без synthetic-данных. Прямой scraping CME остаётся отдельной задачей, но ingest-слой уже позволяет питать `/ideas/market` и `/api/ideas` актуальными уровнями из `manual | mt4_optionsfx | cme_public`.
+
+Проверка вручную:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/options/levels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "symbol": "EURUSD",
+    "underlying_price": 1.085,
+    "timestamp": "2026-05-03T12:00:00Z",
+    "source": "mt4_optionsfx",
+    "levels": [
+      {"type": "max_pain", "price": 1.08},
+      {"type": "put", "price": 1.075},
+      {"type": "call", "price": 1.095}
+    ],
+    "metadata": {}
+  }'
+
+curl http://127.0.0.1:8000/api/options/levels/EURUSD
+curl http://127.0.0.1:8000/ideas/market
+```

--- a/app/main.py
+++ b/app/main.py
@@ -949,6 +949,26 @@ async def api_mt4_options_levels(request: Request):
     return {"status": "ok", "symbol": saved.get("symbol"), "levels_received": len(saved.get("levels") or [])}
 
 
+@app.post("/api/options/levels")
+async def api_options_levels_ingest(request: Request):
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"status": "error", "error": "invalid_json"})
+    if not isinstance(payload, dict):
+        return JSONResponse(status_code=400, content={"status": "error", "error": "invalid_payload"})
+    symbol = str(payload.get("symbol") or "").strip()
+    levels = payload.get("levels")
+    if not symbol:
+        return JSONResponse(status_code=400, content={"status": "error", "error": "symbol_required"})
+    if levels is None or not isinstance(levels, list):
+        return JSONResponse(status_code=400, content={"status": "error", "error": "levels_required"})
+    saved = save_options_levels(payload)
+    latest = get_latest_options_levels(symbol)
+    analysis = latest.get("analysis") if isinstance(latest.get("analysis"), dict) else {}
+    return {"status": "ok", "saved": saved, "analysis": analysis, "available": bool(latest.get("available"))}
+
+
 @app.get("/api/mt4/options-levels/{symbol}")
 def api_mt4_options_levels_symbol(symbol: str):
     payload = get_latest_options_levels(symbol)
@@ -958,6 +978,30 @@ def api_mt4_options_levels_symbol(symbol: str):
             response["stale"] = True
         return response
     return payload
+
+
+@app.get("/api/options/levels/{symbol}")
+def api_options_levels_symbol(symbol: str):
+    return get_latest_options_levels(symbol)
+
+
+@app.get("/api/debug/options/{symbol}")
+def api_debug_options(symbol: str):
+    normalized = normalize_symbol(symbol)
+    payload = get_latest_options_levels(symbol)
+    expected_path = "signals_data/mt4_options_levels.json"
+    return {
+        "symbol": symbol,
+        "symbol_normalized": normalized,
+        "available": bool(payload.get("available")),
+        "source": payload.get("source"),
+        "stale": bool(payload.get("stale")),
+        "reason": payload.get("reason") or ((payload.get("analysis") if isinstance(payload.get("analysis"), dict) else {}).get("reason")),
+        "last_updated": (payload.get("analysis") if isinstance(payload.get("analysis"), dict) else {}).get("last_updated") or payload.get("received_at"),
+        "analysis": payload.get("analysis") if isinstance(payload.get("analysis"), dict) else {},
+        "storage_path_exists": Path(expected_path).exists(),
+        "expected_storage_path": expected_path,
+    }
 
 @app.get("/api/mt4/markup/{symbol}")
 def api_mt4_markup(symbol: str, tf: str = "M15"):
@@ -3624,6 +3668,7 @@ def _extract_numeric_price(row: dict[str, Any] | None) -> tuple[float | None, st
 
 def _normalize_quote_signal(signal: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(signal or {})
+    symbol = normalize_symbol(str(normalized.get("symbol") or normalized.get("instrument") or ""))
     price, source_field = _extract_numeric_price(normalized)
     status_raw = str(normalized.get("data_status") or "").lower()
     diagnostics = normalized.get("diagnostics")
@@ -3640,6 +3685,23 @@ def _normalize_quote_signal(signal: dict[str, Any]) -> dict[str, Any]:
         diagnostics["status_downgrade_reason"] = "market_status_without_numeric_price"
         normalized.setdefault("warning_ru", "Рыночная котировка недоступна или повреждена; используется fallback-статус.")
     normalized["diagnostics"] = diagnostics
+    if symbol:
+        options_snapshot = get_latest_options_levels(symbol)
+        options_available = bool(options_snapshot.get("available"))
+        analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
+        normalized["options_available"] = options_available
+        normalized["options_source"] = options_snapshot.get("source")
+        normalized["options_summary_ru"] = (
+            str(analysis.get("summary_ru") or "").strip()
+            if options_available
+            else "Опционный слой недоступен: нет свежих данных."
+        )
+        normalized["options_analysis"] = analysis if options_available else {"available": False, "source": "unavailable"}
+        market_context = normalized.get("market_context") if isinstance(normalized.get("market_context"), dict) else {}
+        market_context["optionsAnalysis"] = normalized["options_analysis"]
+        market_context["options_available"] = options_available
+        market_context["options_source"] = normalized["options_source"] if options_available else "unavailable"
+        normalized["market_context"] = market_context
     return normalized
 
 

--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -147,7 +147,7 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "available": bool(levels),
-        "source": "mt4_optionsfx",
+        "source": str(entry.get("source") or "mt4_optionsfx"),
         "source_priority": 1,
         "keyLevels": key_levels,
         "keyStrikes": key_levels,
@@ -181,5 +181,5 @@ def get_latest_options_levels(symbol: str) -> dict[str, Any]:
     if stale:
         analysis["available"] = False
         analysis["reason"] = "No MT4 option levels received"
-    source = "mt4_optionsfx" if analysis["available"] else "unavailable"
+    source = str(entry.get("source") or "mt4_optionsfx") if analysis["available"] else "unavailable"
     return {**entry, "analysis": analysis, "available": analysis["available"], "stale": stale, "source": source}

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -296,6 +296,15 @@ class TradeIdeaService:
         hydrated["debug_options_available"] = mt4_available
         hydrated["debug_options_source_selected"] = mt4_source
         if not bool(options_snapshot.get("available")):
+            market_context = hydrated.get("market_context") if isinstance(hydrated.get("market_context"), dict) else {}
+            hydrated["options_available"] = False
+            hydrated["options_source"] = "unavailable"
+            hydrated["options_summary_ru"] = "Опционный слой недоступен: нет свежих данных."
+            hydrated["options_analysis"] = {"available": False, "source": "unavailable"}
+            market_context["optionsAnalysis"] = {"available": False, "source": "unavailable"}
+            market_context["options_available"] = False
+            market_context["options_source"] = "unavailable"
+            hydrated["market_context"] = market_context
             return hydrated
         analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
         source = str(options_snapshot.get("source") or analysis.get("source") or "mt4_optionsfx")
@@ -304,12 +313,12 @@ class TradeIdeaService:
         summary_ru = str(analysis.get("summary_ru") or "").strip()
         market_context = hydrated.get("market_context") if isinstance(hydrated.get("market_context"), dict) else {}
         hydrated["options_analysis"] = analysis
-        hydrated["options_source"] = "mt4_optionsfx"
+        hydrated["options_source"] = source
         hydrated["options_available"] = True
         hydrated["options_summary_ru"] = summary_ru
         market_context["optionsAnalysis"] = analysis
         market_context["options_available"] = True
-        market_context["options_source"] = "mt4_optionsfx"
+        market_context["options_source"] = source
         hydrated["market_context"] = market_context
         return hydrated
 

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -1616,6 +1616,7 @@
         </div>
 
         <div class="box">${escapeHtml(summary)}</div>
+        ${renderOptionsCardSummary(idea)}
         <div class="status-line">
           <span class="badge ${statusView.badgeClass}">${escapeHtml(statusView.icon + " " + statusView.label)}</span>
         </div>
@@ -2773,17 +2774,35 @@
       const strikes = Array.isArray(strikesRaw) ? strikesRaw.join(", ") : (strikesRaw || "—");
       const maxPain = analysis.maxPain ?? idea?.market_context?.options_max_pain ?? "—";
       const bias = analysis.bias || idea.options_bias || "—";
-      const summary = analysis.summary_ru || idea.options_summary_ru || (available ? "Данные MT4 OptionsFX получены." : "Опционный слой CME сейчас недоступен.");
+      const support = Array.isArray(analysis?.barrierZones?.support) ? analysis.barrierZones.support.join(", ") : "—";
+      const resistance = Array.isArray(analysis?.barrierZones?.resistance) ? analysis.barrierZones.resistance.join(", ") : "—";
+      const summary = analysis.summary_ru || idea.options_summary_ru || (available ? "Опционные уровни получены." : "Опционный слой недоступен — нет свежих данных.");
+      if (!available) {
+        return `
+        <div class="modal-section-title">Опционный анализ</div>
+        <div class="box modal-text">Опционный слой недоступен — нет свежих данных.</div>`;
+      }
       return `
-      <div class="modal-section-title">Options Analysis</div>
+      <div class="modal-section-title">Опционный анализ</div>
       <div class="box modal-text">
-        <div><strong>Source:</strong> ${escapeHtml(source)}</div>
-        <div><strong>Status:</strong> ${escapeHtml(status)}</div>
-        <div><strong>Key levels:</strong> ${escapeHtml(String(strikes))}</div>
+        <div><strong>Источник:</strong> ${escapeHtml(source)}</div>
+        <div><strong>Смещение:</strong> ${escapeHtml(String(bias))}</div>
         <div><strong>Max pain:</strong> ${escapeHtml(String(maxPain))}</div>
-        <div><strong>Options bias:</strong> ${escapeHtml(String(bias))}</div>
-        <div><strong>Summary:</strong> ${escapeHtml(String(summary))}</div>
+        <div><strong>Key strikes/levels:</strong> ${escapeHtml(String(strikes))}</div>
+        <div><strong>Barrier support:</strong> ${escapeHtml(String(support))}</div>
+        <div><strong>Barrier resistance:</strong> ${escapeHtml(String(resistance))}</div>
+        <div><strong>Сводка:</strong> ${escapeHtml(String(summary))}</div>
       </div>`;
+    }
+
+    function renderOptionsCardSummary(idea) {
+      const optionsAvailable = Boolean(idea?.options_available);
+      const source = String(idea?.options_source || "unavailable");
+      const summary = String(idea?.options_summary_ru || "").trim();
+      if (!optionsAvailable) {
+        return `<div class="box">Опционный слой недоступен — нет свежих данных.</div>`;
+      }
+      return `<div class="box"><strong>Опционный анализ:</strong> ${escapeHtml(source)} • ${escapeHtml(summary || "Данные получены.")}</div>`;
     }
 
     function normalizeSymbol(value) {

--- a/tests/api/test_options_levels_api.py
+++ b/tests/api/test_options_levels_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import mt4_options_bridge
+
+
+client = TestClient(app)
+
+
+def test_post_options_levels_saves_eurusd_levels() -> None:
+    response = client.post(
+        "/api/options/levels",
+        json={
+            "symbol": "EURUSD",
+            "underlying_price": 1.085,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "source": "mt4_optionsfx",
+            "levels": [
+                {"type": "max_pain", "price": 1.08},
+                {"type": "put", "price": 1.075},
+                {"type": "call", "price": 1.095},
+            ],
+            "metadata": {},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["available"] is True
+    assert payload["saved"]["symbol"] == "EURUSD"
+
+
+def test_get_options_levels_returns_available_true() -> None:
+    response = client.get("/api/options/levels/EURUSD")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["available"] is True
+    assert payload["analysis"]["source"] == "mt4_optionsfx"
+
+
+def test_ideas_market_contains_options_available_after_ingest() -> None:
+    response = client.get("/ideas/market")
+    assert response.status_code == 200
+    ideas = response.json().get("ideas") or []
+    assert any(bool(row.get("options_available")) for row in ideas if row.get("symbol") == "EURUSD")
+
+
+def test_stale_options_become_unavailable_after_ttl(monkeypatch) -> None:
+    monkeypatch.setattr(mt4_options_bridge, "MT4_OPTIONS_LEVELS_TTL_SECONDS", 60)
+    client.post(
+        "/api/options/levels",
+        json={
+            "symbol": "EURUSD",
+            "timestamp": (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(),
+            "source": "manual",
+            "levels": [{"type": "put", "price": 1.07}],
+        },
+    )
+    response = client.get("/api/options/levels/EURUSD")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["available"] is False
+    assert payload["stale"] is True


### PR DESCRIPTION
### Motivation
- Обеспечить стабильный рабочий опционный слой для страницы `/ideas` через простой ingest-путь вместо падений от отсутствия MT4/CME-логики.
- Добавить отладочный API и видимый UI-блок, чтобы оперативно проверять и подпитывать платформу реальными/ручными/MT4 данными без переработки архитектуры.
- Сохранить обратную совместимость с существующим `mt4_options` слоем и не вводить synthetic-данных в production.

### Description
- Добавлены новые backend-маршруты: `POST /api/options/levels` (ingest → вызывает `save_options_levels` и возвращает saved + analysis + available), `GET /api/options/levels/{symbol}` (возвращает `get_latest_options_levels`) и `GET /api/debug/options/{symbol}` (диагностика symbol/available/source/stale/reason/last_updated/analysis/storage_path). (файл: `app/main.py`)
- Исправлено поведение в `mt4_options_bridge`: анализ теперь берёт `source` из получённого entry/payload, а не форсит `mt4_optionsfx`. (файл: `app/services/mt4_options_bridge.py`)
- Обновлён `_hydrate_live_options()` в `TradeIdeaService` так, чтобы при отсутствии данных явно выставлялись `options_available:false`, `options_summary_ru` и `market_context.optionsAnalysis`, а при наличии данных — переносился реальный `source` (не жестко `mt4_optionsfx`). (файл: `app/services/trade_idea_service.py`)
- Интеграция опционного слоя в нормализацию сигналов/идей: при сборке/нормализации сигналов теперь добавляются `options_available`, `options_source`, `options_summary_ru`, `options_analysis` и `market_context.optionsAnalysis`. (файл: `app/main.py`)
- Frontend: добавлен компактный блок «Опционный анализ» в карточке и переработан modal detail-view — показаны `Источник`, `Смещение`/bias, `Max pain`, `Key strikes/levels`, `Barrier support/resistance` и `Сводка`; при отсутствии данных выводится «Опционный слой недоступен — нет свежих данных.». (файл: `app/static/ideas.html`)
- Добавлены тесты интеграции и TTL: `tests/api/test_options_levels_api.py` проверяет POST/GET/ideas-интеграцию и stale-логики. (файл: `tests/api/test_options_levels_api.py`)
- Обновлён `README.md` с краткой инструкцией `curl` для ручной проверки ingest и пояснением про CME scraping vs ingest.
- Изменённые файлы: `app/main.py`, `app/services/mt4_options_bridge.py`, `app/services/trade_idea_service.py`, `app/static/ideas.html`, `tests/api/test_options_levels_api.py`, `README.md`.

### Testing
- Запущены автоматические тесты: `pytest -q tests/api/test_options_levels_api.py tests/test_mt4_options_bridge.py`; все тесты успешно прошли (в результате: 9 passed, 0 failed).
- Локально проверена последовательность ручного ingest → `GET /api/options/levels/EURUSD` → `/ideas/market` и подтверждена видимость `options_available`/`options_summary_ru` в ответах.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f731f4f1f0833193427f2465dd26de)