### PR TITLE
Обновить контракт ответа для `regenerate-all-narratives`

### DIFF
--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -3377,7 +3377,7 @@ class TradeIdeaService:
         ideas = payload.get("ideas") if isinstance(payload.get("ideas"), list) else []
         if not ideas:
             self.legacy_store.write({"updated_at_utc": datetime.now(timezone.utc).isoformat(), "ideas": [], "archive": [], "statistics": {}})
-            return {"ok": True, "updated": 0, "total": 0}
+            return {"status": "ok", "updated": 0}
         now_iso = datetime.now(timezone.utc).isoformat()
         updated_total = 0
         refreshed: list[dict[str, Any]] = []
@@ -3420,7 +3420,7 @@ class TradeIdeaService:
             refreshed.append(idea)
         self.idea_store.write({"updated_at_utc": now_iso, "ideas": refreshed})
         self.refresh_market_ideas()
-        return {"ok": True, "updated": updated_total, "total": len(refreshed)}
+        return {"status": "ok", "updated": updated_total}
 
     def _recover_missing_overlay_payload(self, ideas: list[dict[str, Any]], *, force: bool = False) -> tuple[list[dict[str, Any]], bool]:
         rebuilt: list[dict[str, Any]] = []


### PR DESCRIPTION
### Motivation
- Привести поведение сервиса к строгому API-контракту для endpoint `POST /api/ideas/regenerate-all-narratives`, который должен возвращать `{ "status": "ok", "updated": <count> }`.

### Description
- В `app/services/trade_idea_service.py` изменён формат возвращаемого значения в `regenerate_all_narratives` так, чтобы в случае пустого списка идей и после обработки всех идей метод возвращал `{"status": "ok", "updated": <count>}` вместо прежнего `{"ok": True, ...}`; логика генерации narrative через `IdeaNarrativeLLMService.generate(...)` и запись полей `idea_article_ru`, `narrative_source`, `narrative_model`, `narrative_error` не изменялись.

### Testing
- Запущена команда `pytest -q tests/api/test_ideas_api.py -q`, которая завершилась ошибкой на этапе импорта с `ImportError: cannot import name 'canonical_market_service' from 'app.main'`, что не связано с внесённым изменением в контракт ответа; поэтому тесты по сути не прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f782c297b4833185234977c84bbb39)