### PR TITLE
Удалить некорректный `finally` в `closeIdeaModal` в `app/static/ideas.js`

### DIFF
--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -538,9 +538,8 @@ function closeIdeaModal() {
     modalOverlayCanvas = null;
     modalOverlayContext = null;
     modalOverlayState = null;
-  } finally {
-    isIdeasLoading = false;
   }
+  isIdeasLoading = false;
 }
 
 function renderModalChart(idea) {


### PR DESCRIPTION
### Motivation
- Исправить синтаксическую ошибку, из‑за которой скрипт страницы `/ideas` не парсился и страница оставалась пустой.

### Description
- В `app/static/ideas.js` удалён неверно расположенный `finally` после `if` в функции `closeIdeaModal()`, а присвоение `isIdeasLoading = false` сохранено как обычное выражение.

### Testing
- Выполнена проверка синтаксиса JavaScript командой `node --check app/static/ideas.js`, которая прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c270c3088331a525677ab7d9814d)