### PR TITLE
Добавить endpoint MT4/MT5 volume-delta и интеграцию в взвешенный скоринг

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from app.services.htf_context_filter import HtfContextFilter
 from app.services.cme_scraper import get_cme_market_snapshot
 from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
-from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
+from app.services.mt4_volume_cluster_bridge import get_latest_volume_delta, save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.signal_audit_logger import log_signal_audit
@@ -969,6 +969,47 @@ async def api_mt4_volume_clusters(request: Request):
     except Exception as exc:
         return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
 
+
+
+
+@app.post("/api/mt4/push-volume-delta")
+async def api_mt4_push_volume_delta(request: Request):
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_json"})
+    if not isinstance(payload, dict):
+        return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_payload"})
+
+    required = [
+        "symbol",
+        "timeframe",
+        "timestamp",
+        "cum_delta",
+        "delta_change",
+        "cluster_volume",
+        "poc_price",
+        "absorption_zone",
+        "hft_spike",
+        "source",
+    ]
+    missing = [field for field in required if field not in payload]
+    if missing:
+        return JSONResponse(status_code=400, content={"ok": False, "error": "missing_fields", "fields": missing})
+
+    token = str(payload.get("token") or "").strip()
+    if MT4_BRIDGE_TOKEN and token != MT4_BRIDGE_TOKEN:
+        return JSONResponse(status_code=401, content={"ok": False, "error": "unauthorized"})
+
+    saved = save_volume_cluster_payload(payload)
+    log_signal_audit({
+        "stage": "volume_delta_received",
+        "symbol": saved.get("symbol"),
+        "timeframe": saved.get("timeframe"),
+        "source": saved.get("source"),
+        "timestamp": saved.get("timestamp"),
+    })
+    return {"ok": True, "symbol": saved.get("symbol"), "timeframe": saved.get("timeframe"), "updated_at_utc": now_utc()}
 
 @app.post("/api/mt4/options-levels")
 async def api_mt4_options_levels(request: Request):
@@ -3772,6 +3813,16 @@ def _normalize_quote_signal(signal: dict[str, Any]) -> dict[str, Any]:
     normalized["diagnostics"] = diagnostics
     normalized["candles"] = _format_idea_candles(normalized.get("candles") if isinstance(normalized.get("candles"), list) else [])
     if symbol:
+        volume_delta_snapshot = get_latest_volume_delta(symbol, str(normalized.get("timeframe") or normalized.get("tf") or "M15"))
+        if isinstance(volume_delta_snapshot, dict):
+            normalized["volume_delta"] = volume_delta_snapshot
+            market_context = normalized.get("market_context") if isinstance(normalized.get("market_context"), dict) else {}
+            market_context["volume_delta"] = volume_delta_snapshot
+            normalized["market_context"] = market_context
+            log_signal_audit({"stage": "volume_delta_used", "symbol": symbol, "timeframe": str(normalized.get("timeframe") or normalized.get("tf") or "M15")})
+        else:
+            log_signal_audit({"stage": "volume_delta_missing", "symbol": symbol, "timeframe": str(normalized.get("timeframe") or normalized.get("tf") or "M15")})
+
         options_snapshot = get_latest_options_levels(symbol)
         options_available = bool(options_snapshot.get("available"))
         analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}

--- a/app/services/mt4_volume_cluster_bridge.py
+++ b/app/services/mt4_volume_cluster_bridge.py
@@ -35,6 +35,36 @@ def save_volume_cluster_payload(payload: dict[str, Any]) -> dict[str, Any]:
     symbol = normalize_broker_symbol(payload.get("symbol") or payload.get("broker_symbol"))
     timeframe = str(payload.get("timeframe") or "H1").upper().strip()
     record = dict(payload)
+    if "cum_delta" in record or "delta_change" in record:
+        record.setdefault("delta", {})
+        if isinstance(record["delta"], dict):
+            if "cum_delta" in record and record["cum_delta"] is not None:
+                record["delta"]["cumulative_delta"] = record["cum_delta"]
+            if "delta_change" in record and record["delta_change"] is not None:
+                record["delta"]["delta_change"] = record["delta_change"]
+                if "delta_trend" not in record["delta"]:
+                    try:
+                        change = float(record["delta_change"])
+                        record["delta"]["delta_trend"] = "rising" if change > 0 else "falling" if change < 0 else "flat"
+                    except (TypeError, ValueError):
+                        pass
+    if "poc_price" in record and record.get("poc_price") is not None:
+        record.setdefault("volume_profile", {})
+        if isinstance(record["volume_profile"], dict):
+            record["volume_profile"]["poc"] = record.get("poc_price")
+    if "cluster_volume" in record and record.get("cluster_volume") is not None:
+        record.setdefault("volume_profile", {})
+        if isinstance(record["volume_profile"], dict):
+            record["volume_profile"]["cluster_volume"] = record.get("cluster_volume")
+    if "absorption_zone" in record and record.get("absorption_zone"):
+        record.setdefault("summary", {})
+        if isinstance(record["summary"], dict):
+            record["summary"]["absorption_detected"] = True
+            record["summary"]["absorption_zone"] = record.get("absorption_zone")
+    if "hft_spike" in record:
+        record.setdefault("summary", {})
+        if isinstance(record["summary"], dict):
+            record["summary"]["hft_spike"] = bool(record.get("hft_spike"))
     record["symbol"] = symbol
     record["timeframe"] = timeframe
     record["received_at"] = datetime.now(timezone.utc).isoformat()
@@ -54,3 +84,8 @@ def get_latest_volume_cluster(symbol: str, timeframe: str | None = None) -> dict
     if is_stale(payload.get("timestamp") or payload.get("received_at")):
         return None
     return payload
+
+
+def get_latest_volume_delta(symbol: str, timeframe: str | None = None) -> dict[str, Any] | None:
+    """Backward-compatible alias for external CVD/delta feed readers."""
+    return get_latest_volume_cluster(symbol, timeframe)

--- a/backend/analysis/volume_cluster_adapter.py
+++ b/backend/analysis/volume_cluster_adapter.py
@@ -2,25 +2,36 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.services.mt4_volume_cluster_bridge import get_latest_volume_cluster
+from app.services.mt4_volume_cluster_bridge import get_latest_volume_delta
 
 
 def build_volume_cluster_analysis(symbol: str, timeframe: str, action: str, entry: float | None, price: float | None) -> dict[str, Any]:
-    payload = get_latest_volume_cluster(symbol, timeframe)
+    payload = get_latest_volume_delta(symbol, timeframe)
     if not payload:
-        return {"available": False, "reason": "MT4 volume cluster data is not available", "scoreImpact": 0}
+        return {
+            "available": False,
+            "reason": "MT4 volume cluster data is not available",
+            "scoreImpact": 0,
+            "score_breakdown": {
+                "volume_delta_available": False,
+                "cum_delta_bias": "unknown",
+                "delta_confirmation": "missing",
+                "absorption_confirmation": "missing",
+                "hft_liquidity_event": False,
+            },
+        }
 
     vp = payload.get("volume_profile") if isinstance(payload.get("volume_profile"), dict) else {}
     delta = payload.get("delta") if isinstance(payload.get("delta"), dict) else {}
     summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
     clusters = payload.get("clusters") if isinstance(payload.get("clusters"), list) else []
     current = float(price or payload.get("underlying_price") or 0.0)
-    score = _score(action, entry or current, current, vp, delta, summary)
+    score, score_breakdown = _score(action, entry or current, current, vp, delta, summary)
 
     return {
         "available": True,
         "source": payload.get("source") or "mt4_optionlevels_volume",
-        "poc": vp.get("poc"),
+        "poc": vp.get("poc") or payload.get("poc_price"),
         "vah": vp.get("vah"),
         "val": vp.get("val"),
         "high_volume_nodes": vp.get("high_volume_nodes") or [],
@@ -29,37 +40,59 @@ def build_volume_cluster_analysis(symbol: str, timeframe: str, action: str, entr
         "clusters": clusters,
         "signals": {
             "volume_confirmation": "confirmed" if abs(score) >= 6 else "weak",
-            "delta_confirmation": "divergence" if str(delta.get("divergence") or "none") not in {"none", "unknown"} else "confirmed",
+            "delta_confirmation": score_breakdown["delta_confirmation"],
             "absorption": str(summary.get("absorption_side") or "none") if summary.get("absorption_detected") else "none",
             "cluster_bias": "bullish" if score > 2 else "bearish" if score < -2 else "neutral",
         },
+        "score_breakdown": score_breakdown,
         "scoreImpact": score,
-        "summary_ru": f"Кластерный слой: scoreImpact {score}, POC={vp.get('poc')}, divergence={delta.get('divergence')}.",
+        "summary_ru": f"Кластерный слой: scoreImpact {score}, POC={vp.get('poc') or payload.get('poc_price')}, delta={score_breakdown['cum_delta_bias']}.",
         "volume_profile": vp,
-        "absorption": {"detected": bool(summary.get("absorption_detected")), "side": summary.get("absorption_side"), "price": summary.get("absorption_price")},
+        "absorption": {"detected": bool(summary.get("absorption_detected") or payload.get("absorption_zone")), "side": summary.get("absorption_side"), "price": summary.get("absorption_price"), "zone": payload.get("absorption_zone")},
         "imbalance": [c for c in clusters if isinstance(c, dict) and c.get("type") == "imbalance"],
     }
 
 
-def _score(action: str, entry: float, price: float, vp: dict[str, Any], delta: dict[str, Any], summary: dict[str, Any]) -> int:
+def _score(action: str, entry: float, price: float, vp: dict[str, Any], delta: dict[str, Any], summary: dict[str, Any]) -> tuple[int, dict[str, Any]]:
     score = 0
     a = str(action or "WAIT").upper()
-    div = str(delta.get("divergence") or "unknown")
-    trend = str(delta.get("delta_trend") or "unknown")
-    if a == "BUY":
-        if trend == "rising": score += 6
-        if summary.get("aggressive_buying") is True: score += 5
-        if str(summary.get("absorption_side") or "") == "buy": score += 5
-        if isinstance(vp.get("poc"), (int,float)) and price > float(vp["poc"]): score += 4
-        if div == "bearish": score -= 6
-        if str(summary.get("absorption_side") or "") == "sell": score -= 5
-        if summary.get("aggressive_selling") is True: score -= 4
-    elif a == "SELL":
-        if trend == "falling": score += 6
-        if summary.get("aggressive_selling") is True: score += 5
-        if str(summary.get("absorption_side") or "") == "sell": score += 5
-        if isinstance(vp.get("poc"), (int,float)) and price < float(vp["poc"]): score += 4
-        if div == "bullish": score -= 6
-        if str(summary.get("absorption_side") or "") == "buy": score -= 5
-        if summary.get("aggressive_buying") is True: score -= 4
-    return max(-15, min(15, score))
+    div = str(delta.get("divergence") or "unknown").lower()
+    trend = str(delta.get("delta_trend") or "unknown").lower()
+    absorption_side = str(summary.get("absorption_side") or "").lower()
+    hft_spike = bool(summary.get("hft_spike"))
+
+    cum_delta_bias = "neutral"
+    if trend == "rising":
+        cum_delta_bias = "bullish"
+    elif trend == "falling":
+        cum_delta_bias = "bearish"
+
+    delta_confirmation = "neutral"
+    if a == "BUY" and trend == "rising":
+        score += 5
+        delta_confirmation = "confirmed"
+    elif a == "SELL" and trend == "falling":
+        score += 5
+        delta_confirmation = "confirmed"
+
+    if (a == "BUY" and div == "bearish") or (a == "SELL" and div == "bullish"):
+        score -= 6
+        delta_confirmation = "divergence"
+
+    absorption_confirmation = "none"
+    if (a == "BUY" and absorption_side == "buy") or (a == "SELL" and absorption_side == "sell") or bool(summary.get("absorption_zone")):
+        score += 7
+        absorption_confirmation = "confirmed"
+
+    hft_liquidity_event = False
+    if hft_spike:
+        score += 6
+        hft_liquidity_event = True
+
+    return max(-20, min(20, score)), {
+        "volume_delta_available": True,
+        "cum_delta_bias": cum_delta_bias,
+        "delta_confirmation": delta_confirmation,
+        "absorption_confirmation": absorption_confirmation,
+        "hft_liquidity_event": hft_liquidity_event,
+    }

--- a/tests/test_mt4_volume_cluster.py
+++ b/tests/test_mt4_volume_cluster.py
@@ -44,3 +44,35 @@ def test_divergence_reduces_confidence():
     div = ConfluenceEngine().evaluate({"action": "SELL", "price": 1.171, "symbol": "EURUSD", "timeframe": "H1"})
     assert div["breakdown"]["volume_cluster"] < base["breakdown"]["volume_cluster"]
 
+
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_push_volume_delta_endpoint_accepts_payload():
+    client = TestClient(app)
+    payload = {
+        "symbol": "EURUSD",
+        "timeframe": "M15",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "cum_delta": 1200,
+        "delta_change": 85,
+        "cluster_volume": 4300,
+        "poc_price": 1.1025,
+        "absorption_zone": {"low": 1.1018, "high": 1.1022},
+        "hft_spike": True,
+        "source": "optionlevels_fx",
+    }
+    res = client.post('/api/mt4/push-volume-delta', json=payload)
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+
+
+def test_score_breakdown_contains_volume_delta_fields():
+    save_volume_cluster_payload(_payload(summary={"absorption_side": "sell", "hft_spike": True}, delta={"delta_trend": "falling", "divergence": "none"}))
+    res = ConfluenceEngine().evaluate({"action": "SELL", "price": 1.171, "symbol": "EURUSD", "timeframe": "H1"})
+    vc = res["volume_cluster_analysis"]
+    assert "score_breakdown" in vc
+    assert vc["score_breakdown"]["volume_delta_available"] is True
+    assert "delta_confirmation" in vc["score_breakdown"]


### PR DESCRIPTION
### Motivation
- Поддержать приём внешних кластерных объёмов и cumulative delta (CVD), POC, зоны поглощения и HFT-спайки из MT4/MT5 (OptionLevels FX и аналогов) без ломки существующей логики сигналов.
- Использовать эти данные как модификаторы оценки сигналов, а не как жёсткий фильтр, сохраняя обратную совместимость API и frontend-контрактов.

### Description
- Добавлен новый API endpoint `POST /api/mt4/push-volume-delta` с валидацией полей и опциональной проверкой `MT4_BRIDGE_TOKEN`, который сохраняет snapshot во внутренний стор через `save_volume_cluster_payload` и логгирует событие `volume_delta_received`.
- Расширен `save_volume_cluster_payload` для безопасного маппинга входных полей: `cum_delta` → `delta.cumulative_delta`, `delta_change` → `delta.delta_change` (и вывод `delta_trend` при наличии), `poc_price` → `volume_profile.poc`, `cluster_volume` → `volume_profile.cluster_volume`, `absorption_zone` и `hft_spike` → `summary`.
- Добавлен безопасный getter `get_latest_volume_delta(symbol, timeframe)` как совместимый алиас на существующую логику получения snapshot.
- Интеграция в нормализацию сигналов: `_normalize_quote_signal` теперь запрашивает `get_latest_volume_delta` и при наличии добавляет `volume_delta` в `normalized` и `market_context`, а также пишет аудиты `volume_delta_used` / `volume_delta_missing`.
- Модифицирована реализация `build_volume_cluster_analysis` в `backend/analysis/volume_cluster_adapter.py` чтобы вернуть скоринг-модификатор и подробную `score_breakdown` с полями `volume_delta_available`, `cum_delta_bias`, `delta_confirmation`, `absorption_confirmation`, `hft_liquidity_event` и применить веса согласно спецификации (+5, -6, +7, +6, отсутствие данных = 0).
- Добавлены тесты: расширение `tests/test_mt4_volume_cluster.py` для проверки нового endpoint и наличия `score_breakdown` полей; изменения минимальны и не меняют существующие публичные контракты.

### Testing
- Запущен таргетный набор тестов: `pytest -q tests/test_mt4_volume_cluster.py`.
- Результат: все тесты в наборе прошли успешно (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0160883e808331815f6df27a367bd3)