### PR TITLE
Смягчение парсинга LLM в IdeaNarrativeLLMService и добавление метаданных

### DIFF
--- a/app/services/idea_narrative_llm.py
+++ b/app/services/idea_narrative_llm.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
-REQUIRED_TEXT_FIELDS = (
+TEXT_FIELDS = (
     "idea_thesis",
     "headline",
     "summary",
@@ -36,7 +36,7 @@ REQUIRED_TEXT_FIELDS = (
     "execution_context",
 )
 
-REQUIRED_STRUCTURED_FIELDS = {
+STRUCTURED_FIELDS = {
     "summary_structured": (
         "signal",
         "situation",
@@ -102,7 +102,13 @@ class IdeaNarrativeLLMService:
 
         if not self.api_key:
             logger.warning("idea_narrative_llm_missing_api_key")
-            return NarrativeResult(data=fallback, source="fallback", error="idea_narrative_llm_missing_api_key", model=self.model, generated_at=datetime.now(timezone.utc).isoformat())
+            return NarrativeResult(
+                data=self._attach_narrative_meta(fallback, source="fallback", model=self.model, error="idea_narrative_llm_missing_api_key"),
+                source="fallback",
+                error="idea_narrative_llm_missing_api_key",
+                model=self.model,
+                generated_at=datetime.now(timezone.utc).isoformat(),
+            )
 
         payload = {
             "event_type": event_type,
@@ -120,17 +126,25 @@ class IdeaNarrativeLLMService:
             article=self._request_llm_article(payload=payload)
             if article:
                 first["idea_article_ru"]=article
-            return NarrativeResult(data=first, source="llm", model=self.model, generated_at=generated_at)
+            source = str(first.get("narrative_source") or "llm")
+            return NarrativeResult(data=self._attach_narrative_meta(first, source=source, model=self.model), source=source, model=self.model, generated_at=generated_at)
 
         second = self._request_llm(prompt=self._build_prompt(payload, strict=True))
         if second:
             article=self._request_llm_article(payload=payload)
             if article:
                 second["idea_article_ru"]=article
-            return NarrativeResult(data=second, source="llm", model=self.model, generated_at=generated_at)
+            source = str(second.get("narrative_source") or "llm")
+            return NarrativeResult(data=self._attach_narrative_meta(second, source=source, model=self.model), source=source, model=self.model, generated_at=generated_at)
 
         logger.warning("idea_narrative_llm_fallback_used event_type=%s", event_type)
-        return NarrativeResult(data=fallback, source="fallback", error="idea_narrative_llm_invalid_json_or_quality", model=self.model, generated_at=generated_at)
+        return NarrativeResult(
+            data=self._attach_narrative_meta(fallback, source="fallback", model=self.model, error="idea_narrative_llm_invalid_json_or_quality"),
+            source="fallback",
+            error="idea_narrative_llm_invalid_json_or_quality",
+            model=self.model,
+            generated_at=generated_at,
+        )
 
     def _request_llm(self, *, prompt: str) -> dict[str, Any] | None:
         for idx, model_used in enumerate(self._model_sequence()):
@@ -274,46 +288,59 @@ class IdeaNarrativeLLMService:
         try:
             raw = json.loads(text)
         except json.JSONDecodeError:
-            return None
+            return {"idea_article_ru": self._clean_visible_text(text), "narrative_source": "llm_text"}
 
         if not isinstance(raw, dict):
-            return None
+            return {"idea_article_ru": self._clean_visible_text(text), "narrative_source": "llm_text"}
 
         result: dict[str, Any] = {}
 
-        for field in REQUIRED_TEXT_FIELDS:
+        for field in TEXT_FIELDS:
             value = raw.get(field)
-            if not isinstance(value, str) or not value.strip():
-                return None
-            result[field] = self._clean_visible_text(value)
+            if isinstance(value, str) and value.strip():
+                result[field] = self._clean_visible_text(value)
 
-        for group_name, fields in REQUIRED_STRUCTURED_FIELDS.items():
+        for group_name, fields in STRUCTURED_FIELDS.items():
             group = raw.get(group_name)
             if not isinstance(group, dict):
-                return None
+                continue
 
             cleaned_group: dict[str, str] = {}
             for field in fields:
                 value = group.get(field)
-                if not isinstance(value, str) or not value.strip():
-                    return None
-                cleaned_group[field] = self._clean_visible_text(value)
+                if isinstance(value, str) and value.strip():
+                    cleaned_group[field] = self._clean_visible_text(value)
+            if cleaned_group:
+                result[group_name] = cleaned_group
 
-            result[group_name] = cleaned_group
+        if not result.get("unified_narrative") and result.get("full_text"):
+            result["unified_narrative"] = result["full_text"]
+        if not result.get("unified_narrative") and result.get("summary"):
+            result["unified_narrative"] = result["summary"]
+        if not result.get("unified_narrative") and result.get("idea_article_ru"):
+            result["unified_narrative"] = result["idea_article_ru"]
+        if not result.get("unified_narrative"):
+            return {"idea_article_ru": self._clean_visible_text(text), "narrative_source": "llm_text"}
 
         signal = str(raw.get("signal") or "").strip().upper()
         result["signal"] = signal if signal in {"BUY", "SELL", "WAIT"} else "WAIT"
-        result["risk_note"] = self._clean_visible_text(raw.get("risk_note") or result["risk"])
-
-        if not self._quality_ok(result):
-            return None
+        result["risk_note"] = self._clean_visible_text(raw.get("risk_note") or result.get("risk") or "Риск требует ручной проверки.")
+        result["narrative_source"] = "llm"
 
         return result
+
+    @staticmethod
+    def _attach_narrative_meta(data: dict[str, Any], *, source: str, model: str | None, error: str | None = None) -> dict[str, Any]:
+        payload = dict(data or {})
+        payload["narrative_source"] = source
+        payload["narrative_model"] = model
+        payload["narrative_error"] = error
+        return payload
 
     def _quality_ok(self, data: dict[str, Any]) -> bool:
         joined = " ".join(
             str(data.get(field) or "")
-            for field in REQUIRED_TEXT_FIELDS
+            for field in TEXT_FIELDS
         ).casefold()
 
         banned = (

--- a/tests/narrative/test_idea_narrative_llm.py
+++ b/tests/narrative/test_idea_narrative_llm.py
@@ -47,7 +47,7 @@ def test_parse_valid_llm_json(monkeypatch) -> None:
     assert result.data["headline"] == "EURUSD H1 long"
 
 
-def test_invalid_json_retries_once(monkeypatch) -> None:
+def test_invalid_json_uses_llm_text(monkeypatch) -> None:
     service = IdeaNarrativeLLMService()
     service.api_key = "test"
     calls = {"n": 0}
@@ -60,11 +60,12 @@ def test_invalid_json_retries_once(monkeypatch) -> None:
     monkeypatch.setattr("requests.post", _post)
     result = service.generate(event_type="idea_updated", facts={"symbol": "EURUSD"})
 
-    assert calls["n"] >= 2
-    assert result.source == "llm"
+    assert calls["n"] >= 1
+    assert result.source == "llm_text"
+    assert result.data["idea_article_ru"] == "not-json"
 
 
-def test_fallback_after_invalid_retry(monkeypatch) -> None:
+def test_plain_text_response_is_not_fallback(monkeypatch) -> None:
     service = IdeaNarrativeLLMService()
     service.api_key = "test"
 
@@ -77,13 +78,11 @@ def test_fallback_after_invalid_retry(monkeypatch) -> None:
         facts={"symbol": "EURUSD", "timeframe": "H1", "direction": "bullish", "status": "active"},
     )
 
-    assert result.source == "fallback"
-    assert "EURUSD" in result.data["full_text"]
-    assert "LLM-анализ недоступен" not in result.data["full_text"]
-    assert "ликвидности" in result.data["unified_narrative"].lower()
+    assert result.source == "llm_text"
+    assert result.data["idea_article_ru"] == "still-invalid"
 
 
-def test_rejects_banned_phrase_and_retries(monkeypatch) -> None:
+def test_partial_json_is_used_without_full_reject(monkeypatch) -> None:
     service = IdeaNarrativeLLMService()
     service.api_key = "test"
     calls = {"n": 0}
@@ -106,11 +105,11 @@ def test_rejects_banned_phrase_and_retries(monkeypatch) -> None:
     monkeypatch.setattr("requests.post", _post)
     result = service.generate(event_type="idea_updated", facts={"symbol": "EURUSD"})
 
-    assert calls["n"] >= 2
+    assert calls["n"] >= 1
     assert result.source == "llm"
 
 
-def test_rejects_missing_cause_effect_chain_and_retries(monkeypatch) -> None:
+def test_json_without_strict_quality_checks_is_used(monkeypatch) -> None:
     service = IdeaNarrativeLLMService()
     service.api_key = "test"
     calls = {"n": 0}
@@ -137,7 +136,7 @@ def test_rejects_missing_cause_effect_chain_and_retries(monkeypatch) -> None:
     monkeypatch.setattr("requests.post", _post)
     result = service.generate(event_type="idea_updated", facts={"symbol": "EURUSD"})
 
-    assert calls["n"] >= 2
+    assert calls["n"] >= 1
     assert result.source == "llm"
 
 


### PR DESCRIPTION
### Motivation
- LLM часто возвращает неидеальный JSON или простой текст, и текущая жёсткая валидация переводила такие ответы в полный `fallback`.
- Нужно использовать любую адекватную генерацию LLM и уходить в `fallback` только при пустом ответе, ошибке запроса или отсутствии API-ключа.

### Description
- Смягчена обработка ответа в `IdeaNarrativeLLMService`: при ошибке парсинга JSON или при ответе обычным текстом теперь возвращается `{"idea_article_ru": raw_text}` и источник помечается как `narrative_source: "llm_text"` вместо полного `fallback`.
- Частично валидный JSON принимается: доступные поля из `TEXT_FIELDS` и группы из `STRUCTURED_FIELDS` используются, отсутствующие поля больше не приводят к полному отклонению, и `unified_narrative` восстанавливается из `full_text`/`summary`/`idea_article_ru`, если нужно.
- Убрана строгая проверка наличия всех обязательных текстовых полей на этапе парсинга; теперь достаточно наличия narrative-контента для использования результата LLM.
- Добавлена функция `_attach_narrative_meta` и внедрены метаданные в выходной payload: `narrative_source` (`llm`, `llm_text`, `fallback`), `narrative_model`, `narrative_error`, и эти поля проставляются во всех ветках `generate()` (успех, отсутствие API key, fallback).
- Обновлены тесты, чтобы отразить новую стратегию обработки неидеального вывода LLM (`tests/narrative/test_idea_narrative_llm.py`).

### Testing
- Запущены модульные тесты для сервиса: `pytest -q tests/narrative/test_idea_narrative_llm.py` — все тесты прошли (`6 passed`).
- Изменённые тесты проверяют, что невалидный JSON и plain text используются как `llm_text`, а частичный JSON принимается как `llm`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77a658c048331a88a3edf6732e0a8)