### PR TITLE
Enrich ideas and signals with prop-score metadata

### DIFF
--- a/app/api/ideas_routes.py
+++ b/app/api/ideas_routes.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from fastapi import APIRouter
 
+from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.signal_hub import DEFAULT_PAIRS
 from app.services.trade_idea_service import TradeIdeaService
 from backend.market.services.snapshot_service import MarketSnapshotService
@@ -129,6 +130,8 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
 
             payload["ideas"] = _safe_attach_live_market_contracts(payload.get("ideas") or [], field="ideas")
             payload["archive"] = _safe_attach_live_market_contracts(payload.get("archive") or [], field="archive")
+            payload["ideas"] = enrich_ideas_with_prop_scores(payload.get("ideas") or [])
+            payload["archive"] = enrich_ideas_with_prop_scores(payload.get("archive") or [])
             for idea in payload["ideas"]:
                 if not str(
                     idea.get("description_ru")
@@ -181,6 +184,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             if not ideas:
                 fallback_reason = "no_generated_ideas_provider_or_env_issue"
                 ideas = services.trade_idea_service.fallback_ideas(reason=fallback_reason)
+            ideas = enrich_ideas_with_prop_scores(ideas)
             generated_count = sum(1 for idea in ideas if str(idea.get("source")) != "fallback")
             fallback_count = len(ideas) - generated_count
             logger.info(

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
+from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -712,10 +713,11 @@ def api_signals():
             logger.exception("api_signals: failed to build signal for %s", symbol)
 
     if signals:
+        enriched_signals = enrich_ideas_with_prop_scores(signals)
         archive = load_json(ARCHIVE_FILE)
         return {
-            "signals": signals,
-            "ideas": signals,
+            "signals": enriched_signals,
+            "ideas": enriched_signals,
             "archive": archive,
             "statistics": build_stats(),
             "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
@@ -767,10 +769,11 @@ def api_ideas():
             failed_symbols.append(symbol)
 
     if signals:
+        enriched_signals = enrich_ideas_with_prop_scores(signals)
         archive = load_json(ARCHIVE_FILE)
         return {
-            "signals": signals,
-            "ideas": signals,
+            "signals": enriched_signals,
+            "ideas": enriched_signals,
             "archive": archive,
             "statistics": build_stats(),
             "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",


### PR DESCRIPTION
### Motivation
- Add probabilistic/prop-score enrichment to ideas and signals payloads so downstream consumers receive the same scoring metadata across API and UI endpoints.

### Description
- Import and apply `enrich_ideas_with_prop_scores` in `app/api/ideas_routes.py` and enrich both `ideas` and `archive` in the `/ideas/market` and `/api/ideas` handlers. 
- Import and apply `enrich_ideas_with_prop_scores` in `app/main.py` and enrich signals returned by the `/api/signals` and `/api/ideas` endpoints. 
- Preserve existing payload composition and localization while attaching the prop-score enriched objects to the response.

### Testing
- Ran the project's automated test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa01aed72c83319d18c8e8932d56e1)