### PR TITLE
Включить legacy‑патч для POST /ideas/market

### DIFF
--- a/app/core/env.py
+++ b/app/core/env.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 from app.core.analytics_candles_bridge_patch import install_analytics_candles_bridge_patch
+from app.core.legacy_ideas_market_post_patch import install_legacy_ideas_market_post_patch
 from app.core.analytics_rich_article_patch import install_analytics_rich_article_patch
 from app.core.safe_ai_json_patch import install_safe_ai_json_patch
 from app.core.safe_grok_text_patch import install_safe_grok_text_patch
@@ -40,6 +41,7 @@ def get_twelvedata_api_key() -> str | None:
 install_safe_ai_json_patch()
 install_analytics_candles_bridge_patch()
 install_analytics_rich_article_patch()
+install_legacy_ideas_market_post_patch()
 
 # SAFE grok patch (не ломает FastAPI)
 install_safe_grok_text_patch()


### PR DESCRIPTION
### Motivation
- Включить уже реализованный файл совместимости, чтобы старые MT4-советники могли отправлять POST на `/ideas/market` и бэкенд принимал legacy-поля (candles/options/volume/cumulative_delta/future_volume/hft).

### Description
- В `app/core/env.py` добавлен импорт `from app.core.legacy_ideas_market_post_patch import install_legacy_ideas_market_post_patch` и вызов `install_legacy_ideas_market_post_patch()` сразу после `install_analytics_rich_article_patch()`, никаких других файлов не менял.

### Testing
- Автоматизированные тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1363b1603c83318b416da920cacf9d)