### PR TITLE
Добавлен confirmation-слой CME_OptionsFX (Telegram) для prop-score

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,3 +395,10 @@ curl -X POST http://127.0.0.1:8000/api/options/levels \
 curl http://127.0.0.1:8000/api/options/levels/EURUSD
 curl http://127.0.0.1:8000/ideas/market
 ```
+
+## External Telegram options confirmation
+- `CME_OptionsFX` подключён как дополнительный `options_flow_source`, а не как источник прямого открытия сделок и не как замена существующего CME/options модуля.
+- Endpoint `GET /api/external-signals/cme-optionsfx` возвращает последние распарсенные Telegram-сообщения по `EURUSD`, `GBPUSD`, `USDJPY`, `XAUUSD`, `DXY` с полями `option_bias`, `key_strikes`, `max_pain`, `expiry`, `gamma_zone`, `put_call_bias`, `raw_text`, `source`.
+- Если Telegram credentials не заданы (`TELEGRAM_API_ID`/`TELEGRAM_API_HASH` или `TELEGRAM_BOT_TOKEN`, также поддерживаются `TG_*` aliases), endpoint возвращает `available=false`, а scoring работает как раньше без блокировки сделок.
+- В Prop Signal Engine слой `CME_OptionsFX` используется только как confirmation layer: совпадение options bias с направлением сделки даёт `+4` к score, явный конфликт даёт `-4`, а high-confidence conflict может стать blocker.
+- В payload идеи добавлены `external_options_ru`, `external_options_bias`, `external_options_key_strikes`, `external_options_max_pain`, а `advisor_signal` содержит `external_options_used`, `external_options_alignment`, `external_options_source="CME_OptionsFX"`.

--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -244,6 +244,41 @@ def _sentiment_alignment(idea: dict[str, Any], direction: str) -> dict[str, Any]
     return {"alignment": "conflict", "score": 0, "text_ru": f"sentiment против {direction}: ожидает {implied} ({usd_bias})", "implied_action": implied, "usd_bias": usd_bias}
 
 
+
+def _external_options_confirmation(symbol: str) -> dict[str, Any]:
+    module = sys.modules.get("app.services.prop_signal_engine")
+    getter = getattr(module, "get_cme_optionsfx_confirmation", None) if module is not None else None
+    if callable(getter):
+        try:
+            payload = getter(symbol)
+            return payload if isinstance(payload, dict) else {}
+        except Exception:
+            return {}
+    try:
+        from app.services.external_signal_adapter import get_cme_optionsfx_confirmation
+
+        payload = get_cme_optionsfx_confirmation(symbol)
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _external_options_alignment(symbol: str, direction: str) -> dict[str, Any]:
+    confirmation = _external_options_confirmation(symbol)
+    signal = confirmation.get("signal") if isinstance(confirmation.get("signal"), dict) else None
+    bias = str(confirmation.get("option_bias") or (signal or {}).get("option_bias") or "neutral").lower()
+    implied = "BUY" if bias == "bullish" else "SELL" if bias == "bearish" else "neutral"
+    used = bool(confirmation.get("used") and signal)
+    if not used:
+        return {**confirmation, "used": False, "alignment": "neutral", "score_adjustment": 0, "implied_action": "neutral", "high_confidence_conflict": False, "text_ru": "CME_OptionsFX: нет свежих данных по инструменту, слой не блокирует сделку"}
+    if implied not in {"BUY", "SELL"} or direction not in {"BUY", "SELL"}:
+        return {**confirmation, "used": True, "alignment": "neutral", "score_adjustment": 0, "implied_action": implied, "high_confidence_conflict": False, "text_ru": f"CME_OptionsFX нейтрален: options bias {bias}"}
+    if implied == direction:
+        return {**confirmation, "used": True, "alignment": "aligned", "score_adjustment": 4, "implied_action": implied, "high_confidence_conflict": False, "text_ru": f"CME_OptionsFX подтверждает {direction}: options bias {bias}"}
+    raw = str((signal or {}).get("raw_text") or "").upper()
+    high_conflict = any(marker in raw for marker in ("HIGH CONFIDENCE", "STRONG", "СИЛЬН", "ВЫСОК", "AGGRESSIVE", "DOMINATE"))
+    return {**confirmation, "used": True, "alignment": "conflict", "score_adjustment": -4, "implied_action": implied, "high_confidence_conflict": high_conflict, "text_ru": f"CME_OptionsFX против {direction}: options bias {bias} ожидает {implied}"}
+
 def _row(key: str, label: str, weight: int, score: int, text: str) -> dict[str, Any]:
     score = max(0, min(score, weight))
     return {"key": key, "label_ru": label, "weight": weight, "score": score, "status": "confirmed" if score >= weight * 0.7 else "partial" if score > 0 else "missing", "text_ru": text}
@@ -258,11 +293,15 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     tp = _num(idea.get("tp") or idea.get("take_profit") or idea.get("target"))
     entry, sl, tp, rr, valid, level_source = _levels(symbol, direction, candles, entry, sl, tp)
     sentiment = _sentiment_alignment(idea, direction)
+    external_options = _external_options_alignment(symbol, direction)
     sentiment_conflict = sentiment.get("alignment") == "conflict"
+    external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     has_structure = any(_text_has_data(idea.get(k)) for k in ("reason_ru", "summary_ru", "market_structure", "htf_context", "entry_source"))
     has_liquidity = any(_text_has_data(idea.get(k)) for k in ("liquidity", "selected_zone_type", "selected_zone_low", "fvg", "order_blocks"))
     has_volume = any(_text_has_data(idea.get(k)) for k in ("volume", "volume_ru", "data_status", "provider", "volume_delta"))
     has_options = any(_text_has_data(idea.get(k)) for k in ("options_ru", "options_analysis", "cme"))
+    options_score = 4 if has_options or external_options.get("alignment") == "aligned" else 0 if external_options.get("alignment") == "conflict" else 1
+    options_text = str(external_options.get("text_ru") or ("опционный слой есть" if has_options else "опционный слой не обязателен"))
     rows = [
         _row("direction", "Направление BUY/SELL", 18, 18 if direction in {"BUY", "SELL"} else 0, direction),
         _row("levels", "Entry / SL / TP", 18, 18 if valid else 0, f"уровни валидны ({level_source})" if valid else "нет валидных entry/sl/tp"),
@@ -271,11 +310,12 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         _row("structure", "Структура / импульс", 12, 12 if has_structure else 6 if direction in {"BUY", "SELL"} else 0, "структура/импульс есть" if has_structure else "технический импульс без расширенной структуры"),
         _row("liquidity", "Ликвидность / POI", 8, 8 if has_liquidity else 2 if direction in {"BUY", "SELL"} else 0, "liquidity/POI есть" if has_liquidity else "нет отдельного liquidity слоя"),
         _row("volume", "Volume / tick volume", 5, 5 if has_volume else 1 if candles else 0, "volume/tick proxy есть" if has_volume else "только OHLC/tick proxy"),
-        _row("options", "Опционы / CME", 4, 4 if has_options else 1, "опционный слой есть" if has_options else "опционный слой не обязателен"),
+        _row("options", "Опционы / CME", 4, options_score, options_text),
         _row("sentiment", "Sentiment / новости", 5, int(sentiment.get("score") or 0), str(sentiment.get("text_ru") or "нет sentiment")),
     ]
-    score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
-    allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict)
+    base_score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0)))
+    allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict and not external_options_high_conflict)
     grade = "A" if score >= 70 else "B" if score >= 55 else "C" if score >= 40 else "D"
     mode = "prop_entry" if allowed and score >= 70 else "watchlist" if allowed else "research_only" if score >= 40 else "no_trade"
     blockers = []
@@ -287,8 +327,10 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         blockers.append(f"Слабый R/R {rr:.2f}")
     if sentiment_conflict:
         blockers.append(str(sentiment.get("text_ru")))
-    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing"}
-    advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "level_source": level_source}
+    if external_options_high_conflict:
+        blockers.append(str(external_options.get("text_ru")))
+    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX"}
+    advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "external_options_filter": external_options, "level_source": level_source}
     return score_payload, advisor
 
 
@@ -339,8 +381,18 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["prop_mode"] = score["mode"]
                     enriched["prop_decision_ru"] = score["decision_ru"]
                     enriched["advisor_allowed"] = advisor["allowed"]
+                    external_options_filter = score.get("external_options_filter") if isinstance(score.get("external_options_filter"), dict) else {}
+                    external_options_signal = external_options_filter.get("signal") if isinstance(external_options_filter.get("signal"), dict) else {}
                     enriched["advisor_signal"] = advisor
                     enriched["sentiment_filter"] = score.get("sentiment_filter")
+                    enriched["external_options_filter"] = external_options_filter
+                    enriched["external_options_used"] = score.get("external_options_used")
+                    enriched["external_options_alignment"] = score.get("external_options_alignment")
+                    enriched["external_options_source"] = "CME_OptionsFX"
+                    enriched["external_options_ru"] = external_options_filter.get("text_ru") or "CME_OptionsFX: нет данных"
+                    enriched["external_options_bias"] = external_options_signal.get("option_bias") or external_options_filter.get("option_bias") or "neutral"
+                    enriched["external_options_key_strikes"] = external_options_signal.get("key_strikes") or []
+                    enriched["external_options_max_pain"] = external_options_signal.get("max_pain")
                     return enriched
 
                 module.build_prop_signal_score = patched_build_prop_signal_score

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.services.htf_context_filter import HtfContextFilter
 from app.services.cme_scraper import get_cme_market_snapshot
+from app.services.external_signal_adapter import get_cme_optionsfx_signals
 from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
@@ -194,6 +195,11 @@ def health(request: Request):
         "version": "htf-context-real-candles-1.0",
         "time": now_utc(),
     }
+
+
+@app.get("/api/external-signals/cme-optionsfx")
+def api_external_signals_cme_optionsfx(force_refresh: bool = False) -> dict[str, Any]:
+    return get_cme_optionsfx_signals(force_refresh=force_refresh)
 
 
 @app.get("/", include_in_schema=False)

--- a/app/services/external_signal_adapter.py
+++ b/app/services/external_signal_adapter.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import html
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_SOURCE_URLS = {
+    "sharkfx_ru": "https://t.me/sharkfx_ru",
+    "CME_OptionsFX": "https://t.me/CME_OptionsFX",
+}
+
+EXTERNAL_SIGNAL_SOURCES = {
+    "sharkfx_ru": {
+        "source": "sharkfx_ru",
+        "kind": "trading_signal_source",
+        "url": TELEGRAM_SOURCE_URLS["sharkfx_ru"],
+        "opens_trades_directly": True,
+    },
+    "CME_OptionsFX": {
+        "source": "CME_OptionsFX",
+        "kind": "options_flow_source",
+        "url": TELEGRAM_SOURCE_URLS["CME_OptionsFX"],
+        "opens_trades_directly": False,
+        "purpose": "options/CME confirmation layer",
+    },
+}
+
+SUPPORTED_CME_SYMBOLS = ("EURUSD", "GBPUSD", "USDJPY", "XAUUSD", "DXY")
+TELEGRAM_CACHE_TTL_SECONDS = int(os.getenv("TELEGRAM_EXTERNAL_SIGNALS_CACHE_TTL_SECONDS", "300"))
+TELEGRAM_REQUEST_TIMEOUT_SECONDS = float(os.getenv("TELEGRAM_EXTERNAL_SIGNALS_TIMEOUT_SECONDS", "8"))
+TELEGRAM_MAX_MESSAGES = int(os.getenv("TELEGRAM_EXTERNAL_SIGNALS_MAX_MESSAGES", "20"))
+
+_CACHE: dict[str, dict[str, Any]] = {}
+
+
+def _telegram_credentials_available() -> bool:
+    """Return True only when Telegram access was explicitly configured.
+
+    The adapter intentionally does not scrape Telegram silently without credentials/opt-in. If credentials are
+    absent, API consumers receive available=false and prop scoring remains unchanged.
+    """
+    credential_keys = (
+        "TELEGRAM_API_ID",
+        "TELEGRAM_API_HASH",
+        "TELEGRAM_BOT_TOKEN",
+        "TG_API_ID",
+        "TG_API_HASH",
+        "TG_BOT_TOKEN",
+    )
+    return any(os.getenv(key, "").strip() for key in credential_keys)
+
+
+def _normalize_symbol(value: Any) -> str:
+    raw = str(value or "").upper().replace("/", "").replace(" ", "").strip()
+    if raw in {"GOLD", "XAU", "XAU/USD"}:
+        return "XAUUSD"
+    return raw
+
+
+def _extract_symbols(text: str) -> list[str]:
+    upper = text.upper().replace("/", "")
+    symbols = [symbol for symbol in SUPPORTED_CME_SYMBOLS if re.search(rf"(?<![A-Z0-9]){re.escape(symbol)}(?![A-Z0-9])", upper)]
+    if "GOLD" in upper and "XAUUSD" not in symbols:
+        symbols.append("XAUUSD")
+    return symbols
+
+
+def _option_bias(text: str) -> str:
+    upper = text.upper()
+    bullish_markers = (
+        "BULLISH",
+        "CALL BIAS",
+        "CALLS DOMINATE",
+        "CALL DOMINANCE",
+        "LONG GAMMA SUPPORT",
+        "UPSIDE",
+        "BUYERS",
+        "ПОКУП",
+        "БЫЧ",
+        "РОСТ",
+    )
+    bearish_markers = (
+        "BEARISH",
+        "PUT BIAS",
+        "PUTS DOMINATE",
+        "PUT DOMINANCE",
+        "DOWNSIDE",
+        "SELLERS",
+        "ПРОДА",
+        "МЕДВЕЖ",
+        "СНИЖ",
+        "ПАДЕН",
+    )
+    bull = sum(1 for marker in bullish_markers if marker in upper)
+    bear = sum(1 for marker in bearish_markers if marker in upper)
+    if bull > bear:
+        return "bullish"
+    if bear > bull:
+        return "bearish"
+    return "neutral"
+
+
+def _extract_numbers(fragment: str) -> list[float]:
+    values: list[float] = []
+    for raw in re.findall(r"\b\d{1,5}(?:[.,]\d{1,5})?\b", fragment):
+        try:
+            values.append(float(raw.replace(",", ".")))
+        except ValueError:
+            continue
+    return values
+
+
+def _extract_key_strikes(text: str) -> list[float]:
+    strikes: list[float] = []
+    label_stop = r"(?=\b(?:max\s+pain|pain|expiry|expiration|exp\.?|gamma|put/call|put\s+call|pcr|макс|экспирац|гамма)\b|$)"
+    for match in re.finditer(rf"(?:key\s+strikes?|strikes?|страйк(?:и|ов)?|ключевые\s+страйки?)[:\s\-–]+([^\n\r;]+?){label_stop}", text, re.IGNORECASE):
+        strikes.extend(_extract_numbers(match.group(1))[:8])
+    if not strikes:
+        for match in re.finditer(r"\b(?:strike|страйк)\s*(\d{1,5}(?:[.,]\d{1,5})?)", text, re.IGNORECASE):
+            strikes.extend(_extract_numbers(match.group(1)))
+    unique: list[float] = []
+    for value in strikes:
+        if value not in unique:
+            unique.append(value)
+    return unique[:10]
+
+
+def _extract_first_number_after(label_pattern: str, text: str) -> float | None:
+    match = re.search(rf"(?:{label_pattern})[:\s\-–]+(\d{{1,5}}(?:[.,]\d{{1,5}})?)", text, re.IGNORECASE)
+    if not match:
+        return None
+    values = _extract_numbers(match.group(1))
+    return values[0] if values else None
+
+
+def _extract_expiry(text: str) -> str | None:
+    direct = re.search(
+        r"(?:expiry|expiration|exp\.?|экспирац(?:ия|ии))[:\s\-–]+(\d{4}-\d{2}-\d{2}|\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d{2,4})",
+        text,
+        re.IGNORECASE,
+    )
+    if direct:
+        return direct.group(1).strip()
+    patterns = (
+        r"\b(\d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d{2,4})\b",
+        r"\b(\d{4}-\d{2}-\d{2})\b",
+        r"\b(\d{1,2}[./-]\d{1,2}[./-]\d{2,4})\b",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def _extract_gamma_zone(text: str) -> str | None:
+    match = re.search(
+        r"(?:gamma\s+zone|gamma|гамма(?:\s+зона)?)[:\s\-–]+([^\n\r;]+?)(?=\b(?:put/call|put\s+call|pcr|max\s+pain|expiry|expiration|exp\.?)\b|$)",
+        text,
+        re.IGNORECASE,
+    )
+    return match.group(1).strip()[:120] if match else None
+
+
+def _extract_put_call_bias(text: str) -> str | None:
+    upper = text.upper()
+    if "CALL BIAS" in upper or "CALLS DOMINATE" in upper or "CALL DOMINANCE" in upper:
+        return "call_bias"
+    if "PUT BIAS" in upper or "PUTS DOMINATE" in upper or "PUT DOMINANCE" in upper:
+        return "put_bias"
+    if "PUT/CALL" in upper or "PCR" in upper or "PUT CALL" in upper:
+        return "neutral"
+    return None
+
+
+def parse_cme_optionsfx_message(raw_text: str, published_at: str | None = None) -> list[dict[str, Any]]:
+    text = html.unescape(str(raw_text or "")).strip()
+    if not text:
+        return []
+    symbols = _extract_symbols(text)
+    if not symbols:
+        return []
+    bias = _option_bias(text)
+    parsed = []
+    for symbol in symbols:
+        parsed.append(
+            {
+                "source": "CME_OptionsFX",
+                "source_kind": "options_flow_source",
+                "symbol": symbol,
+                "pair": symbol,
+                "option_bias": bias,
+                "key_strikes": _extract_key_strikes(text),
+                "max_pain": _extract_first_number_after(r"max\s+pain|pain|макс(?:имальная)?\s+боль", text),
+                "expiry": _extract_expiry(text),
+                "gamma_zone": _extract_gamma_zone(text),
+                "put_call_bias": _extract_put_call_bias(text),
+                "raw_text": text,
+                "published_at": published_at,
+            }
+        )
+    return parsed
+
+
+def _fetch_public_telegram_messages(channel: str) -> list[dict[str, str]]:
+    response = requests.get(
+        f"https://t.me/s/{channel}",
+        timeout=TELEGRAM_REQUEST_TIMEOUT_SECONDS,
+        headers={"User-Agent": "AI-Forex-Signal-Platform/1.0"},
+    )
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    messages: list[dict[str, str]] = []
+    for node in soup.select(".tgme_widget_message")[-TELEGRAM_MAX_MESSAGES:]:
+        text_node = node.select_one(".tgme_widget_message_text")
+        if not text_node:
+            continue
+        time_node = node.select_one("time")
+        published_at = time_node.get("datetime") if time_node else None
+        text = text_node.get_text("\n", strip=True)
+        if text:
+            messages.append({"text": text, "published_at": str(published_at or "")})
+    return messages
+
+
+def get_cme_optionsfx_signals(force_refresh: bool = False) -> dict[str, Any]:
+    source = EXTERNAL_SIGNAL_SOURCES["CME_OptionsFX"]
+    now = time.time()
+    cached = _CACHE.get("CME_OptionsFX")
+    if cached and not force_refresh and now - float(cached.get("cached_at_epoch") or 0) < TELEGRAM_CACHE_TTL_SECONDS:
+        return dict(cached["payload"])
+
+    if not _telegram_credentials_available():
+        payload = {
+            "source": "CME_OptionsFX",
+            "source_kind": source["kind"],
+            "source_url": source["url"],
+            "available": False,
+            "reason": "telegram_credentials_missing",
+            "opens_trades_directly": False,
+            "signals": [],
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _CACHE["CME_OptionsFX"] = {"cached_at_epoch": now, "payload": payload}
+        return payload
+
+    try:
+        messages = _fetch_public_telegram_messages("CME_OptionsFX")
+        signals: list[dict[str, Any]] = []
+        for message in messages:
+            signals.extend(parse_cme_optionsfx_message(message.get("text", ""), message.get("published_at") or None))
+        payload = {
+            "source": "CME_OptionsFX",
+            "source_kind": source["kind"],
+            "source_url": source["url"],
+            "available": True,
+            "opens_trades_directly": False,
+            "signals": signals,
+            "messages_checked": len(messages),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    except Exception as exc:  # pragma: no cover - network/runtime defensive path
+        logger.warning("cme_optionsfx_fetch_failed: %s", exc)
+        payload = {
+            "source": "CME_OptionsFX",
+            "source_kind": source["kind"],
+            "source_url": source["url"],
+            "available": False,
+            "reason": "telegram_fetch_failed",
+            "error": str(exc)[:240],
+            "opens_trades_directly": False,
+            "signals": [],
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    _CACHE["CME_OptionsFX"] = {"cached_at_epoch": now, "payload": payload}
+    return payload
+
+
+def get_cme_optionsfx_confirmation(symbol: Any) -> dict[str, Any]:
+    normalized = _normalize_symbol(symbol)
+    payload = get_cme_optionsfx_signals()
+    signals = payload.get("signals") if isinstance(payload.get("signals"), list) else []
+    matches = [item for item in signals if isinstance(item, dict) and _normalize_symbol(item.get("symbol") or item.get("pair")) == normalized]
+    if not payload.get("available") or not normalized:
+        return {
+            "source": "CME_OptionsFX",
+            "available": False,
+            "used": False,
+            "alignment": "neutral",
+            "option_bias": "neutral",
+            "reason": payload.get("reason") or "unavailable",
+            "signal": None,
+        }
+    if not matches:
+        return {
+            "source": "CME_OptionsFX",
+            "available": True,
+            "used": False,
+            "alignment": "neutral",
+            "option_bias": "neutral",
+            "reason": "no_symbol_match",
+            "signal": None,
+        }
+    signal = matches[-1]
+    return {
+        "source": "CME_OptionsFX",
+        "available": True,
+        "used": True,
+        "alignment": "neutral",
+        "option_bias": signal.get("option_bias") or "neutral",
+        "signal": signal,
+    }

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from typing import Any
 
+from app.services.external_signal_adapter import get_cme_optionsfx_confirmation
+
 try:
     from app.services.openai_idea_narrative import enrich_idea_with_openai_narrative
 except Exception:  # pragma: no cover
@@ -111,6 +113,71 @@ def _normalize_symbol(symbol: Any) -> str:
         raw = raw.split(".", 1)[0]
     return raw
 
+
+
+def _external_options_bias_to_action(symbol: str, option_bias: Any) -> str:
+    bias = str(option_bias or "neutral").lower().strip()
+    if bias == "bullish":
+        return "BUY"
+    if bias == "bearish":
+        return "SELL"
+    return "neutral"
+
+
+def _is_high_confidence_options_conflict(signal: dict[str, Any] | None) -> bool:
+    if not isinstance(signal, dict):
+        return False
+    raw = _text(signal.get("raw_text")).upper()
+    return any(marker in raw for marker in ("HIGH CONFIDENCE", "STRONG", "СИЛЬН", "ВЫСОК", "AGGRESSIVE", "DOMINATE"))
+
+
+def _external_options_alignment(idea: dict[str, Any], direction: str) -> dict[str, Any]:
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    confirmation = get_cme_optionsfx_confirmation(symbol)
+    signal = confirmation.get("signal") if isinstance(confirmation.get("signal"), dict) else None
+    bias = str(confirmation.get("option_bias") or (signal or {}).get("option_bias") or "neutral").lower()
+    implied = _external_options_bias_to_action(symbol, bias)
+    used = bool(confirmation.get("used") and signal)
+    if not used:
+        return {
+            **confirmation,
+            "used": False,
+            "alignment": "neutral",
+            "score_adjustment": 0,
+            "implied_action": "neutral",
+            "high_confidence_conflict": False,
+            "text_ru": "CME_OptionsFX: нет свежих данных по инструменту, слой не блокирует сделку",
+        }
+    if implied not in {"BUY", "SELL"} or direction not in {"BUY", "SELL"}:
+        return {
+            **confirmation,
+            "used": True,
+            "alignment": "neutral",
+            "score_adjustment": 0,
+            "implied_action": implied,
+            "high_confidence_conflict": False,
+            "text_ru": f"CME_OptionsFX нейтрален: options bias {bias}",
+        }
+    if implied == direction:
+        return {
+            **confirmation,
+            "used": True,
+            "alignment": "aligned",
+            "score_adjustment": 4,
+            "implied_action": implied,
+            "high_confidence_conflict": False,
+            "text_ru": f"CME_OptionsFX подтверждает {direction}: options bias {bias}",
+        }
+    high_conflict = _is_high_confidence_options_conflict(signal)
+    return {
+        **confirmation,
+        "used": True,
+        "alignment": "conflict",
+        "score_adjustment": -4,
+        "implied_action": implied,
+        "high_confidence_conflict": high_conflict,
+        "text_ru": f"CME_OptionsFX против {direction}: options bias {bias} ожидает {implied}",
+    }
 
 def _pip_size(symbol: str, entry: float | None = None) -> float:
     symbol = (symbol or "").upper()
@@ -403,8 +470,15 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
     volume_text = _first_text(idea, "volume", "volume_ru", "data_status", "provider")
     rows.append(_row("volume", weights["volume"] if volume_text else 1 if candles else 0, weights["volume"], volume_text or "только OHLC/tick proxy"))
 
+    external_options = _external_options_alignment(idea, direction)
+    external_text = str(external_options.get("text_ru") or "")
     options_text = _first_text(idea, "options_ru", "options_analysis.summary", "options_analysis.bias")
-    rows.append(_row("options", weights["options"] if options_text else 1, weights["options"], options_text or "опционный слой не обязателен для базовой идеи"))
+    options_score = weights["options"] if options_text else 1
+    if external_options.get("alignment") == "aligned":
+        options_score = weights["options"]
+    elif external_options.get("alignment") == "conflict":
+        options_score = 0
+    rows.append(_row("options", options_score, weights["options"], " | ".join(part for part in (options_text, external_text) if part) or "опционный слой не обязателен для базовой идеи"))
 
     sentiment = _sentiment_alignment(idea, direction)
     rows.append(_row("sentiment", int(sentiment.get("score") or 0), weights["sentiment"], str(sentiment.get("text_ru") or "нет sentiment")))
@@ -415,11 +489,14 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     safe_idea = idea if isinstance(idea, dict) else {}
     rows = _criterion_rows(safe_idea)
     total_weight = sum(row["weight"] for row in rows) or 1
-    score = round(sum(row["score"] for row in rows) / total_weight * 100)
+    base_score = round(sum(row["score"] for row in rows) / total_weight * 100)
     direction = _direction(safe_idea)
     geo = _trade_geometry(safe_idea)
     sentiment = _sentiment_alignment(safe_idea, direction)
+    external_options = _external_options_alignment(safe_idea, direction)
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0)))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
+    external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     blockers: list[str] = []
 
     if direction == "WAIT":
@@ -432,8 +509,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         blockers.append(f"Слабый R/R {geo.get('rr'):.2f}, минимум 1.10")
     if sentiment_conflict:
         blockers.append(str(sentiment.get("text_ru") or "Sentiment/news против направления сделки"))
+    if external_options_high_conflict:
+        blockers.append(str(external_options.get("text_ru") or "CME_OptionsFX high-confidence conflict против сделки"))
 
-    hard_blocked = direction == "WAIT" or not geo.get("has_levels") or not geo.get("valid_geometry") or geo.get("tiny_tp") or geo.get("weak_rr") or sentiment_conflict
+    hard_blocked = direction == "WAIT" or not geo.get("has_levels") or not geo.get("valid_geometry") or geo.get("tiny_tp") or geo.get("weak_rr") or sentiment_conflict or external_options_high_conflict
     if score >= 70 and not hard_blocked:
         grade, mode, decision_ru = "A", "prop_entry", "Рабочая prop-идея: есть направление, уровни, свечи, приемлемый риск/прибыль и sentiment не против сделки."
     elif score >= 55 and not hard_blocked:
@@ -456,6 +535,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "trade_geometry": geo,
         "sentiment_filter": sentiment,
         "sentiment_used": sentiment.get("alignment") != "missing",
+        "external_options_filter": external_options,
+        "external_options_used": bool(external_options.get("used")),
+        "external_options_alignment": external_options.get("alignment") or "neutral",
+        "external_options_source": "CME_OptionsFX",
         "delta_divergence": None,
         "margin_zone_confluence": None,
         "disclaimer_ru": "Score не блокирует идею только из-за отсутствия optional CME/options/news слоёв; но если sentiment/news явно против направления, автоторговля блокируется.",
@@ -469,7 +552,9 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
     grade = str(score.get("grade") or "").upper()
     mode = str(score.get("mode") or "").lower()
     sentiment_filter = score.get("sentiment_filter") if isinstance(score.get("sentiment_filter"), dict) else {}
+    external_options_filter = score.get("external_options_filter") if isinstance(score.get("external_options_filter"), dict) else {}
     sentiment_conflict = sentiment_filter.get("alignment") == "conflict"
+    external_options_high_conflict = bool(external_options_filter.get("alignment") == "conflict" and external_options_filter.get("high_confidence_conflict"))
     allowed = (
         action in {"BUY", "SELL"}
         and grade in {"A", "B"}
@@ -480,6 +565,7 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
         and not geo.get("tiny_tp")
         and not geo.get("weak_rr")
         and not sentiment_conflict
+        and not external_options_high_conflict
     )
     reason = "allowed: BUY/SELL + valid levels + RR>=1.10 + TP distance ok + sentiment not against + score>=55" if allowed else "blocked: нужен BUY/SELL, валидные уровни, RR>=1.10, sentiment не против и score>=55"
     return {
@@ -497,6 +583,10 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
         "grade": score.get("grade"),
         "mode": score.get("mode"),
         "sentiment_filter": sentiment_filter,
+        "external_options_used": bool(external_options_filter.get("used")),
+        "external_options_alignment": external_options_filter.get("alignment") or "neutral",
+        "external_options_source": "CME_OptionsFX",
+        "external_options_filter": external_options_filter,
         "level_source": geo.get("level_source"),
     }
 
@@ -528,6 +618,12 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
         enriched["risk_reward"] = rounded_rr
     if advisor_signal.get("level_source"):
         enriched["entry_source"] = advisor_signal.get("level_source")
+    external_options_filter = score.get("external_options_filter") if isinstance(score.get("external_options_filter"), dict) else {}
+    external_options_signal = external_options_filter.get("signal") if isinstance(external_options_filter.get("signal"), dict) else {}
+    enriched["external_options_ru"] = external_options_filter.get("text_ru") or "CME_OptionsFX: нет данных"
+    enriched["external_options_bias"] = external_options_signal.get("option_bias") or external_options_filter.get("option_bias") or "neutral"
+    enriched["external_options_key_strikes"] = external_options_signal.get("key_strikes") or []
+    enriched["external_options_max_pain"] = external_options_signal.get("max_pain")
     enriched.update(
         {
             "prop_signal_score": score,
@@ -538,6 +634,10 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "advisor_allowed": advisor_signal["allowed"],
             "advisor_signal": advisor_signal,
             "sentiment_filter": score.get("sentiment_filter"),
+            "external_options_filter": score.get("external_options_filter"),
+            "external_options_used": score.get("external_options_used"),
+            "external_options_alignment": score.get("external_options_alignment"),
+            "external_options_source": "CME_OptionsFX",
         }
     )
     return enriched

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -105,6 +105,32 @@ function formatNumber(value) {
   return String(num);
 }
 
+function formatListValue(value) {
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "—";
+  if (value === undefined || value === null || value === "") return "—";
+  return String(value);
+}
+
+function resolveExternalOptionsRu(idea) {
+  return firstText(
+    idea.external_options_ru,
+    idea.advisor_signal?.external_options_filter?.text_ru,
+    idea.prop_signal_score?.external_options_filter?.text_ru,
+  ) || "CME_OptionsFX: нет данных, слой не блокирует сделку";
+}
+
+function resolveExternalOptionsBias(idea) {
+  return firstText(
+    idea.external_options_bias,
+    idea.advisor_signal?.external_options_filter?.option_bias,
+    idea.prop_signal_score?.external_options_filter?.option_bias,
+  ) || "neutral";
+}
+
+function renderExternalOptionsCompact(idea) {
+  return `<div class="idea-news-line">CME_OptionsFX: <strong>${escapeHtml(resolveExternalOptionsBias(idea))}</strong> · strikes: ${escapeHtml(formatListValue(idea.external_options_key_strikes))} · max pain: ${escapeHtml(formatListValue(idea.external_options_max_pain))}</div>`;
+}
+
 function getIdeaSymbol(idea) {
   return String(idea.instrument || idea.symbol || idea.pair || "РЫНОК").toUpperCase();
 }
@@ -430,6 +456,7 @@ function renderIdeaCard(idea, index) {
       <div><span>R/R</span><strong>${escapeHtml(formatNumber(idea.rr ?? idea.risk_reward))}</strong></div>
     </div>
     ${renderPropCompact(idea)}
+    ${renderExternalOptionsCompact(idea)}
     <div class="idea-news-line">BOS: ${escapeHtml(idea.market_structure?.bos || "—")} · Sweep: ${escapeHtml(idea.liquidity?.sweep || "—")} · FVG: ${escapeHtml(idea.fvg?.type || idea.selected_zone_type || "—")} · HTF: ${escapeHtml(idea.htf_bias || idea.market_structure?.trend_regime || "—")}</div>
     <div class="idea-summary-compact">${escapeHtml(resolveNarrative(idea))}</div>
   </article>`;
@@ -497,6 +524,7 @@ function openIdeaModal(idea) {
         <div><span>R/R</span><strong>${escapeHtml(formatNumber(idea.rr ?? idea.risk_reward))}</strong></div>
       </div>
       <p class="modal-text"><strong>Новости/фундаментал:</strong> ${escapeHtml(resolveNewsContext(idea))}</p>
+      <p class="modal-text"><strong>Options/CME confirmation:</strong> ${escapeHtml(resolveExternalOptionsRu(idea))}<br><strong>Bias:</strong> ${escapeHtml(resolveExternalOptionsBias(idea))}; <strong>Key strikes:</strong> ${escapeHtml(formatListValue(idea.external_options_key_strikes))}; <strong>Max pain:</strong> ${escapeHtml(formatListValue(idea.external_options_max_pain))}</p>
       <p class="modal-text"><strong>Источник:</strong> ${escapeHtml(idea.data_provider || idea.provider || "нет данных")}</p>
       <p class="modal-text"><strong>Setup:</strong> ${escapeHtml(idea.setup_type || "—")}; <strong>BOS:</strong> ${escapeHtml(idea.market_structure?.bos || "—")}; <strong>Sweep:</strong> ${escapeHtml(idea.liquidity?.sweep || "—")}; <strong>FVG:</strong> ${escapeHtml(idea.fvg?.type || idea.selected_zone_type || "—")}; <strong>HTF bias:</strong> ${escapeHtml(idea.htf_bias || idea.market_structure?.trend_regime || "—")}</p>
     </section>`;

--- a/tests/signals/test_cme_optionsfx_adapter.py
+++ b/tests/signals/test_cme_optionsfx_adapter.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+
+from app.services.external_signal_adapter import get_cme_optionsfx_signals, parse_cme_optionsfx_message
+from app.services import prop_signal_engine
+
+
+def test_cme_optionsfx_unavailable_without_telegram_credentials(monkeypatch):
+    for key in ("TELEGRAM_API_ID", "TELEGRAM_API_HASH", "TELEGRAM_BOT_TOKEN", "TG_API_ID", "TG_API_HASH", "TG_BOT_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+
+    payload = get_cme_optionsfx_signals(force_refresh=True)
+
+    assert payload["source"] == "CME_OptionsFX"
+    assert payload["source_kind"] == "options_flow_source"
+    assert payload["available"] is False
+    assert payload["reason"] == "telegram_credentials_missing"
+    assert payload["signals"] == []
+
+
+def test_parse_cme_optionsfx_message_contract():
+    parsed = parse_cme_optionsfx_message(
+        "EURUSD bullish key strikes: 1.0800, 1.0900 max pain 1.0850 "
+        "expiry 2026-06-21 gamma zone 1.0800-1.1000 put/call call bias"
+    )
+
+    assert parsed == [
+        {
+            "source": "CME_OptionsFX",
+            "source_kind": "options_flow_source",
+            "symbol": "EURUSD",
+            "pair": "EURUSD",
+            "option_bias": "bullish",
+            "key_strikes": [1.08, 1.09],
+            "max_pain": 1.085,
+            "expiry": "2026-06-21",
+            "gamma_zone": "1.0800-1.1000",
+            "put_call_bias": "call_bias",
+            "raw_text": "EURUSD bullish key strikes: 1.0800, 1.0900 max pain 1.0850 expiry 2026-06-21 gamma zone 1.0800-1.1000 put/call call bias",
+            "published_at": None,
+        }
+    ]
+
+
+def test_prop_score_uses_cme_optionsfx_as_confirmation_layer(monkeypatch):
+    def fake_confirmation(symbol):
+        return {
+            "source": "CME_OptionsFX",
+            "available": True,
+            "used": True,
+            "option_bias": "bullish",
+            "signal": {
+                "source": "CME_OptionsFX",
+                "symbol": symbol,
+                "option_bias": "bullish",
+                "key_strikes": [1.08, 1.09],
+                "max_pain": 1.085,
+                "raw_text": "EURUSD bullish options flow",
+            },
+        }
+
+    monkeypatch.setattr(prop_signal_engine, "get_cme_optionsfx_confirmation", fake_confirmation)
+    idea = {
+        "symbol": "EURUSD",
+        "signal": "BUY",
+        "entry": 1.08,
+        "sl": 1.07,
+        "tp": 1.10,
+        "candles": [{"high": 1.10, "low": 1.00, "close": 1.08}] * 80,
+        "reason_ru": "технический импульс",
+    }
+
+    score = prop_signal_engine.build_prop_signal_score(idea)
+    enriched = prop_signal_engine.enrich_idea_with_prop_score(idea)
+
+    assert score["external_options_used"] is True
+    assert score["external_options_alignment"] == "aligned"
+    assert enriched["advisor_signal"]["external_options_source"] == "CME_OptionsFX"
+    assert enriched["advisor_signal"]["external_options_alignment"] == "aligned"
+    assert enriched["external_options_bias"] == "bullish"
+    assert enriched["external_options_key_strikes"] == [1.08, 1.09]
+    assert enriched["external_options_max_pain"] == 1.085


### PR DESCRIPTION
### Motivation
- Добавить дополнительный внешний источник подтверждения опционного контекста из Telegram (https://t.me/CME_OptionsFX) без замены существующего CME/options модуля и без прямого открытия сделок.
- Обеспечить безопасное поведение при отсутствии Telegram-учётных данных, чтобы приложение не падало и scoring работал как раньше.

### Description
- Добавлен новый сервис `app/services/external_signal_adapter.py` с поддержкой источников `sharkfx_ru` (trading_signal_source) и `CME_OptionsFX` (options_flow_source) и парсером последних сообщений CME_OptionsFX для символов `EURUSD, GBPUSD, USDJPY, XAUUSD, DXY` (поля: `option_bias, key_strikes, max_pain, expiry, gamma_zone, put_call_bias, raw_text, source`).
- Добавлен endpoint `GET /api/external-signals/cme-optionsfx` в `app/main.py`, который возвращает распарсенные сообщения и пометку `available=false` при отсутствии Telegram credentials.
- Интеграция в `prop_signal_engine`: добавлен confirmation layer `CME_OptionsFX` — совпадение bias с направлением даёт `+4` к score, конфликт даёт `-4`, а high-confidence конфликт становится blocker; в payload идеи и advisor добавлены поля `external_options_ru`, `external_options_bias`, `external_options_key_strikes`, `external_options_max_pain`, `external_options_used`, `external_options_alignment`, `external_options_source`.
- UI: обновлён `app/static/ideas.js` для показа краткой информации CME_OptionsFX на карточке и в модальном окне.
- Runtime recovery patch (`app/core/prop_score_recovery_patch.py`) обновлён, чтобы сохранять совместимость с новым external-options полем при динамическом патчинге.
- Добавлены тесты `tests/signals/test_cme_optionsfx_adapter.py` для контрактов парсера, поведения при отсутствии credentials и подтверждения в prop-score.

### Testing
- Сборка/статическая проверка модулей: `python -m py_compile app/services/external_signal_adapter.py app/services/prop_signal_engine.py app/core/prop_score_recovery_patch.py app/main.py` — успешно.
- Проверка фронтенд-скрипта: `node --check app/static/ideas.js` — успешно.
- Запуск модульных тестов, относящихся к новым изменениям: `pytest -q tests/signals/test_cme_optionsfx_adapter.py tests/signals/test_prop_signal_fallback.py tests/signals/test_options_impact.py` — все целевые тесты прошли (в сумме 9 passed for the run used).
- Endpoint sanity check: `TestClient(app).get('/api/external-signals/cme-optionsfx')` возвращает корректный payload с `available=false` при отсутствии Telegram credentials.
- Примечание: полный `pytest -q` в репозитории по-прежнему падает на ранее существовавших проблемах (ошибка синтаксиса в `app/services/chart_snapshot_service.py` и отсутствующие экспорты из `app.main`), эти проблемы не связаны с внесёнными изменениями.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd78a8b608331822278409864eb9d)