### PR TITLE
Изменить формат ответа POST /api/ideas/regenerate-all-narratives

### DIFF
--- a/app/api/ideas_routes.py
+++ b/app/api/ideas_routes.py
@@ -224,6 +224,11 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
     @router.post("/api/ideas/regenerate-all-narratives")
     async def regenerate_all_narratives():
         logger.info("ideas_narrative_regenerate_all_started")
-        return services.trade_idea_service.regenerate_all_narratives()
+        result = services.trade_idea_service.regenerate_all_narratives()
+        updated = int(result.get("updated") or 0) if isinstance(result, dict) else 0
+        return {
+            "status": "ok",
+            "updated": updated,
+        }
 
     return router


### PR DESCRIPTION
### Motivation
- Привести контракт endpoint `POST /api/ideas/regenerate-all-narratives` к ожидаемому виду и вернуть простую JSON-обёртку поверх существующей логики регенерации.

### Description
- В `app/api/ideas_routes.py` endpoint теперь вызывает `services.trade_idea_service.regenerate_all_narratives()` и возвращает `{ "status": "ok", "updated": <число> }`, извлекая значение `updated` из результата при его наличии.

### Testing
- Выполнена проверка синтаксиса Python для изменённого модуля: `python -m py_compile app/api/ideas_routes.py` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f783414b28833190874b679180f152)