### PR TITLE
Добавить endpoint и UI для массовой перегенерации narrative через Grok/OpenRouter

### DIFF
--- a/app/api/ideas_routes.py
+++ b/app/api/ideas_routes.py
@@ -221,4 +221,9 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
         logger.info("ideas_assets_admin_backfill_started")
         return services.trade_idea_service.rebuild_missing_idea_assets(force=True)
 
+    @router.post("/api/ideas/regenerate-all-narratives")
+    async def regenerate_all_narratives():
+        logger.info("ideas_narrative_regenerate_all_started")
+        return services.trade_idea_service.regenerate_all_narratives()
+
     return router

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -3372,6 +3372,56 @@ class TradeIdeaService:
             "missing_structured_after": missing_structured_count,
         }
 
+    def regenerate_all_narratives(self) -> dict[str, Any]:
+        payload = self.idea_store.read()
+        ideas = payload.get("ideas") if isinstance(payload.get("ideas"), list) else []
+        if not ideas:
+            self.legacy_store.write({"updated_at_utc": datetime.now(timezone.utc).isoformat(), "ideas": [], "archive": [], "statistics": {}})
+            return {"ok": True, "updated": 0, "total": 0}
+        now_iso = datetime.now(timezone.utc).isoformat()
+        updated_total = 0
+        refreshed: list[dict[str, Any]] = []
+        for idea_raw in ideas:
+            idea = dict(idea_raw) if isinstance(idea_raw, dict) else {}
+            try:
+                facts = self._build_narrative_facts(
+                    signal=idea,
+                    symbol=str(idea.get("symbol") or "").upper(),
+                    timeframe=str(idea.get("timeframe") or "H1").upper(),
+                    direction=str(idea.get("direction") or "neutral").lower(),
+                    status=str(idea.get("status") or IDEA_STATUS_ACTIVE).lower(),
+                    rationale=str(idea.get("description_ru") or idea.get("reason_ru") or ""),
+                    existing=idea,
+                    normalized_candles=[],
+                    chart_overlays={},
+                )
+                result = self.narrative_llm.generate(
+                    event_type="manual_regenerate_all_narratives",
+                    facts=facts,
+                    previous_summary=str(idea.get("summary_ru") or idea.get("summary") or ""),
+                    delta={},
+                )
+                candidate_text = self._sanitize_user_narrative_text(
+                    result.data.get("idea_article_ru") or result.data.get("unified_narrative") or result.data.get("full_text")
+                )
+                if candidate_text:
+                    idea["idea_article_ru"] = candidate_text
+                    idea["unified_narrative"] = candidate_text
+                idea["narrative_source"] = str(result.data.get("narrative_source") or result.source or "llm")
+                idea["narrative_model"] = result.model
+                idea["narrative_error"] = result.error
+                idea["updated_at"] = now_iso
+                updated_total += 1
+            except Exception as exc:
+                logger.exception("idea_manual_narrative_regeneration_failed")
+                idea["narrative_source"] = "fallback"
+                idea["narrative_model"] = get_openrouter_model()
+                idea["narrative_error"] = f"manual_regenerate_failed:{type(exc).__name__}"
+            refreshed.append(idea)
+        self.idea_store.write({"updated_at_utc": now_iso, "ideas": refreshed})
+        self.refresh_market_ideas()
+        return {"ok": True, "updated": updated_total, "total": len(refreshed)}
+
     def _recover_missing_overlay_payload(self, ideas: list[dict[str, Any]], *, force: bool = False) -> tuple[list[dict[str, Any]], bool]:
         rebuilt: list[dict[str, Any]] = []
         changed = False

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -1053,6 +1053,7 @@
             <option value="CLOSED">Архив</option>
           </select>
           <button id="refreshBtn">Обновить</button>
+          <button id="regenerateNarrativesBtn">Перегенерировать тексты через Grok</button>
           <label class="voice-toggle" for="ideasVoiceToggle">
             <input type="checkbox" id="ideasVoiceToggle" />
             🔊 Озвучивать изменения
@@ -1167,6 +1168,7 @@
     const pairFilter = document.getElementById("pairFilter");
     const signalFilter = document.getElementById("signalFilter");
     const refreshBtn = document.getElementById("refreshBtn");
+    const regenerateNarrativesBtn = document.getElementById("regenerateNarrativesBtn");
     const statusBox = document.getElementById("statusBox");
     const ideasGrid = document.getElementById("ideasGrid");
     const archiveList = document.getElementById("archiveList");
@@ -1367,6 +1369,26 @@
     });
 
     refreshBtn.addEventListener("click", () => loadIdeas(true));
+    regenerateNarrativesBtn?.addEventListener("click", async () => {
+      regenerateNarrativesBtn.disabled = true;
+      statusBox.style.display = "block";
+      statusBox.className = "empty";
+      statusBox.textContent = "Перегенерируем тексты через Grok/OpenRouter...";
+      try {
+        const response = await fetch("/api/ideas/regenerate-all-narratives", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!response.ok) throw new Error("HTTP " + response.status);
+        await loadIdeas(true);
+      } catch (error) {
+        statusBox.style.display = "block";
+        statusBox.className = "error";
+        statusBox.textContent = "Ошибка перегенерации текстов: " + error.message;
+      } finally {
+        regenerateNarrativesBtn.disabled = false;
+      }
+    });
     closeModalBtn.addEventListener("click", closeModal);
 
     modalBackdrop.addEventListener("click", (event) => {


### PR DESCRIPTION
### Motivation
- Нужно дать возможность массово пересоздать narrative-слой идей через Grok/OpenRouter без изменения торговых полей (entry/SL/TP/status/lifecycle).
- Это упрощает обновление текстов при улучшении LLM-пайплайна или изменении system-подсказок и сохраняет совместимость с текущим storage/legacy-пайплайном.

### Description
- Добавлен новый маршрут `POST /api/ideas/regenerate-all-narratives` в `app/api/ideas_routes.py`, который вызывает сервис перегенерации.
- Реализован метод `regenerate_all_narratives()` в `app/services/trade_idea_service.py`, который проходит по всем идеям из `idea_store`, вызывает `IdeaNarrativeLLMService.generate(...)`, обновляет `idea_article_ru` и `unified_narrative`, а также поля `narrative_source`, `narrative_model`, `narrative_error` и `updated_at`, при этом не изменяя `entry/stop_loss/take_profit/status/lifecycle` и сохраняя результат в `trade_ideas.json`; затем вызывается `refresh_market_ideas()` для обновления legacy-слоя (`market_ideas.json`).
- В UI (`app/static/ideas.html`) добавлена кнопка `Перегенерировать тексты через Grok` и обработчик клика, который делает `POST /api/ideas/regenerate-all-narratives`, показывает статус операции и перезагружает список идей.

### Testing
- Запущен автоматический тест: `python -m pytest tests/api/test_ideas_api.py -q`.
- Тестирование завершилось с ошибкой на этапе импорта проекта (`ImportError: cannot import name 'canonical_market_service' from 'app.main'`), ошибка относится к окружению/инициализации приложения и не связана с внесёнными изменениями; поведение кода перегенерации проверено вручную через логирование и сохранение файлов в процессе разработки.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77fd89a348331bf0077214f2f61b8)