### PR TITLE
Добавить Telegram External Signals Adapter (SharkFX) и интеграция в prop_signal_engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 
 ## Что обновлено в версии 3.8
+- Добавлен Telegram External Signals Adapter для публичного канала SharkFX (`https://t.me/sharkfx_ru`): `GET /api/external-signals/sharkfx` возвращает `available=false` без Telegram credentials, а при наличии `TELEGRAM_BOT_TOKEN` или `TELEGRAM_API_ID`/`TELEGRAM_API_HASH` безопасно парсит последние доступные сообщения в контракт `symbol/action/entry/sl/tp/confidence/source`.
+- Prop Signal Engine получил внешний SharkFX-фильтр: совпадение направления по тому же symbol добавляет `+5` к score, конфликт добавляет blocker и `-10`, отсутствие внешнего сигнала остаётся neutral и не может быть единственным основанием для авто-входа.
 - Добавлен отдельный Confluence Engine (`services/confluence/confluenceEngine.ts`): объединяет SMC + Liquidity + Options + Volume в единый institutional score, даёт fallback при отсутствии слоя, учитывает conflict/pinning warnings и возвращает финальный `signal/confidence/summary` breakdown.
 - Добавлен единый `CanonicalMarketService` и интерфейс `RealMarketDataProvider` для всех рыночных endpoint: `GET /price/{symbol}`, `GET /market`, `GET /chart/{symbol}/{tf}`, а также `GET /api/price/{symbol}`, `GET /api/market`, `GET /api/canonical/chart/{symbol}/{tf}`.
 - Добавлен MT4 Candle Bridge: `POST /api/mt4/push-candles` принимает реальные broker OHLC, хранит ограниченный in-memory буфер (до 600 баров на symbol/timeframe) и делает MT4 первичным источником в `fetch_candles()` с безопасным fallback на cache/TwelveData/Dukascopy при stale/empty bridge.
@@ -81,6 +83,7 @@
 - `GET /heatmap`
 
 ### Новый API сигналов
+- `GET /api/external-signals/sharkfx` — безопасный Telegram adapter для SharkFX. Без credentials возвращает `available=false`; при наличии доступа возвращает распарсенные внешние сигналы с `source=sharkfx_ru`.
 - `GET /api/signals`
 - `GET /api/signals/active`
 - `GET /api/signals/{id}` — поддерживает и lookup по `signal_id`, и обратную совместимость для symbol lookup

--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -6,6 +6,8 @@ import threading
 import time
 from typing import Any
 
+from app.services.external_signal_adapter import get_latest_sharkfx_signal
+
 logger = logging.getLogger(__name__)
 
 
@@ -240,6 +242,37 @@ def _row(key: str, label: str, weight: int, score: int, text: str) -> dict[str, 
     return {"key": key, "label_ru": label, "weight": weight, "score": score, "status": "confirmed" if score >= weight * 0.7 else "partial" if score > 0 else "missing", "text_ru": text}
 
 
+def _external_signal_filter(symbol: str, direction: str) -> dict[str, Any]:
+    normalized = _normalize_symbol(symbol)
+    result: dict[str, Any] = {
+        "source": "sharkfx_ru",
+        "symbol": normalized,
+        "alignment": "neutral",
+        "score_delta": 0,
+        "used": False,
+        "blocker": False,
+        "signal": None,
+        "text_ru": "SharkFX: свежий внешний сигнал по symbol не найден; фильтр нейтрален.",
+    }
+    if not normalized or direction not in {"BUY", "SELL"}:
+        return result
+    try:
+        external_signal = get_latest_sharkfx_signal(normalized)
+    except Exception:
+        external_signal = None
+    if not isinstance(external_signal, dict):
+        return result
+    external_action = str(external_signal.get("action") or "").upper().strip()
+    if external_action not in {"BUY", "SELL"}:
+        return result
+    result.update({"used": True, "signal": external_signal})
+    if external_action == direction:
+        result.update({"alignment": "aligned", "score_delta": 5, "text_ru": f"SharkFX подтверждает {direction} по {normalized}; +5 к score."})
+    else:
+        result.update({"alignment": "conflict", "score_delta": -10, "blocker": True, "text_ru": f"SharkFX против {direction} по {normalized}: внешний сигнал {external_action}; blocker / -10 к score."})
+    return result
+
+
 def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     candles = _candles(idea)
@@ -250,6 +283,8 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     entry, sl, tp, rr, valid, level_source = _levels(symbol, direction, candles, entry, sl, tp)
     sentiment = _sentiment_alignment(idea, direction)
     sentiment_conflict = sentiment.get("alignment") == "conflict"
+    external_filter = _external_signal_filter(symbol, direction)
+    external_conflict = external_filter.get("alignment") == "conflict"
     has_structure = any(_text_has_data(idea.get(k)) for k in ("reason_ru", "summary_ru", "market_structure", "htf_context", "entry_source"))
     has_liquidity = any(_text_has_data(idea.get(k)) for k in ("liquidity", "selected_zone_type", "selected_zone_low", "fvg", "order_blocks"))
     has_volume = any(_text_has_data(idea.get(k)) for k in ("volume", "volume_ru", "data_status", "provider", "volume_delta"))
@@ -266,7 +301,8 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         _row("sentiment", "Sentiment / новости", 5, int(sentiment.get("score") or 0), str(sentiment.get("text_ru") or "нет sentiment")),
     ]
     score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
-    allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict)
+    score = max(0, min(100, score + int(external_filter.get("score_delta") or 0)))
+    allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict and not external_conflict)
     grade = "A" if score >= 70 else "B" if score >= 55 else "C" if score >= 40 else "D"
     mode = "prop_entry" if allowed and score >= 70 else "watchlist" if allowed else "research_only" if score >= 40 else "no_trade"
     blockers = []
@@ -278,8 +314,10 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         blockers.append(f"Слабый R/R {rr:.2f}")
     if sentiment_conflict:
         blockers.append(str(sentiment.get("text_ru")))
-    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles)}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing"}
-    advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "level_source": level_source}
+    if external_conflict:
+        blockers.append(str(external_filter.get("text_ru")))
+    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles)}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_signal_filter": external_filter, "external_signal_used": bool(external_filter.get("used")), "external_signal_alignment": external_filter.get("alignment") or "neutral", "external_signal_source": "sharkfx_ru"}
+    advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment/SharkFX not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_signal_filter": external_filter, "external_signal_used": bool(external_filter.get("used")), "external_signal_alignment": external_filter.get("alignment") or "neutral", "external_signal_source": "sharkfx_ru", "level_source": level_source}
     return score_payload, advisor
 
 
@@ -332,6 +370,10 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["advisor_allowed"] = advisor["allowed"]
                     enriched["advisor_signal"] = advisor
                     enriched["sentiment_filter"] = score.get("sentiment_filter")
+                    enriched["external_signal_filter"] = score.get("external_signal_filter")
+                    enriched["external_signal_used"] = score.get("external_signal_used")
+                    enriched["external_signal_alignment"] = score.get("external_signal_alignment")
+                    enriched["external_signal_source"] = "sharkfx_ru"
                     return enriched
 
                 module.build_prop_signal_score = patched_build_prop_signal_score

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
+from app.services.external_signal_adapter import fetch_sharkfx_external_signals
 from app.services.signal_audit_logger import log_signal_audit
 from backend.chat_service import ChatRequest, ForexChatService
 
@@ -758,6 +759,24 @@ def heatmap_page():
 @app.get("/api/heatmap")
 def api_heatmap(mode: str = "core", tf: str = "M15"):
     return build_currency_heatmap(mode=mode, tf=tf)
+
+
+@app.get("/api/external-signals/sharkfx")
+def api_external_signals_sharkfx(force_refresh: bool = False):
+    try:
+        return fetch_sharkfx_external_signals(force_refresh=force_refresh)
+    except Exception as exc:
+        logger.exception("api_external_signals_sharkfx_failed")
+        return {
+            "available": False,
+            "source": "sharkfx_ru",
+            "channel_url": "https://t.me/sharkfx_ru",
+            "signals": [],
+            "count": 0,
+            "updated_at_utc": now_utc(),
+            "reason": "external_signal_adapter_error",
+            "error": str(exc)[:500],
+        }
 
 
 @app.get("/api/signals")

--- a/app/services/external_signal_adapter.py
+++ b/app/services/external_signal_adapter.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+from telethon import TelegramClient
+from telethon.sessions import StringSession
+
+logger = logging.getLogger(__name__)
+
+SHARKFX_CHANNEL = "sharkfx_ru"
+SHARKFX_URL = "https://t.me/sharkfx_ru"
+CACHE_TTL_SECONDS = int(os.getenv("EXTERNAL_SIGNAL_CACHE_TTL_SECONDS", "120"))
+BOT_API_TIMEOUT_SECONDS = float(os.getenv("TELEGRAM_BOT_API_TIMEOUT_SECONDS", "6"))
+MAX_MESSAGES = int(os.getenv("TELEGRAM_EXTERNAL_SIGNAL_LIMIT", "25"))
+
+_SYMBOL_RE = re.compile(
+    r"\b("
+    r"EURUSD|GBPUSD|USDJPY|USDCHF|USDCAD|AUDUSD|NZDUSD|"
+    r"EURGBP|EURJPY|EURCHF|EURCAD|EURAUD|EURNZD|"
+    r"GBPJPY|GBPCHF|GBPCAD|GBPAUD|GBPNZD|"
+    r"AUDJPY|AUDCAD|AUDNZD|NZDJPY|NZDCAD|CADJPY|CADCHF|CHFJPY|"
+    r"XAUUSD|GOLD|XAGUSD|SILVER|BTCUSD|ETHUSD"
+    r")\b",
+    re.IGNORECASE,
+)
+_ACTION_RE = re.compile(r"\b(BUY|SELL|LONG|SHORT|ПОКУП(?:АТЬ|КА)?|ПРОДА(?:ВАТЬ|ЖА)?)\b", re.IGNORECASE)
+_NUMBER_RE = r"([0-9]+(?:[\s,.][0-9]+)?)"
+_ENTRY_RE = re.compile(rf"(?:ENTRY|ENTER|ВХОД|ТОЧКА\s+ВХОДА|ОТКРЫТИЕ|PRICE|@)\s*[:=\-–—]?\s*{_NUMBER_RE}", re.IGNORECASE)
+_SL_RE = re.compile(rf"(?:\bSL\b|STOP\s*LOSS|STOPLOSS|СТОП|СТОП\s*ЛОСС)\s*[:=\-–—]?\s*{_NUMBER_RE}", re.IGNORECASE)
+_TP_RE = re.compile(rf"(?:\bTP\s*\d*\b|TAKE\s*PROFIT|TAKEPROFIT|ТЕЙК|ЦЕЛЬ)\s*[:=\-–—]?\s*{_NUMBER_RE}", re.IGNORECASE)
+_CONFIDENCE_RE = re.compile(r"(?:CONFIDENCE|CONF|ВЕРОЯТНОСТЬ|УВЕРЕННОСТЬ)\s*[:=\-–—]?\s*(\d{1,3})(?:\s*%)?", re.IGNORECASE)
+
+_CACHE: dict[str, Any] = {"updated_at": 0.0, "payload": None}
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_number(raw: str | None) -> float | None:
+    if not raw:
+        return None
+    text = str(raw).strip().replace(" ", "").replace(",", ".")
+    try:
+        return float(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_external_symbol(symbol: Any) -> str:
+    raw = str(symbol or "").upper().strip().replace("/", "")
+    if raw == "GOLD":
+        return "XAUUSD"
+    if raw == "SILVER":
+        return "XAGUSD"
+    return raw
+
+
+def parse_external_signal_text(text: str, *, message_id: Any = None, date: Any = None) -> dict[str, Any] | None:
+    """Extract a normalized external signal from a Telegram message text."""
+    body = str(text or "").strip()
+    if not body:
+        return None
+
+    symbol_match = _SYMBOL_RE.search(body.replace("/", ""))
+    action_match = _ACTION_RE.search(body)
+    if not symbol_match or not action_match:
+        return None
+
+    action_raw = action_match.group(1).upper()
+    action = "SELL" if action_raw in {"SELL", "SHORT"} or action_raw.startswith("ПРОДА") else "BUY"
+    entry_match = _ENTRY_RE.search(body)
+    sl_match = _SL_RE.search(body)
+    tp_match = _TP_RE.search(body)
+    confidence_match = _CONFIDENCE_RE.search(body)
+
+    signal = {
+        "source": SHARKFX_CHANNEL,
+        "symbol": normalize_external_symbol(symbol_match.group(1)),
+        "action": action,
+        "entry": _normalize_number(entry_match.group(1) if entry_match else None),
+        "sl": _normalize_number(sl_match.group(1) if sl_match else None),
+        "tp": _normalize_number(tp_match.group(1) if tp_match else None),
+        "confidence": _normalize_number(confidence_match.group(1) if confidence_match else None),
+        "message_id": message_id,
+        "message_date": str(date) if date else None,
+        "text_preview": body[:280],
+    }
+    return signal
+
+
+def _credentials_status() -> dict[str, Any]:
+    bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    api_id = os.getenv("TELEGRAM_API_ID", "").strip()
+    api_hash = os.getenv("TELEGRAM_API_HASH", "").strip()
+    session_string = os.getenv("TELEGRAM_SESSION_STRING", "").strip()
+    has_bot_api = bool(bot_token)
+    has_telethon = bool(api_id and api_hash)
+    return {
+        "bot_token": bot_token,
+        "api_id": api_id,
+        "api_hash": api_hash,
+        "session_string": session_string,
+        "has_bot_api": has_bot_api,
+        "has_telethon": has_telethon,
+        "has_any": has_bot_api or has_telethon,
+    }
+
+
+def _unavailable(reason: str, *, error: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "available": False,
+        "source": SHARKFX_CHANNEL,
+        "channel_url": SHARKFX_URL,
+        "signals": [],
+        "count": 0,
+        "updated_at_utc": _now_utc(),
+        "reason": reason,
+    }
+    if error:
+        payload["error"] = error[:500]
+    return payload
+
+
+def _payload(signals: list[dict[str, Any]], *, provider: str, warning: str | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "available": True,
+        "source": SHARKFX_CHANNEL,
+        "channel_url": SHARKFX_URL,
+        "provider": provider,
+        "signals": signals,
+        "count": len(signals),
+        "updated_at_utc": _now_utc(),
+    }
+    if warning:
+        result["warning"] = warning
+    return result
+
+
+def _parse_bot_api_updates(updates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for update in reversed(updates[-MAX_MESSAGES:]):
+        message = update.get("channel_post") or update.get("edited_channel_post") or update.get("message") or {}
+        chat = message.get("chat") if isinstance(message, dict) else {}
+        username = str((chat or {}).get("username") or "").lower()
+        if username and username != SHARKFX_CHANNEL:
+            continue
+        text = message.get("text") or message.get("caption") or ""
+        signal = parse_external_signal_text(text, message_id=message.get("message_id"), date=message.get("date"))
+        if not signal:
+            continue
+        key = (signal["symbol"], signal["action"], str(signal.get("message_id") or signal.get("text_preview")))
+        if key in seen:
+            continue
+        seen.add(key)
+        signals.append(signal)
+    return signals
+
+
+def _fetch_via_bot_api(bot_token: str) -> dict[str, Any]:
+    try:
+        url = f"https://api.telegram.org/bot{bot_token}/getUpdates"
+        response = requests.get(
+            url,
+            params={"limit": MAX_MESSAGES, "timeout": 0, "allowed_updates": '["channel_post","edited_channel_post","message"]'},
+            timeout=BOT_API_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if not data.get("ok"):
+            return _unavailable("telegram_bot_api_error", error=str(data))
+        updates = data.get("result") if isinstance(data.get("result"), list) else []
+        signals = _parse_bot_api_updates(updates)
+        return _payload(
+            signals,
+            provider="telegram_bot_api",
+            warning="Bot API отдаёт только updates, которые доступны боту; история публичного канала может быть пустой без добавления бота в канал.",
+        )
+    except Exception as exc:
+        logger.exception("telegram_bot_api_fetch_failed")
+        return _unavailable("telegram_bot_api_fetch_failed", error=str(exc))
+
+
+async def _fetch_via_telethon_async(credentials: dict[str, Any]) -> dict[str, Any]:
+    client = None
+    try:
+        session = StringSession(credentials.get("session_string") or "")
+        client = TelegramClient(session, int(credentials["api_id"]), credentials["api_hash"])
+        if credentials.get("bot_token"):
+            await client.start(bot_token=credentials["bot_token"])
+        else:
+            await client.connect()
+            if not await client.is_user_authorized():
+                return _unavailable("telegram_session_required")
+
+        messages = await client.get_messages(SHARKFX_CHANNEL, limit=MAX_MESSAGES)
+        signals: list[dict[str, Any]] = []
+        for message in messages:
+            text = getattr(message, "message", "") or getattr(message, "text", "") or ""
+            signal = parse_external_signal_text(
+                text,
+                message_id=getattr(message, "id", None),
+                date=getattr(message, "date", None),
+            )
+            if signal:
+                signals.append(signal)
+        return _payload(signals, provider="telegram_api")
+    except Exception as exc:
+        logger.exception("telegram_api_fetch_failed")
+        return _unavailable("telegram_api_fetch_failed", error=str(exc))
+    finally:
+        if client is not None:
+            try:
+                await client.disconnect()
+            except Exception:
+                logger.exception("telegram_api_disconnect_failed")
+
+
+def _fetch_via_telethon(credentials: dict[str, Any]) -> dict[str, Any]:
+    try:
+        return asyncio.run(_fetch_via_telethon_async(credentials))
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(_fetch_via_telethon_async(credentials))
+        except Exception as exc:
+            logger.exception("telegram_api_loop_failed")
+            return _unavailable("telegram_api_loop_failed", error=str(exc))
+        finally:
+            loop.close()
+    except Exception as exc:
+        logger.exception("telegram_api_fetch_wrapper_failed")
+        return _unavailable("telegram_api_fetch_wrapper_failed", error=str(exc))
+
+
+def fetch_sharkfx_external_signals(*, force_refresh: bool = False) -> dict[str, Any]:
+    """Return parsed SharkFX Telegram signals without making the app depend on Telegram availability."""
+    cached_payload = _CACHE.get("payload")
+    cache_age = time.time() - float(_CACHE.get("updated_at") or 0.0)
+    if not force_refresh and isinstance(cached_payload, dict) and cache_age < CACHE_TTL_SECONDS:
+        return cached_payload
+
+    credentials = _credentials_status()
+    if not credentials["has_any"]:
+        payload = _unavailable("telegram_credentials_missing")
+    elif credentials["has_telethon"]:
+        payload = _fetch_via_telethon(credentials)
+    elif credentials["has_bot_api"]:
+        payload = _fetch_via_bot_api(credentials["bot_token"])
+    else:
+        payload = _unavailable("telegram_credentials_incomplete")
+
+    _CACHE["updated_at"] = time.time()
+    _CACHE["payload"] = payload
+    return payload
+
+
+def get_latest_sharkfx_signal(symbol: str) -> dict[str, Any] | None:
+    normalized = normalize_external_symbol(symbol)
+    try:
+        payload = fetch_sharkfx_external_signals()
+        if not payload.get("available"):
+            return None
+        for signal in payload.get("signals") or []:
+            if normalize_external_symbol(signal.get("symbol")) == normalized:
+                return signal
+    except Exception:
+        logger.exception("external_signal_lookup_failed symbol=%s", symbol)
+    return None

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services.external_signal_adapter import get_latest_sharkfx_signal
+
 try:
     from app.services.openai_idea_narrative import enrich_idea_with_openai_narrative
 except Exception:  # pragma: no cover
@@ -221,6 +223,52 @@ def _sentiment_alignment(idea: dict[str, Any], direction: str) -> dict[str, Any]
     return {**payload, "alignment": "conflict", "score": 0, "text_ru": f"sentiment против {direction}: ожидает {implied} ({payload.get('usd_bias')})"}
 
 
+def _external_signal_filter(idea: dict[str, Any], direction: str) -> dict[str, Any]:
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    result: dict[str, Any] = {
+        "source": "sharkfx_ru",
+        "symbol": symbol,
+        "alignment": "neutral",
+        "score_delta": 0,
+        "used": False,
+        "blocker": False,
+        "signal": None,
+        "text_ru": "SharkFX: свежий внешний сигнал по symbol не найден; фильтр нейтрален.",
+    }
+    if not symbol or direction not in {"BUY", "SELL"}:
+        return result
+    try:
+        external_signal = get_latest_sharkfx_signal(symbol)
+    except Exception:
+        external_signal = None
+    if not isinstance(external_signal, dict):
+        return result
+
+    external_action = str(external_signal.get("action") or "").upper().strip()
+    if external_action not in {"BUY", "SELL"}:
+        return result
+
+    result.update({"used": True, "signal": external_signal})
+    if external_action == direction:
+        result.update(
+            {
+                "alignment": "aligned",
+                "score_delta": 5,
+                "text_ru": f"SharkFX подтверждает {direction} по {symbol}; +5 к score.",
+            }
+        )
+    else:
+        result.update(
+            {
+                "alignment": "conflict",
+                "score_delta": -10,
+                "blocker": True,
+                "text_ru": f"SharkFX против {direction} по {symbol}: внешний сигнал {external_action}; blocker / -10 к score.",
+            }
+        )
+    return result
+
+
 def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
     direction = _direction(idea)
     geo = _trade_geometry(idea)
@@ -277,6 +325,9 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     geo = _trade_geometry(safe_idea)
     sentiment = _sentiment_alignment(safe_idea, direction)
     sentiment_conflict = sentiment.get("alignment") == "conflict"
+    external_filter = _external_signal_filter(safe_idea, direction)
+    score = max(0, min(100, score + int(external_filter.get("score_delta") or 0)))
+    external_conflict = external_filter.get("alignment") == "conflict"
     blockers: list[str] = []
 
     if direction == "WAIT":
@@ -289,8 +340,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         blockers.append(f"Слабый R/R {geo.get('rr'):.2f}, минимум 1.10")
     if sentiment_conflict:
         blockers.append(str(sentiment.get("text_ru") or "Sentiment/news против направления сделки"))
+    if external_conflict:
+        blockers.append(str(external_filter.get("text_ru") or "SharkFX против направления сделки"))
 
-    hard_blocked = direction == "WAIT" or not geo.get("has_levels") or not geo.get("valid_geometry") or geo.get("tiny_tp") or geo.get("weak_rr") or sentiment_conflict
+    hard_blocked = direction == "WAIT" or not geo.get("has_levels") or not geo.get("valid_geometry") or geo.get("tiny_tp") or geo.get("weak_rr") or sentiment_conflict or external_conflict
     if score >= 70 and not hard_blocked:
         grade, mode, decision_ru = "A", "prop_entry", "Рабочая prop-идея: есть направление, уровни, свечи, приемлемый риск/прибыль и sentiment не против сделки."
     elif score >= 55 and not hard_blocked:
@@ -313,6 +366,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "trade_geometry": geo,
         "sentiment_filter": sentiment,
         "sentiment_used": sentiment.get("alignment") != "missing",
+        "external_signal_filter": external_filter,
+        "external_signal_used": bool(external_filter.get("used")),
+        "external_signal_alignment": external_filter.get("alignment") or "neutral",
+        "external_signal_source": "sharkfx_ru",
         "delta_divergence": None,
         "margin_zone_confluence": None,
         "disclaimer_ru": "Score не блокирует идею только из-за отсутствия optional CME/options/news слоёв; но если sentiment/news явно против направления, автоторговля блокируется.",
@@ -327,6 +384,8 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
     mode = str(score.get("mode") or "").lower()
     sentiment_filter = score.get("sentiment_filter") if isinstance(score.get("sentiment_filter"), dict) else {}
     sentiment_conflict = sentiment_filter.get("alignment") == "conflict"
+    external_filter = score.get("external_signal_filter") if isinstance(score.get("external_signal_filter"), dict) else {}
+    external_conflict = external_filter.get("alignment") == "conflict"
     allowed = (
         action in {"BUY", "SELL"}
         and grade in {"A", "B"}
@@ -337,8 +396,9 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
         and not geo.get("tiny_tp")
         and not geo.get("weak_rr")
         and not sentiment_conflict
+        and not external_conflict
     )
-    reason = "allowed: BUY/SELL + valid levels + RR>=1.10 + TP distance ok + sentiment not against + score>=55" if allowed else "blocked: нужен BUY/SELL, валидные уровни, RR>=1.10, sentiment не против и score>=55"
+    reason = "allowed: BUY/SELL + valid levels + RR>=1.10 + TP distance ok + sentiment not against + SharkFX not against + score>=55" if allowed else "blocked: нужен BUY/SELL, валидные уровни, RR>=1.10, sentiment/SharkFX не против и score>=55"
     return {
         "allowed": allowed,
         "reason": reason,
@@ -354,6 +414,10 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
         "grade": score.get("grade"),
         "mode": score.get("mode"),
         "sentiment_filter": sentiment_filter,
+        "external_signal_filter": external_filter,
+        "external_signal_used": bool(external_filter.get("used")),
+        "external_signal_alignment": external_filter.get("alignment") or "neutral",
+        "external_signal_source": "sharkfx_ru",
     }
 
 
@@ -373,6 +437,10 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "advisor_allowed": advisor_signal["allowed"],
             "advisor_signal": advisor_signal,
             "sentiment_filter": score.get("sentiment_filter"),
+            "external_signal_filter": score.get("external_signal_filter"),
+            "external_signal_used": score.get("external_signal_used"),
+            "external_signal_alignment": score.get("external_signal_alignment"),
+            "external_signal_source": "sharkfx_ru",
         }
     )
     return enriched

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ ta==0.11.0
 python-dotenv==1.0.1
 websocket-client==1.8.0
 feedparser==6.0.11
+telethon==1.38.1

--- a/tests/test_external_signal_adapter.py
+++ b/tests/test_external_signal_adapter.py
@@ -1,0 +1,68 @@
+from app.services.external_signal_adapter import fetch_sharkfx_external_signals, parse_external_signal_text
+from app.services.prop_signal_engine import build_prop_signal_score
+
+
+def test_parse_external_signal_text_extracts_core_fields():
+    signal = parse_external_signal_text(
+        "EURUSD BUY\nEntry: 1.0850\nSL: 1.0810\nTP1: 1.0930\nConfidence: 78%",
+        message_id=101,
+        date="2026-06-03T10:00:00Z",
+    )
+
+    assert signal is not None
+    assert signal["source"] == "sharkfx_ru"
+    assert signal["symbol"] == "EURUSD"
+    assert signal["action"] == "BUY"
+    assert signal["entry"] == 1.0850
+    assert signal["sl"] == 1.0810
+    assert signal["tp"] == 1.0930
+    assert signal["confidence"] == 78
+
+
+def test_fetch_sharkfx_external_signals_is_unavailable_without_credentials(monkeypatch):
+    for key in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_API_ID", "TELEGRAM_API_HASH", "TELEGRAM_SESSION_STRING"):
+        monkeypatch.delenv(key, raising=False)
+    import app.services.external_signal_adapter as adapter
+
+    adapter._CACHE["updated_at"] = 0
+    adapter._CACHE["payload"] = None
+
+    payload = fetch_sharkfx_external_signals(force_refresh=True)
+
+    assert payload["available"] is False
+    assert payload["source"] == "sharkfx_ru"
+    assert payload["signals"] == []
+    assert payload["reason"] == "telegram_credentials_missing"
+
+
+def test_prop_score_external_signal_alignment(monkeypatch):
+    import app.services.prop_signal_engine as engine
+
+    monkeypatch.setattr(
+        engine,
+        "get_latest_sharkfx_signal",
+        lambda symbol: {"source": "sharkfx_ru", "symbol": symbol, "action": "BUY", "entry": 1.0850, "sl": 1.0810, "tp": 1.0930},
+    )
+
+    score = build_prop_signal_score({"symbol": "EURUSD", "action": "BUY", "entry": 1.0850, "sl": 1.0810, "tp": 1.0930})
+
+    assert score["external_signal_used"] is True
+    assert score["external_signal_alignment"] == "aligned"
+    assert score["external_signal_filter"]["score_delta"] == 5
+
+
+def test_prop_score_external_signal_conflict_blocks(monkeypatch):
+    import app.services.prop_signal_engine as engine
+
+    monkeypatch.setattr(
+        engine,
+        "get_latest_sharkfx_signal",
+        lambda symbol: {"source": "sharkfx_ru", "symbol": symbol, "action": "SELL", "entry": 1.0850, "sl": 1.0900, "tp": 1.0750},
+    )
+
+    score = build_prop_signal_score({"symbol": "EURUSD", "action": "BUY", "entry": 1.0850, "sl": 1.0810, "tp": 1.0930})
+
+    assert score["external_signal_used"] is True
+    assert score["external_signal_alignment"] == "conflict"
+    assert score["external_signal_filter"]["score_delta"] == -10
+    assert any("SharkFX против" in blocker for blocker in score["blockers"])


### PR DESCRIPTION
### Motivation
- Нужно получать и учитывать публичные сигналы из Telegram-канала SharkFX без жёсткой зависимости от Telegram (без падений приложения при отсутствии credentials). 
- Включить внешний сигнал как дополнительный фильтр в scoring/advise pipeline, чтобы улучшать согласование внешних и внутренних сигналов.

### Description
- Добавлен новый модуль `app/services/external_signal_adapter.py`, который парсит последние сообщения канала `https://t.me/sharkfx_ru` через `TELEGRAM_BOT_TOKEN` (Bot API) или Telethon (`TELEGRAM_API_ID`/`TELEGRAM_API_HASH`/`TELEGRAM_SESSION_STRING`) и извлекает `symbol/action/entry/sl/tp/confidence/source`, при отсутствии credentials возвращает `available=false` и не ломает приложение. 
- Добавлен публичный endpoint `GET /api/external-signals/sharkfx` в `app/main.py`, возвращающий payload адаптера и безопасно обрабатывающий исключения адаптера. 
- Интегрирован фильтр внешних сигналов в `app/services/prop_signal_engine.py`: функция `_external_signal_filter` устанавливает `external_signal_used`, `external_signal_alignment` и `external_signal_filter`; совпадение направления даёт `score_delta = +5`, конфликт даёт `score_delta = -10` и помечается как blocker; внешняя проверка не может единолично разрешать автотрейд (внутренние условия остаются обязательными). 
- Обновлён runtime recovery patch `app/core/prop_score_recovery_patch.py` и `enrich_idea_with_prop_score`/advisor payload, добавлена поддержка полей `external_signal_*`. 
- Добавлены тесты `tests/test_external_signal_adapter.py` и зависимость `telethon==1.38.1`, а также обновлён `README.md` с описанием нового API.

### Testing
- Запущены юнит-тесты адаптера: `pytest tests/test_external_signal_adapter.py` — 4 passed. 
- Запущены сигнальные тесты на устойчивость: `pytest tests/signals/test_signal_engine_resilience.py` — 8 passed. 
- Совместный запуск новых тестов: `pytest tests/test_external_signal_adapter.py tests/signals/test_signal_engine_resilience.py` — 12 passed. 
- Проверена работоспособность endpoint через TestClient: `GET /api/external-signals/sharkfx` вернул `200` и payload с `available=false` и `reason=telegram_credentials_missing` при отсутствии переменных окружения. 
- Произведена проверка компиляции модулей (`python -m py_compile ...`) — успешно; известная проблема: полный набор тестов `tests/signals/test_signal_engine_resilience.py tests/test_production_safety.py` падает на этапе collection из-за импорта `trade_idea_service` из `app.main` в `tests/test_production_safety.py` (не связана с этим PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd644b3808331806e3cda3fa1f893)