### PR TITLE
Добавить GET /api/mt4/ingest-get для сохранения свечи и кластерных объёмов

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -991,6 +991,74 @@ def api_mt4_signals():
     return payload
 
 
+
+
+@app.get("/api/mt4/ingest-get")
+def api_mt4_ingest_get(
+    symbol: str = "",
+    broker_symbol: str = "",
+    tf: str = "M15",
+    time: int = 0,
+    open: float = 0.0,
+    high: float = 0.0,
+    low: float = 0.0,
+    close: float = 0.0,
+    volume: float = 0.0,
+    tick_volume: float = 0.0,
+    future_volume: float = 0.0,
+    buy_volume: float = 0.0,
+    sell_volume: float = 0.0,
+    delta: float = 0.0,
+    cumulative_delta: float = 0.0,
+    future_delta: float = 0.0,
+    hft_signal: str = "",
+    bars: str = "",
+    broker: str = "",
+    account: str = "",
+    token: str = "",
+):
+    if MT4_BRIDGE_TOKEN and token.strip() != MT4_BRIDGE_TOKEN:
+        return JSONResponse(status_code=401, content={"ok": False, "error": "unauthorized"})
+
+    normalized_symbol = normalize_mt4_symbol(symbol or broker_symbol)
+    timeframe = str(tf or "M15").upper()
+    if not normalized_symbol:
+        return JSONResponse(status_code=400, content={"ok": False, "error": "symbol_required"})
+
+    store_key = f"{normalized_symbol}:{timeframe}"
+    MT4_CANDLE_STORE[store_key] = {
+        "time": int(time or 0),
+        "open": float(open or 0.0),
+        "high": float(high or 0.0),
+        "low": float(low or 0.0),
+        "close": float(close or 0.0),
+        "volume": float(volume or 0.0),
+    }
+
+    save_volume_cluster_payload({
+        "symbol": normalized_symbol,
+        "timeframe": timeframe,
+        "tick_volume": tick_volume,
+        "future_volume": future_volume,
+        "buy_volume": buy_volume,
+        "sell_volume": sell_volume,
+        "delta": delta,
+        "cumulative_delta": cumulative_delta,
+        "future_delta": future_delta,
+        "hft_signal": hft_signal,
+        "bars": bars,
+        "broker": broker,
+        "account": account,
+    })
+
+    return {
+        "ok": True,
+        "route": "ingest-get",
+        "symbol": normalized_symbol,
+        "timeframe": timeframe,
+    }
+
+
 @app.post("/api/mt4/push-candles")
 async def api_mt4_push_candles(request: Request):
     try:


### PR DESCRIPTION
### Motivation
- Добавить лёгкий GET-эндпоинт для быстрого инжеста одной свечи и связанных объёмных метрик из MT4-подключения. 
- Обеспечить совместимость с существующим мостом MT4 через ту же схему авторизации и нормализацию символов. 
- Упростить отправку одиночных данных (например, тесты или простые интеграции) без изменения существующих POST-ручек.

### Description
- В `app/main.py` добавлен `GET /api/mt4/ingest-get`, принимающий перечисленные query-параметры (`symbol`, `broker_symbol`, `tf`, `time`, `open`, `high`, `low`, `close`, `volume`, `tick_volume`, `future_volume`, `buy_volume`, `sell_volume`, `delta`, `cumulative_delta`, `future_delta`, `hft_signal`, `bars`, `broker`, `account`, `token`).
- Реализована авторизация по `token` в том же стиле, что и прочие MT4-эндпоинты, и нормализация символа через `normalize_mt4_symbol(symbol or broker_symbol)`, покрывающая случаи вида `EURUSD.cs -> EURUSD` и `XAUUSD.cs -> XAUUSD`.
- Сохранение свечи в `MT4_CANDLE_STORE[f"{symbol}:{tf}"]` в формате `{ "time": ..., "open": ..., "high": ..., "low": ..., "close": ..., "volume": ... }`.
- Вызов `save_volume_cluster_payload(...)` с требуемыми полями (`symbol`, `timeframe`, `tick_volume`, `future_volume`, `buy_volume`, `sell_volume`, `delta`, `cumulative_delta`, `future_delta`, `hft_signal`, `bars`, `broker`, `account`), и возврат ответа `{"ok": true, "route": "ingest-get", "symbol": symbol, "timeframe": tf}`.
- Существующие маршруты не изменялись и поведение других эндпоинтов сохранено.

### Testing
- `python -m py_compile app/main.py` — успешно, файл корректно компилируется.
- Локальный коммит изменений выполнен и файл `app/main.py` обновлён без ошибок синтаксиса.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1406c53ab08331a911c3c458b4b63d)