### PR TITLE
Добавить безопасную валидацию свечей перед SMC/ликвидити-анализом

### DIFF
--- a/backend/analysis/candle_validation.py
+++ b/backend/analysis/candle_validation.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from backend.core.audit.signal_audit_logger import SignalAuditLogger
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CandleValidationResult:
+    valid_candles: list[dict[str, Any]]
+    suspicious_candles: list[dict[str, Any]]
+    excluded_count: int
+    warnings: list[str]
+    data_quality: dict[str, Any]
+
+
+class CandleValidationService:
+    """Мягкая валидация свечей: маркирует аномалии и исключает только явно невалидные значения."""
+
+    def validate(self, candles: list[dict[str, Any]], *, symbol: str | None = None, timeframe: str | None = None) -> CandleValidationResult:
+        if not candles:
+            return CandleValidationResult([], [], 0, [], {"has_warnings": False, "suspicious_count": 0, "excluded_count": 0})
+
+        seen_timestamps: set[int] = set()
+        ranges_for_baseline: list[float] = []
+        valid: list[dict[str, Any]] = []
+        suspicious: list[dict[str, Any]] = []
+        warnings: set[str] = set()
+        excluded_count = 0
+
+        for idx, candle in enumerate(candles):
+            issues: list[str] = []
+            excluded = False
+            flagged = False
+
+            timestamp = candle.get("time")
+            if timestamp is None:
+                issues.append("missing_timestamp")
+                flagged = True
+            else:
+                try:
+                    ts = int(timestamp)
+                    if ts in seen_timestamps:
+                        issues.append("duplicated_timestamp")
+                        excluded = True
+                    seen_timestamps.add(ts)
+                except (TypeError, ValueError):
+                    issues.append("invalid_timestamp")
+                    excluded = True
+
+            try:
+                o = float(candle["open"])
+                h = float(candle["high"])
+                l = float(candle["low"])
+                c = float(candle["close"])
+            except (KeyError, TypeError, ValueError):
+                issues.append("invalid_ohlc")
+                excluded = True
+                o = h = l = c = 0.0
+
+            if not excluded:
+                if min(o, h, l, c) <= 0:
+                    issues.append("non_positive_price")
+                    excluded = True
+                if h < max(o, c) or l > min(o, c) or h < l:
+                    issues.append("impossible_ohlc")
+                    excluded = True
+
+            candle_range = max(h - l, 0.0)
+            if not excluded:
+                recent_ranges = ranges_for_baseline[-14:]
+                baseline_range = (sum(recent_ranges) / len(recent_ranges)) if recent_ranges else candle_range
+                if baseline_range > 0 and candle_range > baseline_range * 8.0:
+                    issues.append("extreme_range_vs_recent")
+                    flagged = True
+                upper_wick = h - max(o, c)
+                lower_wick = min(o, c) - l
+                body = abs(c - o)
+                wick_baseline = max(body, baseline_range * 0.2, 1e-9)
+                if upper_wick > wick_baseline * 10 or lower_wick > wick_baseline * 10:
+                    issues.append("extreme_wick_outlier")
+                    flagged = True
+
+            processed = dict(candle)
+            if issues:
+                warnings.update(issues)
+                processed["validation_flags"] = issues
+                suspicious.append({"index": idx, "time": processed.get("time"), "issues": issues, "excluded": excluded})
+                self._audit_anomaly(symbol=symbol, timeframe=timeframe, candle=processed, issues=issues, excluded=excluded)
+
+            if excluded:
+                excluded_count += 1
+                continue
+
+            if flagged:
+                processed["data_quality"] = "suspicious"
+            valid.append(processed)
+            ranges_for_baseline.append(candle_range)
+
+        data_quality = {
+            "has_warnings": bool(suspicious),
+            "suspicious_count": len(suspicious),
+            "excluded_count": excluded_count,
+            "warning_codes": sorted(warnings),
+        }
+        if excluded_count >= len(candles):
+            logger.warning("candle_validation_all_excluded symbol=%s timeframe=%s total=%s", symbol, timeframe, len(candles))
+
+        return CandleValidationResult(valid, suspicious, excluded_count, sorted(warnings), data_quality)
+
+    def _audit_anomaly(self, *, symbol: str | None, timeframe: str | None, candle: dict[str, Any], issues: list[str], excluded: bool) -> None:
+        SignalAuditLogger.log(
+            {
+                "event": "candle_validation_anomaly",
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "issues": issues,
+                "excluded": excluded,
+                "candle": {
+                    "time": candle.get("time"),
+                    "open": candle.get("open"),
+                    "high": candle.get("high"),
+                    "low": candle.get("low"),
+                    "close": candle.get("close"),
+                },
+            }
+        )

--- a/backend/analysis/feature_builder.py
+++ b/backend/analysis/feature_builder.py
@@ -4,6 +4,7 @@ import logging
 from statistics import mean
 
 from backend.pattern_detector import PatternDetector
+from backend.analysis.candle_validation import CandleValidationService
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +28,12 @@ class FeatureBuilder:
         return "unknown"
     def __init__(self) -> None:
         self.pattern_detector = PatternDetector()
+        self.candle_validator = CandleValidationService()
 
     def build(self, snapshot: dict) -> dict:
         candles = snapshot.get("candles", [])
+        validation = self.candle_validator.validate(candles, symbol=snapshot.get("symbol"), timeframe=snapshot.get("timeframe"))
+        candles = validation.valid_candles
         pattern_analysis = self.pattern_detector.detect(candles)
         candle_count = len(candles)
         data_status = str(snapshot.get("data_status", "unavailable")).lower()
@@ -67,6 +71,8 @@ class FeatureBuilder:
                 "dominant_pattern_type": None,
                 "conflicting_pattern_detected": False,
                 "feature_completeness": "none",
+                "data_quality": validation.data_quality,
+                "data_warnings": validation.warnings,
             }
 
         if candle_count < 3:
@@ -100,6 +106,8 @@ class FeatureBuilder:
                     "dominant_pattern_type": None,
                     "conflicting_pattern_detected": False,
                     "feature_completeness": "partial",
+                    "data_quality": validation.data_quality,
+                    "data_warnings": validation.warnings,
                 }
             direction = "up" if last_close >= prev_close else "down"
             summary = pattern_analysis["summary"]
@@ -126,6 +134,8 @@ class FeatureBuilder:
                 "dominant_pattern_type": None,
                 "conflicting_pattern_detected": False,
                 "feature_completeness": "minimal",
+                "data_quality": validation.data_quality,
+                "data_warnings": validation.warnings,
             }
 
         try:
@@ -157,6 +167,8 @@ class FeatureBuilder:
                 "dominant_pattern_type": None,
                 "conflicting_pattern_detected": False,
                 "feature_completeness": "partial",
+                "data_quality": validation.data_quality,
+                "data_warnings": validation.warnings,
             }
 
         delta = closes[-1] - closes[-2]
@@ -289,4 +301,6 @@ class FeatureBuilder:
             "dominant_pattern_type": dominant_pattern,
             "conflicting_pattern_detected": bullish_patterns > 0 and bearish_patterns > 0,
             "feature_completeness": feature_completeness,
+            "data_quality": validation.data_quality,
+            "data_warnings": validation.warnings,
         }

--- a/tests/analysis/test_candle_validation.py
+++ b/tests/analysis/test_candle_validation.py
@@ -1,0 +1,34 @@
+from backend.analysis.candle_validation import CandleValidationService
+from backend.feature_builder import FeatureBuilder
+
+
+def test_candle_validation_excludes_only_invalid_and_marks_outlier() -> None:
+    candles = [
+        {"time": 1, "open": 1.1, "high": 1.11, "low": 1.09, "close": 1.105},
+        {"time": 2, "open": 1.105, "high": 1.115, "low": 1.10, "close": 1.11},
+        {"time": 2, "open": 1.11, "high": 1.20, "low": 1.10, "close": 1.12},  # duplicate ts -> excluded
+        {"time": 4, "open": 1.12, "high": 1.30, "low": 1.11, "close": 1.121},  # suspicious wick/range
+        {"time": 5, "open": -1.0, "high": -0.9, "low": -1.1, "close": -1.0},  # invalid
+    ]
+    result = CandleValidationService().validate(candles, symbol="EURUSD", timeframe="H1")
+
+    assert result.excluded_count == 2
+    assert len(result.valid_candles) == 3
+    assert result.data_quality["has_warnings"] is True
+    assert "duplicated_timestamp" in result.data_quality["warning_codes"]
+    assert any(item.get("data_quality") == "suspicious" for item in result.valid_candles)
+
+
+def test_feature_builder_exposes_data_quality_without_breaking_contract() -> None:
+    candles = [
+        {"open": 1.1, "high": 1.11, "low": 1.09, "close": 1.105},
+        {"open": 1.105, "high": 1.115, "low": 1.10, "close": 1.11},
+        {"open": 1.11, "high": 1.112, "low": 1.101, "close": 1.102},
+        {"open": 1.102, "high": 1.103, "low": 1.09, "close": 1.091},
+    ]
+
+    features = FeatureBuilder().build({"data_status": "real", "symbol": "EURUSD", "timeframe": "M15", "candles": candles})
+    assert "liquidity_sweep" in features
+    assert "data_quality" in features
+    assert "data_warnings" in features
+    assert "missing_timestamp" in features["data_warnings"]


### PR DESCRIPTION
### Motivation
- Уменьшить риск ложных сигналов от аномальных свечей (спайки, битые тики, невозможные OHLC и т.п.) при расчёте SMC/ликвидити/сетап-метрик. 
- Не менять архитектуру поставщиков данных и не фейкать отсутствующие свечи, а лишь безопасно пометить и исключить явно неверные записи.

### Description
- Добавлен сервис `CandleValidationService` в `backend/analysis/candle_validation.py`, который детектит: `missing/invalid/duplicated timestamp`, `invalid/impossible OHLC`, `non_positive_price`, `extreme_wick_outlier`, `extreme_range_vs_recent` и маркирует подозрительные свечи, исключая только явно невалидные.
- Интеграция в `FeatureBuilder` (`backend/analysis/feature_builder.py`) — валидация выполняется перед SMC/liquidity/pattern-логикой и после неё используются только валидные свечи; подозрительные свечи сохраняют флаги `data_quality`/`validation_flags` и помечаются как `suspicious` в payload.
- Добавлено аудиторное логирование каждого обнаруженного инцидента через `SignalAuditLogger` (`event: candle_validation_anomaly`) для дальнейшего расследования.
- Контракт совместим по обратной совместимости: существующие поля не удалены, расширение ответа включает `data_quality` и `data_warnings` для потребителей.
- Добавлены юнит-тесты `tests/analysis/test_candle_validation.py` покрывающие исключение только явно неверных свечей и сохранение полей качества данных в `FeatureBuilder`.

### Testing
- Запуск модульных тестов: `pytest -q tests/analysis/test_candle_validation.py tests/test_smc_detector.py` — все тесты прошли: `4 passed`.
- Дополнительный запуск с `test_pattern_detector` выявил падение на существующем импорте в другом тесте, не связанном с изменениями валидации: `ImportError: cannot import name 'signal_analytics_service' from 'app.main'` (это внешний/существующий тестовый сбой, не влияющий на добавленный код).
- Покрытие: добавленные тесты проверяют как логику валидации, так и то, что `FeatureBuilder` сохраняет контракт и отдаёт `data_quality`/`data_warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b2a67b488331b80464367c4a317c)