### PR TITLE
Фикс lifecycle /ideas: блокировка active-полей и корректная статистика закрытых идей

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -44,6 +44,19 @@ IDEA_STATUS_ARCHIVED = "archived"
 ACTIVE_STATUSES = {IDEA_STATUS_CREATED, IDEA_STATUS_WAITING, IDEA_STATUS_TRIGGERED, IDEA_STATUS_ACTIVE}
 CLOSED_STATUSES = {IDEA_STATUS_TP_HIT, IDEA_STATUS_SL_HIT, IDEA_STATUS_ARCHIVED}
 TERMINAL_STATUSES = {IDEA_STATUS_TP_HIT, IDEA_STATUS_SL_HIT}
+LOCKED_ACTIVE_FIELDS = {
+    "signal",
+    "action",
+    "entry",
+    "stop_loss",
+    "stopLoss",
+    "take_profit",
+    "takeProfit",
+    "direction",
+    "idea_id",
+    "created_at",
+    "activated_at",
+}
 ALLOWED_LIFECYCLE_TRANSITIONS = {
     IDEA_STATUS_CREATED: {IDEA_STATUS_WAITING},
     IDEA_STATUS_WAITING: {IDEA_STATUS_TRIGGERED},
@@ -974,6 +987,8 @@ class TradeIdeaService:
                 return IDEA_STATUS_SL_HIT
             if entry is not None and latest_close >= entry:
                 return IDEA_STATUS_ACTIVE if existing_status in {IDEA_STATUS_TRIGGERED, IDEA_STATUS_ACTIVE} else IDEA_STATUS_TRIGGERED
+            if existing_status == IDEA_STATUS_ACTIVE:
+                return IDEA_STATUS_ACTIVE
             return IDEA_STATUS_WAITING if existing_status in {IDEA_STATUS_CREATED, IDEA_STATUS_WAITING} else existing_status
         if direction == "bearish":
             if take_profit is not None and latest_close <= take_profit:
@@ -982,7 +997,11 @@ class TradeIdeaService:
                 return IDEA_STATUS_SL_HIT
             if entry is not None and latest_close <= entry:
                 return IDEA_STATUS_ACTIVE if existing_status in {IDEA_STATUS_TRIGGERED, IDEA_STATUS_ACTIVE} else IDEA_STATUS_TRIGGERED
+            if existing_status == IDEA_STATUS_ACTIVE:
+                return IDEA_STATUS_ACTIVE
             return IDEA_STATUS_WAITING if existing_status in {IDEA_STATUS_CREATED, IDEA_STATUS_WAITING} else existing_status
+        if existing_status == IDEA_STATUS_ACTIVE:
+            return IDEA_STATUS_ACTIVE
         return IDEA_STATUS_WAITING if existing_status in {IDEA_STATUS_CREATED, IDEA_STATUS_WAITING} else existing_status
 
     @staticmethod
@@ -1757,7 +1776,7 @@ class TradeIdeaService:
             signal=signal,
         )
         updates = self._history_to_updates(history)
-        persisted_status = IDEA_STATUS_ARCHIVED if is_terminal else status
+        persisted_status = status
         existing_narrative_version = int(existing.get("narrative_version") or 1) if existing else 0
         narrative_version = existing_narrative_version + 1 if should_refresh_narrative else max(existing_narrative_version, 1)
         narrative_history = self._append_narrative_history(
@@ -1833,7 +1852,9 @@ class TradeIdeaService:
             "updated_at": now.isoformat(),
             "internal_refresh_at": now.isoformat(),
             "closed_at": closed_at,
+            "activated_at": existing.get("activated_at") if existing else None,
             "close_reason": close_reason,
+            "close_reason_ru": self._close_reason_ru(status) if is_terminal else existing.get("close_reason_ru") if existing else None,
             "close_explanation": close_explanation,
             "version": version,
             "change_summary": self._change_summary(signal, existing),
@@ -1941,6 +1962,18 @@ class TradeIdeaService:
                 "fallback_used": pipeline["fallback_used"],
             },
         }
+        if status == IDEA_STATUS_ACTIVE and not payload.get("activated_at"):
+            payload["activated_at"] = now.isoformat()
+        if is_terminal:
+            payload["close_price"] = latest_close
+            payload["result"] = "tp" if status == IDEA_STATUS_TP_HIT else "sl" if status == IDEA_STATUS_SL_HIT else payload.get("result")
+        payload["lifecycle_history"] = self._append_lifecycle_history(
+            existing.get("lifecycle_history") if existing else None,
+            previous_status=str((existing or {}).get("status") or "").lower() if existing else "",
+            next_status=status,
+            at=now.isoformat(),
+        )
+        payload = self._preserve_locked_active_fields(existing=existing, payload=payload)
         payload = self._apply_meaningful_update_metadata(
             existing=existing,
             signal=signal,
@@ -3823,10 +3856,10 @@ class TradeIdeaService:
 
         if final_status == IDEA_STATUS_TP_HIT:
             exit_price = take_profit
-            result = "win"
+            result = "tp"
         elif final_status == IDEA_STATUS_SL_HIT:
             exit_price = stop_loss
-            result = "loss"
+            result = "sl"
         else:
             exit_price = latest_close
             result = "breakeven"
@@ -4133,6 +4166,36 @@ class TradeIdeaService:
             IDEA_STATUS_TP_HIT: "TP reached",
             IDEA_STATUS_SL_HIT: "SL reached",
         }.get(status)
+
+    @staticmethod
+    def _close_reason_ru(status: str) -> str | None:
+        return {
+            IDEA_STATUS_TP_HIT: "Закрыто по тейк-профиту.",
+            IDEA_STATUS_SL_HIT: "Закрыто по стоп-лоссу.",
+        }.get(status)
+
+    @staticmethod
+    def _append_lifecycle_history(
+        history: Any,
+        *,
+        previous_status: str,
+        next_status: str,
+        at: str,
+    ) -> list[dict[str, str]]:
+        items = list(history) if isinstance(history, list) else []
+        if previous_status and previous_status != next_status:
+            reason = "entry_triggered" if next_status == IDEA_STATUS_ACTIVE else "status_changed"
+            items.append({"from": previous_status, "to": next_status, "at": at, "reason": reason})
+        return items
+
+    @staticmethod
+    def _preserve_locked_active_fields(*, existing: dict[str, Any] | None, payload: dict[str, Any]) -> dict[str, Any]:
+        if not existing or str(existing.get("status") or "").lower() != IDEA_STATUS_ACTIVE:
+            return payload
+        for field in LOCKED_ACTIVE_FIELDS:
+            if field in existing:
+                payload[field] = existing.get(field)
+        return payload
 
     @staticmethod
     def _build_close_explanation(*, status: str, symbol: str, direction: str, target: str, invalidation: str) -> str:

--- a/app/services/trade_idea_stats_service.py
+++ b/app/services/trade_idea_stats_service.py
@@ -5,7 +5,7 @@ from typing import Any
 
 
 class TradeIdeaStatsService:
-    CLOSED_FINAL_STATUSES = {"tp_hit", "sl_hit", "invalidated"}
+    CLOSED_FINAL_STATUSES = {"tp_hit", "sl_hit"}
 
     @classmethod
     def aggregate(cls, ideas: list[dict[str, Any]]) -> dict[str, float | int]:
@@ -14,11 +14,14 @@ class TradeIdeaStatsService:
         rr_values = [float(idea["rr"]) for idea in closed if cls._is_number(idea.get("rr"))]
 
         total = len(closed)
-        wins = sum(1 for idea in closed if idea.get("result") == "win")
-        losses = sum(1 for idea in closed if idea.get("result") == "loss")
+        wins = sum(1 for idea in closed if str(idea.get("result") or "").lower() in {"tp", "win"})
+        losses = sum(1 for idea in closed if str(idea.get("result") or "").lower() in {"sl", "loss"})
         winrate = (wins / total * 100) if total else 0.0
 
         return {
+            "total": total,
+            "tp_count": wins,
+            "sl_count": losses,
             "total_trades": total,
             "wins": wins,
             "losses": losses,

--- a/tests/test_idea_update.py
+++ b/tests/test_idea_update.py
@@ -98,20 +98,20 @@ def test_trade_idea_archives_on_tp_and_keeps_history(tmp_path: Path) -> None:
     payload = service.refresh_market_ideas()
 
     assert created["idea_id"] == updated["idea_id"] == archived["idea_id"]
-    assert archived["status"] == "archived"
+    assert archived["status"] == "tp_hit"
     assert archived["final_status"] == "tp_hit"
     assert archived["close_reason"] == "TP reached"
     assert archived["closed_at"] is not None
     assert len(payload["ideas"]) == 0
     assert len(payload["archive"]) == 1
-    assert archived["result"] == "win"
+    assert archived["result"] == "tp"
     assert archived["entry_price"] == 1.082
     assert archived["exit_price"] == 1.088
     assert archived["pnl_percent"] > 0
     assert archived["rr"] == 2.0
     assert archived["duration"] is not None
-    assert payload["statistics"]["total_trades"] == 1
-    assert payload["statistics"]["wins"] == 1
+    assert payload["statistics"]["total"] == 1
+    assert payload["statistics"]["tp_count"] == 1
     assert payload["statistics"]["winrate"] == 100.0
     history_types = [item["type"] for item in archived["history"]]
     assert "tp_hit" in history_types
@@ -189,7 +189,7 @@ def test_no_trade_does_not_reopen_closed_lifecycle(tmp_path: Path) -> None:
     ideas = service.idea_store.read()["ideas"]
     assert len(ideas) == 1
     assert unchanged["idea_id"] == closed["idea_id"]
-    assert unchanged["status"] == "archived"
+    assert unchanged["status"] == "tp_hit"
     assert unchanged["final_status"] == "tp_hit"
 
 
@@ -228,6 +228,30 @@ def test_active_and_triggered_do_not_return_to_waiting(tmp_path: Path) -> None:
     assert first["status"] in {"triggered", "active", "created", "waiting"}
     if first["status"] in {"triggered", "active"}:
         assert second["status"] == first["status"]
+
+
+def test_active_locked_fields_do_not_change_on_refresh(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    base = {"symbol": "EURUSD", "timeframe": "H1", "action": "BUY", "entry": 1.1, "stop_loss": 1.09, "take_profit": 1.12, "latest_close": 1.101, "reason_ru": "x"}
+    active = service.upsert_trade_idea(base)
+    active = service.upsert_trade_idea({**base, "latest_close": 1.102})
+    refreshed = service.upsert_trade_idea({**base, "entry": 1.2, "stop_loss": 1.0, "take_profit": 1.3, "action": "SELL"})
+    if active["status"] == "active":
+        assert refreshed["entry"] == active["entry"]
+        assert refreshed["stop_loss"] == active["stop_loss"]
+        assert refreshed["take_profit"] == active["take_profit"]
+
+
+def test_statistics_count_only_closed(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    open_idea = {"symbol": "EURUSD", "timeframe": "H1", "action": "BUY", "entry": 1.1, "stop_loss": 1.09, "take_profit": 1.12, "latest_close": 1.095, "reason_ru": "x"}
+    service.upsert_trade_idea(open_idea)
+    closed_base = {"symbol": "GBPUSD", "timeframe": "H1", "action": "SELL", "entry": 1.25, "stop_loss": 1.255, "take_profit": 1.24, "latest_close": 1.249, "reason_ru": "x"}
+    service.upsert_trade_idea(closed_base)
+    service.upsert_trade_idea({**closed_base, "latest_close": 1.239})
+    payload = service.refresh_market_ideas()
+    assert payload["statistics"]["total"] == 1
+    assert payload["statistics"]["tp_count"] == 1
 
 
 def test_zero_levels_do_not_override_existing(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Исправить некорректный lifecycle, при котором `active` идея могла откатиться в `waiting/created/triggered` и её уровни (entry/SL/TP) менялись после активации.
- Гарантировать, что после активации ключевые поля не изменяются и что `active` может перейти только в `tp_hit`/`sl_hit`.
- Считать статистику только по действительно закрытым сделкам и добавить историю переходов lifecycle.

### Description
- Добавлен набор заблокированных полей `LOCKED_ACTIVE_FIELDS` и функция `_preserve_locked_active_fields` для сохранения этих полей при обновлениях для уже `active` идеи (`signal/action`, `entry`, `stop_loss/stopLoss`, `take_profit/takeProfit`, `direction`, `idea_id`, `created_at`, `activated_at`).
- В логике live-price `_status_from_live_price` защищён возврат `active → waiting` и обеспечена неизменяемость статуса `active` вне переходов в `tp_hit`/`sl_hit`.
- При сборке payload для идеи добавлены/уточнены поля: `activated_at`, `close_reason_ru`, `close_price`, `result` (`"tp"`/`"sl"`) и `lifecycle_history` (запись переходов вида `{from,to,at,reason}`).
- Изменено поведение сохранения статуса: теперь `persisted_status` оставляется как вычисленный `status` (т.е. `tp_hit`/`sl_hit` оставляются терминальными статусами) и terminal-поля заполняются корректно.
- В `_attach_trade_result_metrics` значение `result` при закрытии теперь устанавливается в `"tp"`/`"sl"` вместо `"win"`/`"loss"`.
- Обновлён `TradeIdeaStatsService`: закрытые статусы ограничены `tp_hit`/`sl_hit`, агрегат теперь возвращает дополнительные ключи `total`, `tp_count`, `sl_count` и при подсчёте учитываются новые значения `result`.
- Тесты `tests/test_idea_update.py` обновлены/добавлены assertions для нового контрактa (`status == tp_hit`, `result == tp`, статистика через `total`/`tp_count`) и добавлены тесты на то, что locked-поля не меняются и что статистика считает только закрытые сделки.
- Изменённые файлы: `app/services/trade_idea_service.py`, `app/services/trade_idea_stats_service.py`, `tests/test_idea_update.py`.

### Testing
- Запущено `pytest -q tests/test_idea_update.py`, результат: сборка тестов прервана на этапе импорта из-за существующей синтаксической ошибки в `app/services/chart_snapshot_service.py` (`from **future** import annotations`), которая не связана с внесёнными изменениями и блокирует выполнение тестов в текущем окружении (ошибка импорта).
- Локальные изменения тестов и кода закоммичены, ожидается прохождение тестов после исправления указанной синтаксической ошибки в импорте зависимого модуля.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75427b9148331bbe00bda0dacd76f)