### PR TITLE
Добавить prop-level derived анализ в MT4 options layer

### DIFF
--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -140,10 +140,14 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
         price = float(underlying)
     except (TypeError, ValueError):
         price = None
-    options_flow = analyze_options(levels, price)
+    options_flow = analyze_options(levels, price, symbol=str(entry.get("symbol") or ""))
     max_pain = options_flow.get("max_pain")
     bias = str(options_flow.get("bias") or "neutral")
     summary_ru = str(options_flow.get("summary_ru") or "Опционные уровни MT4 получены, явного смещения не выявлено.")
+
+    target_levels = options_flow.get("targetLevels") or targets
+    hedge_levels = options_flow.get("hedgeLevels") or hedges
+    derived_levels = options_flow.get("derivedLevels") or []
 
     return {
         "available": bool(levels),
@@ -154,9 +158,18 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
         "maxPain": max_pain,
         "barrierZones": {"support": support, "resistance": resistance},
         "bias": bias,
+        "prop_bias": options_flow.get("prop_bias") or bias,
+        "prop_score": options_flow.get("prop_score") or 0,
+        "pinningRisk": options_flow.get("pinningRisk") or "low",
+        "rangeRisk": options_flow.get("rangeRisk") or "low",
+        "callWalls": options_flow.get("callWalls") or [],
+        "putWalls": options_flow.get("putWalls") or [],
         "summary_ru": summary_ru,
-        "targetLevels": targets,
-        "hedgeLevels": hedges,
+        "targetLevels": target_levels,
+        "hedgeLevels": hedge_levels,
+        "derivedLevels": derived_levels,
+        "straddle": options_flow.get("straddle") or [],
+        "strangle": options_flow.get("strangle") or [],
         "targets_above": options_flow.get("targets_above") or [],
         "targets_below": options_flow.get("targets_below") or [],
         "hedge_above": options_flow.get("hedge_above") or [],

--- a/app/services/options_analysis.py
+++ b/app/services/options_analysis.py
@@ -2,79 +2,188 @@ from __future__ import annotations
 
 from typing import Any
 
+SUPPORTED_TYPES = {
+    "call",
+    "put",
+    "max_pain",
+    "balance",
+    "spread",
+    "straddle",
+    "strangle",
+    "target_volume",
+    "hedge_volume",
+    "gamma_level",
+    "support",
+    "resistance",
+    "key_level",
+}
 
-def analyze_options(levels: list[dict[str, Any]] | None, price: float | int | None) -> dict[str, Any]:
-    rows = levels if isinstance(levels, list) else []
-    parsed_price: float | None
+
+def _safe_float(value: Any) -> float | None:
     try:
-        parsed_price = float(price) if price is not None else None
+        return float(value)
     except (TypeError, ValueError):
-        parsed_price = None
+        return None
 
+
+def analyze_options(levels: list[dict[str, Any]] | None, price: float | int | None, symbol: str = "EURUSD") -> dict[str, Any]:
+    rows = [row for row in (levels or []) if isinstance(row, dict)]
+    parsed_price = _safe_float(price)
+    tolerance = 0.0005 if str(symbol).upper() == "EURUSD" else 0.001
+
+    normalized_rows: list[dict[str, Any]] = []
+    by_type: dict[str, list[dict[str, Any]]] = {}
     max_pain: float | None = None
-    targets_above: list[float] = []
-    targets_below: list[float] = []
-    hedge_above: list[float] = []
-    hedge_below: list[float] = []
 
     for row in rows:
-        if not isinstance(row, dict):
-            continue
         level_type = str(row.get("type") or "").strip().lower()
-        try:
-            level_price = float(row.get("price"))
-        except (TypeError, ValueError):
+        if level_type not in SUPPORTED_TYPES:
             continue
-
+        level_price = _safe_float(row.get("price"))
+        if level_price is None:
+            continue
+        normalized = {**row, "type": level_type, "price": level_price}
+        normalized_rows.append(normalized)
+        by_type.setdefault(level_type, []).append(normalized)
         if level_type == "max_pain" and max_pain is None:
             max_pain = level_price
+
+    def top_levels(candidates: list[dict[str, Any]], *, above: bool) -> list[float]:
         if parsed_price is None:
-            continue
-        if level_type == "target_volume":
-            (targets_above if level_price > parsed_price else targets_below).append(level_price)
-        elif level_type == "hedge_volume":
-            (hedge_above if level_price > parsed_price else hedge_below).append(level_price)
+            return []
+        filtered = [
+            c["price"]
+            for c in candidates
+            if (c["price"] > parsed_price if above else c["price"] < parsed_price)
+        ]
+        filtered = sorted(filtered, key=lambda p: abs(p - parsed_price))
+        return filtered[:3]
+
+    targets_above = top_levels(by_type.get("target_volume", []), above=True)
+    targets_below = top_levels(by_type.get("target_volume", []), above=False)
+    hedge_above = top_levels(by_type.get("hedge_volume", []), above=True)
+    hedge_below = top_levels(by_type.get("hedge_volume", []), above=False)
+
+    derived_levels: list[dict[str, Any]] = []
+
+    if parsed_price is not None and not by_type.get("target_volume"):
+        upper_candidates = by_type.get("call", []) + by_type.get("balance", []) + by_type.get("spread", [])
+        lower_candidates = by_type.get("put", []) + by_type.get("balance", []) + by_type.get("spread", [])
+        targets_above = top_levels(upper_candidates, above=True)
+        targets_below = top_levels(lower_candidates, above=False)
+        for level_price in targets_above + targets_below:
+            derived_levels.append({"type": "target_volume", "price": level_price, "source": "derived_options_engine"})
+
+    if parsed_price is not None and not by_type.get("hedge_volume"):
+        hedge_above = top_levels(by_type.get("call", []) + by_type.get("spread", []), above=True)
+        hedge_below = top_levels(by_type.get("put", []) + by_type.get("spread", []), above=False)
+        for level_price in hedge_above + hedge_below:
+            derived_levels.append({"type": "hedge_volume", "price": level_price, "source": "derived_options_engine"})
+
+    call_prices = sorted(row["price"] for row in by_type.get("call", []))
+    put_prices = sorted(row["price"] for row in by_type.get("put", []))
+
+    has_straddle = bool(by_type.get("straddle"))
+    has_strangle = bool(by_type.get("strangle"))
+
+    if not has_straddle and call_prices and put_prices:
+        for cp in call_prices:
+            strike = next((pp for pp in put_prices if abs(cp - pp) <= tolerance), None)
+            if strike is not None:
+                derived_levels.append({"type": "straddle", "price": cp, "source": "derived_options_engine"})
+                has_straddle = True
+                break
+
+    if parsed_price is not None and not has_strangle and call_prices and put_prices:
+        lower_puts = [p for p in put_prices if p < parsed_price]
+        upper_calls = [c for c in call_prices if c > parsed_price]
+        best_pair: tuple[float, float] | None = None
+        best_distance = float("inf")
+        for p in lower_puts:
+            for c in upper_calls:
+                symmetry_distance = abs((parsed_price - p) - (c - parsed_price))
+                if symmetry_distance < best_distance:
+                    best_distance = symmetry_distance
+                    best_pair = (p, c)
+        if best_pair:
+            lower, upper = best_pair
+            derived_levels.append(
+                {
+                    "type": "strangle",
+                    "price": round((lower + upper) / 2, 6),
+                    "lower": lower,
+                    "upper": upper,
+                    "source": "derived_options_engine",
+                }
+            )
+            has_strangle = True
+
+    call_walls = top_levels(by_type.get("call", []), above=True) if parsed_price is not None else call_prices[:3]
+    put_walls = top_levels(by_type.get("put", []), above=False) if parsed_price is not None else put_prices[:3]
 
     score = 0
     if parsed_price is not None:
         if targets_above:
-            score += 1
-        if hedge_below:
-            score += 1
-        if isinstance(max_pain, (int, float)) and max_pain > parsed_price:
-            score += 1
-
+            score += 2
         if targets_below:
+            score -= 2
+        if put_walls:
+            score += 1
+        if call_walls:
             score -= 1
-        if hedge_above:
-            score -= 1
-        if isinstance(max_pain, (int, float)) and max_pain < parsed_price:
+        if max_pain is not None and max_pain > parsed_price:
+            score += 1
+        elif max_pain is not None and max_pain < parsed_price:
             score -= 1
 
-    bias = "neutral"
-    if score > 0:
-        bias = "bullish"
-    elif score < 0:
-        bias = "bearish"
+    prop_bias = "bullish" if score >= 2 else "bearish" if score <= -2 else "neutral"
 
-    if not rows:
-        summary_ru = "Опционные уровни MT4 недоступны: сценарий рассчитан без options layer."
-    elif parsed_price is None:
-        summary_ru = "Опционные уровни MT4 получены, но текущая цена отсутствует для оценки смещения."
-    else:
-        summary_ru = (
-            f"Опционные уровни указывают на {bias} смещение. "
-            f"Max Pain выступает ориентиром на уровне {max_pain if max_pain is not None else 'n/a'}. "
-            f"Хеджирующие уровни ограничивают движение: выше цены {len(hedge_above)}, ниже цены {len(hedge_below)}."
-        )
+    existing_straddles = [{"type": "straddle", "price": r["price"], "source": r.get("source", "mt4_optionsfx")} for r in by_type.get("straddle", [])]
+    existing_strangles = [
+        {
+            "type": "strangle",
+            "price": r["price"],
+            "lower": r.get("lower"),
+            "upper": r.get("upper"),
+            "source": r.get("source", "mt4_optionsfx"),
+        }
+        for r in by_type.get("strangle", [])
+    ]
+
+    all_straddles = existing_straddles + [d for d in derived_levels if d.get("type") == "straddle"]
+    all_strangles = existing_strangles + [d for d in derived_levels if d.get("type") == "strangle"]
+
+    pinning_risk = "low"
+    if parsed_price is not None and any(abs(item["price"] - parsed_price) <= tolerance for item in all_straddles if isinstance(item.get("price"), (int, float))):
+        pinning_risk = "high"
+
+    range_risk = "low" if not all_strangles else "medium"
+
+    summary_ru = (
+        f"Prop bias: {prop_bias}, score={score}. "
+        f"Call walls: {len(call_walls)}, Put walls: {len(put_walls)}. "
+        f"Pinning risk: {pinning_risk}, Range risk: {range_risk}."
+    ) if normalized_rows else "Опционные уровни MT4 недоступны: сценарий рассчитан без options layer."
 
     return {
-        "available": bool(rows),
+        "available": bool(normalized_rows),
+        "normalized_levels": normalized_rows,
         "max_pain": max_pain,
         "targets_above": sorted(targets_above),
         "targets_below": sorted(targets_below),
         "hedge_above": sorted(hedge_above),
         "hedge_below": sorted(hedge_below),
-        "bias": bias,
+        "bias": prop_bias,
+        "prop_bias": prop_bias,
+        "prop_score": score,
+        "pinningRisk": pinning_risk,
+        "rangeRisk": range_risk,
+        "callWalls": sorted(call_walls),
+        "putWalls": sorted(put_walls),
+        "targetLevels": sorted(set(targets_above + targets_below)),
+        "hedgeLevels": sorted(set(hedge_above + hedge_below)),
+        "derivedLevels": derived_levels,
+        "straddle": all_straddles,
+        "strangle": all_strangles,
         "summary_ru": summary_ru,
     }

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -212,6 +212,14 @@ function renderIdeaCard(idea) {
   const providerLabel = String(idea.data_provider || "").toLowerCase() === "twelvedata" ? "TwelveData" : "Yahoo fallback";
   const warningText = String(idea.warning || "").trim();
   const sentiment = idea?.sentiment || {};
+  const optionsAnalysis = idea?.options_analysis || {};
+  const renderLevels = (arr) => Array.isArray(arr) && arr.length ? arr.join(", ") : "—";
+  const straddleText = Array.isArray(optionsAnalysis.straddle) && optionsAnalysis.straddle.length
+    ? optionsAnalysis.straddle.map((x) => x.price).join(", ")
+    : "—";
+  const strangleText = Array.isArray(optionsAnalysis.strangle) && optionsAnalysis.strangle.length
+    ? optionsAnalysis.strangle.map((x) => `${x.lower ?? "?"}-${x.upper ?? "?"}`).join(", ")
+    : "—";
   const hasSentiment = Number.isFinite(Number(sentiment.long_pct)) && Number.isFinite(Number(sentiment.short_pct));
   const sentimentLabel = hasSentiment
     ? `Sentiment: Long ${Number(sentiment.long_pct)}% / Short ${Number(sentiment.short_pct)}%`
@@ -253,6 +261,23 @@ function renderIdeaCard(idea) {
           <li><strong>Цель 1:</strong> ${escapeHtml(tradePlan.target_1 || "")}</li>
           <li><strong>Цель 2:</strong> ${escapeHtml(tradePlan.target_2 || "")}</li>
           <li><strong>Альтернатива:</strong> ${escapeHtml(tradePlan.alternative_scenario_ru || "")}</li>
+        </ul>
+      </section>
+
+
+      <section class="idea-section idea-section-plan">
+        <h4>Prop-level options</h4>
+        <ul class="trade-plan-list">
+          <li><strong>Prop bias:</strong> ${escapeHtml(optionsAnalysis.prop_bias || optionsAnalysis.bias || "neutral")}</li>
+          <li><strong>Score:</strong> ${escapeHtml(optionsAnalysis.prop_score ?? 0)}</li>
+          <li><strong>Call walls:</strong> ${escapeHtml(renderLevels(optionsAnalysis.callWalls))}</li>
+          <li><strong>Put walls:</strong> ${escapeHtml(renderLevels(optionsAnalysis.putWalls))}</li>
+          <li><strong>Target zones:</strong> ${escapeHtml(renderLevels(optionsAnalysis.targetLevels))}</li>
+          <li><strong>Hedge zones:</strong> ${escapeHtml(renderLevels(optionsAnalysis.hedgeLevels))}</li>
+          <li><strong>Straddle:</strong> ${escapeHtml(straddleText)}</li>
+          <li><strong>Strangle:</strong> ${escapeHtml(strangleText)}</li>
+          <li><strong>Pinning risk:</strong> ${escapeHtml(optionsAnalysis.pinningRisk || "low")}</li>
+          <li><strong>Range risk:</strong> ${escapeHtml(optionsAnalysis.rangeRisk || "low")}</li>
         </ul>
       </section>
 

--- a/tests/test_mt4_options_bridge.py
+++ b/tests/test_mt4_options_bridge.py
@@ -47,3 +47,58 @@ def test_empty_levels_are_safe():
     save_options_levels({"symbol": "AUDUSD", "levels": []})
     payload = get_latest_options_levels("AUDUSD")
     assert payload["available"] is False
+
+
+def test_derived_straddle_from_call_put_same_strike():
+    save_options_levels({
+        "symbol": "EURUSD",
+        "underlying_price": 1.1000,
+        "levels": [
+            {"type": "call", "price": 1.1010},
+            {"type": "put", "price": 1.1010},
+        ],
+    })
+    payload = get_latest_options_levels("EURUSD")
+    assert any(item.get("type") == "straddle" for item in payload["analysis"]["derivedLevels"])
+
+
+def test_derived_strangle_around_price():
+    save_options_levels({
+        "symbol": "EURUSD",
+        "underlying_price": 1.1000,
+        "levels": [
+            {"type": "put", "price": 1.0990},
+            {"type": "call", "price": 1.1010},
+        ],
+    })
+    payload = get_latest_options_levels("EURUSD")
+    assert any(item.get("type") == "strangle" for item in payload["analysis"]["derivedLevels"])
+
+
+def test_derived_hedge_levels_from_call_and_put():
+    save_options_levels({
+        "symbol": "EURUSD",
+        "underlying_price": 1.1000,
+        "levels": [
+            {"type": "call", "price": 1.1020},
+            {"type": "put", "price": 1.0980},
+        ],
+    })
+    payload = get_latest_options_levels("EURUSD")
+    analysis = payload["analysis"]
+    assert 1.102 in analysis["hedge_above"]
+    assert 1.098 in analysis["hedge_below"]
+
+
+def test_derived_target_levels_when_mt4_missing_target_volume():
+    save_options_levels({
+        "symbol": "EURUSD",
+        "underlying_price": 1.1000,
+        "levels": [
+            {"type": "call", "price": 1.1030},
+            {"type": "put", "price": 1.0970},
+            {"type": "balance", "price": 1.1015},
+        ],
+    })
+    payload = get_latest_options_levels("EURUSD")
+    assert payload["analysis"]["targetLevels"]


### PR DESCRIPTION
### Motivation
- Усилить опционный слой MT4 аналитикой уровня проп-деск, добавив производные уровни и скоринг, при этом не ломая текущий ingest.
- Заполнить отсутствующие поля (`target_volume`, `hedge_volume`, `straddle`, `strangle`) синтетическими значениями, когда их не прислал MT4.
- Сделать данные понятными для фронтенда и идей: явные поля для bias/score/стен/рисков и русскоязычное summary.

### Description
- Расширен `analyze_options` в `app/services/options_analysis.py` для нормализации набора типов (`call`, `put`, `max_pain`, `balance`, `spread`, `straddle`, `strangle`, `target_volume`, `hedge_volume`, `gamma_level`, `support`, `resistance`, `key_level`) и добавлена безопасная конверсия цен.
- Добавлены производные уровни: при отсутствии `target_volume` и/или `hedge_volume` формируются `targetLevels` и `hedgeLevels` из ближайших сильных `call`/`put`/`balance`/`spread` и помечаются как `source: "derived_options_engine"`.
- Реализованы выводы `straddle` (совпадающие strike с tolerance 0.0005 для EURUSD) и `strangle` (симметричная пара вокруг `underlying_price`), и добавлены поля `derivedLevels`, `straddle`, `strangle`.
- Введён prop-level скоринг (`prop_score`) и классификация `prop_bias`, а также риски `pinningRisk` и `rangeRisk`, вычисление `callWalls`/`putWalls` и формирование `summary_ru`.
- Обновлён bridge `app/services/mt4_options_bridge.py` чтобы вызывать `analyze_options(..., symbol=...)` и вернуть новые поля в `analysis` без изменения контрактов ingest (`available` по-прежнему определяется наличием уровней).
- Обновлён UI `app/static/ideas.js` для отображения Prop bias, Score, Call/Put walls, Target/Hedge zones, Straddle/Strangle и Pinning/Range risk в карточке идеи.
- Добавлены автоматизированные тесты в `tests/test_mt4_options_bridge.py` на derivation: `straddle`, `strangle`, `hedge_above`/`hedge_below`, и создание `targetLevels` при отсутствии исходного `target_volume`.

### Testing
- Запущено `pytest -q tests/test_mt4_options_bridge.py`, все тесты прошли успешно: `9 passed`.
- Изменения покрыты тестами, существующий ingest и поведение `get_latest_options_levels` и endpointов не нарушены по результатам тестов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74b7426188331b2d16bcd8d417ce0)