### PR TITLE
Add Volume Delta priority chain and prop-engine integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@
 - `symbol` и `timeframe` всегда остаются в ответе API;
 - текущий UI не менялся, поэтому карточки продолжают рендериться в прежнем дизайне.
 
+
+### Volume Delta priority chain
+MT4/FutureVolume слой теперь передаёт стабильный объект `volume_delta` в payload и prop score:
+- `source` — `FutureDelta`, `FutureVolume`, `tick_volume` или `unavailable`;
+- `delta` — дельта текущей свечи/буфера;
+- `cumdelta` — накопленная дельта;
+- `is_proxy` — `false` только для primary-данных FutureDelta, `true` для расчётов от FutureVolume/tick volume;
+- `priority_used` — 1 для FutureDelta, 2 для расчёта от FutureVolume, 3 для расчёта от MT4 tick volume.
+
+Приоритет расчёта: сначала реальные буферы FutureDelta (`delta`/`cumdelta`), затем proxy-дельта `future_volume * body_ratio`, затем proxy-дельта `tick_volume * body_ratio`, где `body_ratio = (close - open) / max(high - low, tiny)`. Prop engine подтверждает BUY только при росте цены и CumDelta, SELL — при падении цены и CumDelta; при расхождении выставляется `delta_divergence=true` и score уменьшается.
+
 ### Модель статистики сигналов
 Ответ `GET /api/signals` дополнительно содержит:
 - `stats.total`

--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -284,6 +284,56 @@ def _row(key: str, label: str, weight: int, score: int, text: str) -> dict[str, 
     return {"key": key, "label_ru": label, "weight": weight, "score": score, "status": "confirmed" if score >= weight * 0.7 else "partial" if score > 0 else "missing", "text_ru": text}
 
 
+def _price_delta(candles: list[dict[str, Any]]) -> float | None:
+    closes = [_num(c.get("close")) for c in candles[-3:]]
+    closes = [x for x in closes if x is not None]
+    if len(closes) < 2:
+        return None
+    return closes[-1] - closes[-2]
+
+
+def _extract_volume_delta(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    nested = payload.get("volume_delta") if isinstance(payload.get("volume_delta"), dict) else {}
+    delta = _num(nested.get("delta") if nested else payload.get("volume_delta_delta") or payload.get("delta") or payload.get("delta_change"))
+    cumdelta = _num((nested.get("cumdelta") or nested.get("cum_delta") or nested.get("cumulative_delta")) if nested else payload.get("cumdelta") or payload.get("cum_delta") or payload.get("cumulative_delta"))
+    if delta is None and cumdelta is None:
+        return None
+    source = str((nested.get("source") if nested else None) or payload.get("volume_delta_source") or "unavailable")
+    priority = (nested.get("priority_used") if nested else payload.get("volume_delta_priority_used"))
+    is_proxy = nested.get("is_proxy") if nested else payload.get("volume_delta_is_proxy")
+    if is_proxy is None:
+        is_proxy = source != "FutureDelta"
+    return {"available": True, "source": source, "delta": delta, "cumdelta": cumdelta, "is_proxy": bool(is_proxy), "priority_used": priority}
+
+
+def _volume_delta_context(idea: dict[str, Any], symbol: str, timeframe: str, direction: str, candles: list[dict[str, Any]]) -> dict[str, Any]:
+    vd = _extract_volume_delta(idea)
+    if vd is None:
+        try:
+            from app.services.mt4_volume_cluster_bridge import get_latest_volume_cluster
+            vd = _extract_volume_delta(get_latest_volume_cluster(symbol, timeframe))
+        except Exception:
+            vd = None
+    price_delta = _price_delta(candles)
+    if vd is None:
+        return {"available": False, "source": "unavailable", "delta": None, "cumdelta": None, "is_proxy": True, "priority_used": None, "price_trend": "unknown", "cumdelta_trend": "unknown", "confirmed": False, "delta_divergence": False, "score_adjustment": 0, "text_ru": "Volume Delta недоступна: FutureDelta/FutureVolume/tick volume не получены."}
+    delta = _num(vd.get("delta"))
+    price_trend = "rising" if price_delta is not None and price_delta > 0 else "falling" if price_delta is not None and price_delta < 0 else "flat"
+    cumdelta_trend = "rising" if delta is not None and delta > 0 else "falling" if delta is not None and delta < 0 else "flat"
+    confirmed = (direction == "BUY" and price_trend == "rising" and cumdelta_trend == "rising") or (direction == "SELL" and price_trend == "falling" and cumdelta_trend == "falling")
+    divergence = False
+    adjustment = 0
+    if direction in {"BUY", "SELL"} and price_trend in {"rising", "falling"} and cumdelta_trend in {"rising", "falling"} and not confirmed:
+        divergence = price_trend != cumdelta_trend
+        adjustment = -5 if divergence else -3
+    text = f"CumDelta source={vd.get('source')} ({'proxy' if vd.get('is_proxy') else 'real'}), priority={vd.get('priority_used') or '—'}, delta={vd.get('delta')}, cumdelta={vd.get('cumdelta')}, price={price_trend}, cumdelta_trend={cumdelta_trend}"
+    if divergence:
+        text += "; delta_divergence=true"
+    return {**vd, "price_delta": price_delta, "price_trend": price_trend, "cumdelta_trend": cumdelta_trend, "confirmed": confirmed, "delta_divergence": divergence, "score_adjustment": adjustment, "text_ru": text}
+
+
 def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     candles = _candles(idea)
@@ -294,11 +344,12 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     entry, sl, tp, rr, valid, level_source = _levels(symbol, direction, candles, entry, sl, tp)
     sentiment = _sentiment_alignment(idea, direction)
     external_options = _external_options_alignment(symbol, direction)
+    volume_delta = _volume_delta_context(idea, symbol, str(idea.get("timeframe") or idea.get("tf") or ""), direction, candles)
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     has_structure = any(_text_has_data(idea.get(k)) for k in ("reason_ru", "summary_ru", "market_structure", "htf_context", "entry_source"))
     has_liquidity = any(_text_has_data(idea.get(k)) for k in ("liquidity", "selected_zone_type", "selected_zone_low", "fvg", "order_blocks"))
-    has_volume = any(_text_has_data(idea.get(k)) for k in ("volume", "volume_ru", "data_status", "provider", "volume_delta"))
+    has_volume = any(_text_has_data(idea.get(k)) for k in ("volume", "volume_ru", "data_status", "provider", "volume_delta")) or bool(volume_delta.get("available"))
     has_options = any(_text_has_data(idea.get(k)) for k in ("options_ru", "options_analysis", "cme"))
     options_score = 4 if has_options or external_options.get("alignment") == "aligned" else 0 if external_options.get("alignment") == "conflict" else 1
     options_text = str(external_options.get("text_ru") or ("опционный слой есть" if has_options else "опционный слой не обязателен"))
@@ -309,12 +360,12 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         _row("candles", "Реальные свечи", 14, 14 if len(candles) >= 80 else 10 if len(candles) >= 30 else 6 if len(candles) >= 12 else 0, f"{len(candles)} свечей"),
         _row("structure", "Структура / импульс", 12, 12 if has_structure else 6 if direction in {"BUY", "SELL"} else 0, "структура/импульс есть" if has_structure else "технический импульс без расширенной структуры"),
         _row("liquidity", "Ликвидность / POI", 8, 8 if has_liquidity else 2 if direction in {"BUY", "SELL"} else 0, "liquidity/POI есть" if has_liquidity else "нет отдельного liquidity слоя"),
-        _row("volume", "Volume / tick volume", 5, 5 if has_volume else 1 if candles else 0, "volume/tick proxy есть" if has_volume else "только OHLC/tick proxy"),
+        _row("volume", "Volume / tick volume", 5, 5 if volume_delta.get("confirmed") else 3 if volume_delta.get("available") else 5 if has_volume else 1 if candles else 0, str(volume_delta.get("text_ru") or ("volume/tick proxy есть" if has_volume else "только OHLC/tick proxy"))),
         _row("options", "Опционы / CME", 4, options_score, options_text),
         _row("sentiment", "Sentiment / новости", 5, int(sentiment.get("score") or 0), str(sentiment.get("text_ru") or "нет sentiment")),
     ]
     base_score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0)))
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0)))
     allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict and not external_options_high_conflict)
     grade = "A" if score >= 70 else "B" if score >= 55 else "C" if score >= 40 else "D"
     mode = "prop_entry" if allowed and score >= 70 else "watchlist" if allowed else "research_only" if score >= 40 else "no_trade"
@@ -329,7 +380,9 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         blockers.append(str(sentiment.get("text_ru")))
     if external_options_high_conflict:
         blockers.append(str(external_options.get("text_ru")))
-    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX"}
+    if volume_delta.get("delta_divergence"):
+        blockers.append("Delta divergence: цена и CumDelta расходятся")
+    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "volume_delta": volume_delta, "volume_delta_source": volume_delta.get("source"), "delta_divergence": bool(volume_delta.get("delta_divergence"))}
     advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "external_options_filter": external_options, "level_source": level_source}
     return score_payload, advisor
 
@@ -389,6 +442,9 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["external_options_used"] = score.get("external_options_used")
                     enriched["external_options_alignment"] = score.get("external_options_alignment")
                     enriched["external_options_source"] = "CME_OptionsFX"
+                    enriched["volume_delta"] = score.get("volume_delta")
+                    enriched["volume_delta_source"] = score.get("volume_delta_source")
+                    enriched["delta_divergence"] = score.get("delta_divergence")
                     enriched["external_options_ru"] = external_options_filter.get("text_ru") or "CME_OptionsFX: нет данных"
                     enriched["external_options_bias"] = external_options_signal.get("option_bias") or external_options_filter.get("option_bias") or "neutral"
                     enriched["external_options_key_strikes"] = external_options_signal.get("key_strikes") or []

--- a/app/main.py
+++ b/app/main.py
@@ -1081,6 +1081,11 @@ def api_mt4_ingest_get(
     save_volume_cluster_payload({
         "symbol": normalized_symbol,
         "timeframe": timeframe,
+        "timestamp": datetime.fromtimestamp(candle_time, tz=timezone.utc).isoformat() if candle_time > 0 else None,
+        "open": open,
+        "high": high,
+        "low": low,
+        "close": close,
         "tick_volume": tick_volume,
         "future_volume": future_volume,
         "buy_volume": buy_volume,

--- a/app/services/mt4_options_bridge.py
+++ b/app/services/mt4_options_bridge.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from app.services.options_analysis import analyze_options
+from app.services.mt4_volume_cluster_bridge import build_volume_delta_priority_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -53,14 +54,16 @@ def _float_or_none(value: Any) -> float | None:
         return None
 
 
-def _build_volume_delta_snapshot(payload: dict[str, Any]) -> dict[str, Any]:
+def _build_volume_delta_snapshot(payload: dict[str, Any], symbol: str = "", timeframe: str = "") -> dict[str, Any]:
     cluster_volume = _float_or_none(payload.get("cluster_volume"))
-    cum_delta = _float_or_none(payload.get("cum_delta") or payload.get("cumulative_delta"))
-    delta_change = _float_or_none(payload.get("delta_change") or payload.get("cluster_delta") or payload.get("delta"))
     poc_price = _float_or_none(payload.get("poc_price") or payload.get("poc"))
     hft_spike = bool(payload.get("hft_spike"))
     absorption_zone = payload.get("absorption_zone") if isinstance(payload.get("absorption_zone"), dict) else {}
-    available = bool(payload.get("volume_delta_available")) or any(
+    snapshot = build_volume_delta_priority_snapshot(payload, symbol=symbol, timeframe=timeframe)
+
+    delta_change = _float_or_none(snapshot.get("delta"))
+    cum_delta = _float_or_none(snapshot.get("cumdelta"))
+    available = bool(snapshot.get("available")) or any(
         value not in (None, 0.0) for value in (cluster_volume, cum_delta, delta_change, poc_price)
     ) or hft_spike
 
@@ -77,11 +80,7 @@ def _build_volume_delta_snapshot(payload: dict[str, Any]) -> dict[str, Any]:
 
     parts: list[str] = []
     if available:
-        parts.append("Future Volume / CumDelta получены")
-    if cum_delta is not None:
-        parts.append(f"cum_delta={cum_delta:.2f}")
-    if delta_change is not None:
-        parts.append(f"delta_change={delta_change:.2f}")
+        parts.append(str(snapshot.get("summary_ru") or "Volume Delta получена"))
     if cluster_volume is not None:
         parts.append(f"cluster_volume={cluster_volume:.2f}")
     if poc_price is not None:
@@ -91,9 +90,11 @@ def _build_volume_delta_snapshot(payload: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "available": available,
-        "source": payload.get("volume_source") or "future_volume",
+        "source": snapshot.get("source") or payload.get("volume_source") or "unavailable",
         "timeframe": payload.get("timeframe"),
         "cluster_volume": cluster_volume,
+        "delta": delta_change,
+        "cumdelta": cum_delta,
         "cum_delta": cum_delta,
         "cumulative_delta": cum_delta,
         "delta_change": delta_change,
@@ -101,6 +102,9 @@ def _build_volume_delta_snapshot(payload: dict[str, Any]) -> dict[str, Any]:
         "hft_spike": hft_spike,
         "absorption_zone": absorption_zone,
         "delta_bias": delta_bias,
+        "is_proxy": bool(snapshot.get("is_proxy")),
+        "priority_used": snapshot.get("priority_used"),
+        "body_ratio": snapshot.get("body_ratio"),
         "summary_ru": ", ".join(parts) if parts else "Данные CumDelta / delta не получены.",
     }
 
@@ -124,7 +128,7 @@ def save_options_levels(payload: dict[str, Any]) -> dict[str, Any]:
 
     now = datetime.now(timezone.utc)
     _prune_options_store(now)
-    volume_delta = _build_volume_delta_snapshot(payload)
+    volume_delta = _build_volume_delta_snapshot(payload, symbol=symbol, timeframe=str(payload.get("timeframe") or ""))
     entry = {
         "symbol": symbol,
         "timestamp": (source_timestamp or now).isoformat(),
@@ -137,8 +141,13 @@ def save_options_levels(payload: dict[str, Any]) -> dict[str, Any]:
         "volume_delta": volume_delta,
         "volume_delta_available": bool(volume_delta.get("available")),
         "cum_delta": volume_delta.get("cum_delta"),
+        "cumdelta": volume_delta.get("cumdelta"),
         "cumulative_delta": volume_delta.get("cumulative_delta"),
         "delta_change": volume_delta.get("delta_change"),
+        "delta": volume_delta.get("delta"),
+        "volume_delta_source": volume_delta.get("source"),
+        "volume_delta_is_proxy": volume_delta.get("is_proxy"),
+        "volume_delta_priority_used": volume_delta.get("priority_used"),
         "cluster_volume": volume_delta.get("cluster_volume"),
         "poc_price": volume_delta.get("poc_price"),
         "hft_spike": volume_delta.get("hft_spike"),
@@ -282,8 +291,13 @@ def _build_analysis(entry: dict[str, Any]) -> dict[str, Any]:
         "volume_delta": volume_delta,
         "volume_delta_available": bool(volume_delta.get("available")),
         "cum_delta": volume_delta.get("cum_delta"),
+        "cumdelta": volume_delta.get("cumdelta"),
         "cumulative_delta": volume_delta.get("cumulative_delta"),
         "delta_change": volume_delta.get("delta_change"),
+        "delta": volume_delta.get("delta"),
+        "volume_delta_source": volume_delta.get("source"),
+        "volume_delta_is_proxy": volume_delta.get("is_proxy"),
+        "volume_delta_priority_used": volume_delta.get("priority_used"),
         "cluster_volume": volume_delta.get("cluster_volume"),
         "poc_price": volume_delta.get("poc_price"),
         "hft_spike": volume_delta.get("hft_spike"),

--- a/app/services/mt4_volume_cluster_bridge.py
+++ b/app/services/mt4_volume_cluster_bridge.py
@@ -4,6 +4,8 @@ import os
 from datetime import datetime, timezone
 from typing import Any
 
+TINY_PRICE_RANGE = 1e-12
+
 MT4_VOLUME_CLUSTER_TTL_SECONDS = int(os.getenv("MT4_VOLUME_CLUSTER_TTL_SECONDS", "1800"))
 _STORE: dict[str, dict[str, Any]] = {}
 
@@ -31,12 +33,120 @@ def is_stale(timestamp: Any) -> bool:
     return (datetime.now(timezone.utc) - parsed).total_seconds() > MT4_VOLUME_CLUSTER_TTL_SECONDS
 
 
+def _float_or_none(value: Any) -> float | None:
+    try:
+        if value in (None, "", "—"):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _nested_float(payload: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        current: Any = payload
+        for part in key.split("."):
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = current.get(part)
+        parsed = _float_or_none(current)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _previous_cumdelta(symbol: str, timeframe: str) -> float:
+    previous = _STORE.get(f"{symbol}:{timeframe}") or _STORE.get(symbol) or {}
+    if not isinstance(previous, dict):
+        return 0.0
+    volume_delta = previous.get("volume_delta") if isinstance(previous.get("volume_delta"), dict) else {}
+    return _float_or_none(volume_delta.get("cumdelta") or volume_delta.get("cumulative_delta") or previous.get("cumulative_delta")) or 0.0
+
+
+def build_volume_delta_priority_snapshot(payload: dict[str, Any], symbol: str = "", timeframe: str = "") -> dict[str, Any]:
+    """Build the stable Volume Delta priority chain used by MT4/FutureVolume payloads.
+
+    Priority:
+    1. Real FutureDelta indicator buffers when delta/cumdelta are non-zero.
+    2. Proxy delta calculated from FutureVolume and candle body ratio.
+    3. Proxy delta calculated from MT4 tick volume and candle body ratio.
+    """
+    future_delta = _nested_float(payload, "future_delta", "future_delta_buffer", "FutureDelta.delta", "future_delta.delta")
+    explicit_delta = _nested_float(payload, "delta", "delta_change", "cluster_delta", "volume_delta.delta")
+    explicit_cumdelta = _nested_float(payload, "cumdelta", "cum_delta", "cumulative_delta", "volume_delta.cumdelta", "volume_delta.cumulative_delta", "FutureDelta.cumdelta", "future_delta.cumdelta")
+    primary_delta = future_delta if future_delta not in (None, 0.0) else explicit_delta
+    primary_cumdelta = explicit_cumdelta
+
+    if (primary_delta not in (None, 0.0)) or (primary_cumdelta not in (None, 0.0)):
+        delta = float(primary_delta or 0.0)
+        cumdelta = float(primary_cumdelta if primary_cumdelta is not None else _previous_cumdelta(symbol, timeframe) + delta)
+        return {
+            "available": True,
+            "source": "FutureDelta",
+            "delta": delta,
+            "cumdelta": cumdelta,
+            "cumulative_delta": cumdelta,
+            "is_proxy": False,
+            "priority_used": 1,
+            "summary_ru": f"FutureDelta primary: delta={delta:.2f}, cumdelta={cumdelta:.2f}",
+        }
+
+    open_price = _float_or_none(payload.get("open"))
+    high = _float_or_none(payload.get("high"))
+    low = _float_or_none(payload.get("low"))
+    close = _float_or_none(payload.get("close"))
+    body_ratio = 0.0
+    if None not in (open_price, high, low, close):
+        body_ratio = (float(close) - float(open_price)) / max(float(high) - float(low), TINY_PRICE_RANGE)
+
+    for source, volume_key, priority in (("FutureVolume", "future_volume", 2), ("tick_volume", "tick_volume", 3)):
+        source_volume = _float_or_none(payload.get(volume_key))
+        if source_volume is None or source_volume == 0.0:
+            continue
+        delta = float(source_volume) * body_ratio
+        cumdelta = _previous_cumdelta(symbol, timeframe) + delta
+        return {
+            "available": True,
+            "source": source,
+            "delta": delta,
+            "cumdelta": cumdelta,
+            "cumulative_delta": cumdelta,
+            "is_proxy": True,
+            "priority_used": priority,
+            "body_ratio": body_ratio,
+            "source_volume": source_volume,
+            "summary_ru": f"{source} proxy: delta={delta:.2f}, cumdelta={cumdelta:.2f}, body_ratio={body_ratio:.3f}",
+        }
+
+    return {
+        "available": False,
+        "source": "unavailable",
+        "delta": None,
+        "cumdelta": None,
+        "cumulative_delta": None,
+        "is_proxy": True,
+        "priority_used": None,
+        "summary_ru": "FutureDelta/FutureVolume/tick volume недоступны для расчёта Volume Delta.",
+    }
+
+
 def save_volume_cluster_payload(payload: dict[str, Any]) -> dict[str, Any]:
     symbol = normalize_broker_symbol(payload.get("symbol") or payload.get("broker_symbol"))
     timeframe = str(payload.get("timeframe") or "H1").upper().strip()
     record = dict(payload)
     record["symbol"] = symbol
     record["timeframe"] = timeframe
+    record["volume_delta"] = build_volume_delta_priority_snapshot(record, symbol, timeframe)
+    record["volume_delta_available"] = bool(record["volume_delta"].get("available"))
+    if not isinstance(record.get("delta"), dict):
+        record["delta"] = record["volume_delta"].get("delta")
+    record["volume_delta_delta"] = record["volume_delta"].get("delta")
+    record["cumdelta"] = record["volume_delta"].get("cumdelta")
+    record["cumulative_delta"] = record["volume_delta"].get("cumdelta")
+    record["volume_delta_source"] = record["volume_delta"].get("source")
+    record["volume_delta_is_proxy"] = record["volume_delta"].get("is_proxy")
+    record["volume_delta_priority_used"] = record["volume_delta"].get("priority_used")
     record["received_at"] = datetime.now(timezone.utc).isoformat()
     _STORE[f"{symbol}:{timeframe}"] = record
     _STORE[symbol] = record

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -4,6 +4,7 @@ import sys
 from typing import Any
 
 from app.services.external_signal_adapter import get_cme_optionsfx_confirmation
+from app.services.mt4_volume_cluster_bridge import get_latest_volume_cluster
 
 try:
     from app.services.openai_idea_narrative import enrich_idea_with_openai_narrative
@@ -280,6 +281,114 @@ def _candles(idea: dict[str, Any]) -> list[dict[str, Any]]:
     return _candles_from_main(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
 
 
+def _price_delta(candles: list[dict[str, Any]]) -> float | None:
+    closes = [_to_float(candle.get("close")) for candle in candles[-3:]]
+    closes = [close for close in closes if close is not None]
+    if len(closes) < 2:
+        return None
+    return closes[-1] - closes[-2]
+
+
+def _extract_volume_delta_from_payload(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    nested = payload.get("volume_delta") if isinstance(payload.get("volume_delta"), dict) else {}
+    delta = _to_float(nested.get("delta") if nested else payload.get("delta") or payload.get("delta_change"))
+    cumdelta = _to_float(
+        (nested.get("cumdelta") or nested.get("cum_delta") or nested.get("cumulative_delta"))
+        if nested else payload.get("cumdelta") or payload.get("cum_delta") or payload.get("cumulative_delta")
+    )
+    if delta is None and cumdelta is None:
+        return None
+    source = str((nested.get("source") if nested else None) or payload.get("volume_delta_source") or payload.get("volume_source") or "unavailable")
+    priority_used = nested.get("priority_used") if nested else payload.get("volume_delta_priority_used")
+    try:
+        priority_used = int(priority_used) if priority_used not in (None, "") else None
+    except (TypeError, ValueError):
+        priority_used = None
+    is_proxy = (nested.get("is_proxy") if nested else payload.get("volume_delta_is_proxy"))
+    if is_proxy is None:
+        is_proxy = source != "FutureDelta"
+    return {
+        "available": True,
+        "source": source,
+        "delta": delta,
+        "cumdelta": cumdelta,
+        "is_proxy": bool(is_proxy),
+        "priority_used": priority_used,
+        "summary_ru": str((nested.get("summary_ru") if nested else None) or payload.get("delta_summary_ru") or ""),
+    }
+
+
+def _volume_delta_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
+    candles = _candles(idea)
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    timeframe = str(idea.get("timeframe") or idea.get("tf") or "").upper().strip() or None
+    volume_delta = _extract_volume_delta_from_payload(idea)
+    if volume_delta is None:
+        volume_delta = _extract_volume_delta_from_payload(idea.get("analysis") if isinstance(idea.get("analysis"), dict) else None)
+    if volume_delta is None and symbol:
+        volume_delta = _extract_volume_delta_from_payload(get_latest_volume_cluster(symbol, timeframe))
+    if volume_delta is None:
+        return {
+            "available": False,
+            "source": "unavailable",
+            "delta": None,
+            "cumdelta": None,
+            "is_proxy": True,
+            "priority_used": None,
+            "price_delta": _price_delta(candles),
+            "price_trend": "unknown",
+            "cumdelta_trend": "unknown",
+            "confirmed": False,
+            "delta_divergence": False,
+            "score_adjustment": 0,
+            "text_ru": "Volume Delta недоступна: FutureDelta/FutureVolume/tick volume не получены.",
+        }
+
+    price_delta = _price_delta(candles)
+    delta_value = _to_float(volume_delta.get("delta"))
+    price_trend = "rising" if price_delta is not None and price_delta > 0 else "falling" if price_delta is not None and price_delta < 0 else "flat"
+    cumdelta_trend = "rising" if delta_value is not None and delta_value > 0 else "falling" if delta_value is not None and delta_value < 0 else "flat"
+    confirmed = False
+    divergence = False
+    adjustment = 0
+    if direction == "BUY" and price_trend == "rising" and cumdelta_trend == "rising":
+        confirmed = True
+    elif direction == "SELL" and price_trend == "falling" and cumdelta_trend == "falling":
+        confirmed = True
+    elif direction in {"BUY", "SELL"} and price_trend in {"rising", "falling"} and cumdelta_trend in {"rising", "falling"}:
+        divergence = price_trend != cumdelta_trend
+        if divergence:
+            adjustment = -5
+        elif direction == "BUY" and price_trend == "falling" and cumdelta_trend == "falling":
+            adjustment = -3
+        elif direction == "SELL" and price_trend == "rising" and cumdelta_trend == "rising":
+            adjustment = -3
+
+    source_label = volume_delta.get("source") or "unavailable"
+    proxy_label = "proxy" if volume_delta.get("is_proxy") else "real"
+    text = (
+        f"CumDelta source={source_label} ({proxy_label}), priority={volume_delta.get('priority_used') or '—'}, "
+        f"delta={volume_delta.get('delta')}, cumdelta={volume_delta.get('cumdelta')}, "
+        f"price={price_trend}, cumdelta_trend={cumdelta_trend}"
+    )
+    if divergence:
+        text += "; delta_divergence=true"
+    elif confirmed:
+        text += "; delta подтверждает направление"
+    return {
+        **volume_delta,
+        "price_delta": price_delta,
+        "price_trend": price_trend,
+        "cumdelta_trend": cumdelta_trend,
+        "confirmed": confirmed,
+        "delta_divergence": divergence,
+        "score_adjustment": adjustment,
+        "text_ru": text,
+    }
+
+
 def _trade_geometry(idea: dict[str, Any]) -> dict[str, Any]:
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     entry = _to_float(idea.get("entry") if idea.get("entry") is not None else idea.get("entry_price"))
@@ -467,8 +576,15 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
     liquidity_text = _first_text(idea, "selected_zone_type", "selected_zone_low", "liquidity", "liquidity_zones", "liquidity_levels")
     rows.append(_row("liquidity", weights["liquidity"] if liquidity_text else 2 if direction in {"BUY", "SELL"} else 0, weights["liquidity"], liquidity_text or "нет отдельного liquidity слоя"))
 
+    volume_delta = _volume_delta_context(idea, direction)
     volume_text = _first_text(idea, "volume", "volume_ru", "data_status", "provider")
-    rows.append(_row("volume", weights["volume"] if volume_text else 1 if candles else 0, weights["volume"], volume_text or "только OHLC/tick proxy"))
+    if volume_delta.get("confirmed"):
+        volume_score = weights["volume"]
+    elif volume_delta.get("available"):
+        volume_score = round(weights["volume"] * 0.55)
+    else:
+        volume_score = weights["volume"] if volume_text else 1 if candles else 0
+    rows.append(_row("volume", volume_score, weights["volume"], str(volume_delta.get("text_ru") or volume_text or "только OHLC/tick proxy")))
 
     external_options = _external_options_alignment(idea, direction)
     external_text = str(external_options.get("text_ru") or "")
@@ -494,7 +610,8 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     geo = _trade_geometry(safe_idea)
     sentiment = _sentiment_alignment(safe_idea, direction)
     external_options = _external_options_alignment(safe_idea, direction)
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0)))
+    volume_delta = _volume_delta_context(safe_idea, direction)
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0)))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     blockers: list[str] = []
@@ -511,6 +628,8 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         blockers.append(str(sentiment.get("text_ru") or "Sentiment/news против направления сделки"))
     if external_options_high_conflict:
         blockers.append(str(external_options.get("text_ru") or "CME_OptionsFX high-confidence conflict против сделки"))
+    if volume_delta.get("delta_divergence"):
+        blockers.append("Delta divergence: цена и CumDelta расходятся")
 
     hard_blocked = direction == "WAIT" or not geo.get("has_levels") or not geo.get("valid_geometry") or geo.get("tiny_tp") or geo.get("weak_rr") or sentiment_conflict or external_options_high_conflict
     if score >= 70 and not hard_blocked:
@@ -539,7 +658,9 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "external_options_used": bool(external_options.get("used")),
         "external_options_alignment": external_options.get("alignment") or "neutral",
         "external_options_source": "CME_OptionsFX",
-        "delta_divergence": None,
+        "volume_delta": volume_delta,
+        "volume_delta_source": volume_delta.get("source"),
+        "delta_divergence": bool(volume_delta.get("delta_divergence")),
         "margin_zone_confluence": None,
         "disclaimer_ru": "Score не блокирует идею только из-за отсутствия optional CME/options/news слоёв; но если sentiment/news явно против направления, автоторговля блокируется.",
     }
@@ -638,6 +759,9 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "external_options_used": score.get("external_options_used"),
             "external_options_alignment": score.get("external_options_alignment"),
             "external_options_source": "CME_OptionsFX",
+            "volume_delta": score.get("volume_delta"),
+            "volume_delta_source": score.get("volume_delta_source"),
+            "delta_divergence": score.get("delta_divergence"),
         }
     )
     return enriched

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -131,6 +131,46 @@ function renderExternalOptionsCompact(idea) {
   return `<div class="idea-news-line">CME_OptionsFX: <strong>${escapeHtml(resolveExternalOptionsBias(idea))}</strong> · strikes: ${escapeHtml(formatListValue(idea.external_options_key_strikes))} · max pain: ${escapeHtml(formatListValue(idea.external_options_max_pain))}</div>`;
 }
 
+
+function resolveVolumeDelta(idea) {
+  const prop = getPropScore(idea);
+  const vd = (idea?.volume_delta && typeof idea.volume_delta === "object")
+    ? idea.volume_delta
+    : (prop?.volume_delta && typeof prop.volume_delta === "object")
+      ? prop.volume_delta
+      : {};
+  return {
+    source: vd.source || idea?.volume_delta_source || prop?.volume_delta_source || "unavailable",
+    delta: vd.delta,
+    cumdelta: vd.cumdelta ?? vd.cum_delta ?? vd.cumulative_delta,
+    isProxy: vd.is_proxy === true,
+    priority: vd.priority_used ?? "—",
+    divergence: Boolean(vd.delta_divergence || idea?.delta_divergence || prop?.delta_divergence),
+    priceTrend: vd.price_trend || "—",
+    cumdeltaTrend: vd.cumdelta_trend || "—",
+  };
+}
+
+function volumeDeltaSourceLabel(source) {
+  const raw = String(source || "unavailable");
+  const labels = {
+    FutureDelta: "FutureDelta",
+    FutureVolume: "FutureVolume",
+    tick_volume: "tick_volume",
+    unavailable: "нет данных",
+  };
+  return labels[raw] || raw;
+}
+
+function renderVolumeDeltaCompact(idea) {
+  const vd = resolveVolumeDelta(idea);
+  return `<div class="volume-delta-pill ${vd.divergence ? "divergent" : ""}">
+    <span>CumDelta source</span><strong>${escapeHtml(volumeDeltaSourceLabel(vd.source))}</strong>
+    <em>${vd.isProxy ? "proxy" : "real"} · priority ${escapeHtml(vd.priority)}</em>
+    <small>Δ ${escapeHtml(formatNumber(vd.delta))} · CumΔ ${escapeHtml(formatNumber(vd.cumdelta))}${vd.divergence ? " · Delta divergence" : ""}</small>
+  </div>`;
+}
+
 function getIdeaSymbol(idea) {
   return String(idea.instrument || idea.symbol || idea.pair || "РЫНОК").toUpperCase();
 }
@@ -376,6 +416,12 @@ function injectUiStyles() {
     .idea-card-top { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; margin-bottom:12px; }
     .idea-title { margin:8px 0 6px; font-size:22px; line-height:1.15; }
     .idea-news-line { color:#b9d6f8; font-size:12px; line-height:1.5; }
+    .volume-delta-pill { margin:10px 0; padding:10px 11px; border-radius:14px; border:1px solid rgba(69,202,255,.24); background:rgba(69,202,255,.08); display:grid; gap:2px; color:#dbeeff; }
+    .volume-delta-pill span { color:#9bb8d8; font-size:10px; font-weight:950; text-transform:uppercase; letter-spacing:.06em; }
+    .volume-delta-pill strong { color:#f4f8ff; font-size:14px; }
+    .volume-delta-pill em, .volume-delta-pill small { color:#b9d6f8; font-style:normal; font-size:12px; }
+    .volume-delta-pill.divergent { border-color:rgba(248,113,113,.48); background:rgba(127,29,29,.24); }
+    .volume-delta-pill.divergent strong { color:#fecdd3; }
     .idea-label,.badge { border-radius:999px; padding:8px 12px; font-size:12px; font-weight:950; white-space:nowrap; }
     .badge-buy,.idea-label-buy { color:#00150c; background:linear-gradient(180deg,#54ffb5,#31f59d); }
     .badge-sell,.idea-label-sell { color:#fff; background:linear-gradient(180deg,#d93f5b,#8f2034); }
@@ -456,6 +502,7 @@ function renderIdeaCard(idea, index) {
       <div><span>R/R</span><strong>${escapeHtml(formatNumber(idea.rr ?? idea.risk_reward))}</strong></div>
     </div>
     ${renderPropCompact(idea)}
+    ${renderVolumeDeltaCompact(idea)}
     ${renderExternalOptionsCompact(idea)}
     <div class="idea-news-line">BOS: ${escapeHtml(idea.market_structure?.bos || "—")} · Sweep: ${escapeHtml(idea.liquidity?.sweep || "—")} · FVG: ${escapeHtml(idea.fvg?.type || idea.selected_zone_type || "—")} · HTF: ${escapeHtml(idea.htf_bias || idea.market_structure?.trend_regime || "—")}</div>
     <div class="idea-summary-compact">${escapeHtml(resolveNarrative(idea))}</div>
@@ -525,6 +572,7 @@ function openIdeaModal(idea) {
       </div>
       <p class="modal-text"><strong>Новости/фундаментал:</strong> ${escapeHtml(resolveNewsContext(idea))}</p>
       <p class="modal-text"><strong>Options/CME confirmation:</strong> ${escapeHtml(resolveExternalOptionsRu(idea))}<br><strong>Bias:</strong> ${escapeHtml(resolveExternalOptionsBias(idea))}; <strong>Key strikes:</strong> ${escapeHtml(formatListValue(idea.external_options_key_strikes))}; <strong>Max pain:</strong> ${escapeHtml(formatListValue(idea.external_options_max_pain))}</p>
+      <p class="modal-text"><strong>CumDelta source:</strong> ${escapeHtml(volumeDeltaSourceLabel(resolveVolumeDelta(idea).source))}; <strong>Delta divergence:</strong> ${resolveVolumeDelta(idea).divergence ? "true" : "false"}; <strong>Price/CumDelta:</strong> ${escapeHtml(resolveVolumeDelta(idea).priceTrend)} / ${escapeHtml(resolveVolumeDelta(idea).cumdeltaTrend)}</p>
       <p class="modal-text"><strong>Источник:</strong> ${escapeHtml(idea.data_provider || idea.provider || "нет данных")}</p>
       <p class="modal-text"><strong>Setup:</strong> ${escapeHtml(idea.setup_type || "—")}; <strong>BOS:</strong> ${escapeHtml(idea.market_structure?.bos || "—")}; <strong>Sweep:</strong> ${escapeHtml(idea.liquidity?.sweep || "—")}; <strong>FVG:</strong> ${escapeHtml(idea.fvg?.type || idea.selected_zone_type || "—")}; <strong>HTF bias:</strong> ${escapeHtml(idea.htf_bias || idea.market_structure?.trend_regime || "—")}</p>
     </section>`;

--- a/tests/test_volume_delta_priority.py
+++ b/tests/test_volume_delta_priority.py
@@ -1,0 +1,108 @@
+from app.services.mt4_volume_cluster_bridge import _STORE, save_volume_cluster_payload
+from app.services.prop_signal_engine import build_prop_signal_score, enrich_idea_with_prop_score
+
+
+def setup_function():
+    _STORE.clear()
+
+
+def _candles(up=True):
+    base = 1.1000
+    rows = []
+    for idx in range(14):
+        close = base + idx * 0.0002 if up else base - idx * 0.0002
+        rows.append({"open": close - 0.0001 if up else close + 0.0001, "high": close + 0.0003, "low": close - 0.0003, "close": close})
+    return rows
+
+
+def test_future_delta_has_primary_priority_over_future_volume():
+    saved = save_volume_cluster_payload({
+        "symbol": "EURUSD",
+        "timeframe": "M15",
+        "open": 1.1000,
+        "high": 1.1010,
+        "low": 1.0990,
+        "close": 1.1008,
+        "future_volume": 1000,
+        "tick_volume": 500,
+        "future_delta": 250,
+        "cumulative_delta": 1200,
+    })
+    vd = saved["volume_delta"]
+    assert vd["source"] == "FutureDelta"
+    assert vd["delta"] == 250
+    assert vd["cumdelta"] == 1200
+    assert vd["is_proxy"] is False
+    assert vd["priority_used"] == 1
+
+
+def test_future_volume_proxy_is_second_priority_when_future_delta_zero():
+    saved = save_volume_cluster_payload({
+        "symbol": "GBPUSD",
+        "timeframe": "M15",
+        "open": 1.1000,
+        "high": 1.1010,
+        "low": 1.0990,
+        "close": 1.1005,
+        "future_volume": 800,
+        "tick_volume": 300,
+        "future_delta": 0,
+        "cumulative_delta": 0,
+    })
+    vd = saved["volume_delta"]
+    assert vd["source"] == "FutureVolume"
+    assert round(vd["delta"], 6) == 200
+    assert round(vd["cumdelta"], 6) == 200
+    assert vd["is_proxy"] is True
+    assert vd["priority_used"] == 2
+
+
+def test_tick_volume_proxy_is_third_priority_when_future_volume_missing():
+    saved = save_volume_cluster_payload({
+        "symbol": "AUDUSD",
+        "timeframe": "M15",
+        "open": 1.1000,
+        "high": 1.1010,
+        "low": 1.0990,
+        "close": 1.0995,
+        "tick_volume": 400,
+        "future_delta": 0,
+    })
+    vd = saved["volume_delta"]
+    assert vd["source"] == "tick_volume"
+    assert round(vd["delta"], 6) == -100
+    assert round(vd["cumdelta"], 6) == -100
+    assert vd["is_proxy"] is True
+    assert vd["priority_used"] == 3
+
+
+def test_prop_engine_confirms_buy_when_price_and_cumdelta_rise():
+    idea = {
+        "symbol": "EURUSD",
+        "signal": "BUY",
+        "entry": 1.1028,
+        "sl": 1.0980,
+        "tp": 1.1100,
+        "candles": _candles(up=True),
+        "volume_delta": {"source": "FutureDelta", "delta": 180, "cumdelta": 1200, "is_proxy": False, "priority_used": 1},
+    }
+    score = build_prop_signal_score(idea)
+    assert score["volume_delta"]["confirmed"] is True
+    assert score["delta_divergence"] is False
+
+
+def test_prop_engine_marks_delta_divergence_and_reduces_score():
+    idea = {
+        "symbol": "EURUSD",
+        "signal": "BUY",
+        "entry": 1.1028,
+        "sl": 1.0980,
+        "tp": 1.1100,
+        "candles": _candles(up=True),
+        "volume_delta": {"source": "FutureDelta", "delta": -180, "cumdelta": 900, "is_proxy": False, "priority_used": 1},
+    }
+    without_divergence = enrich_idea_with_prop_score({**idea, "volume_delta": {"source": "FutureDelta", "delta": 180, "cumdelta": 1200, "is_proxy": False, "priority_used": 1}})
+    with_divergence = enrich_idea_with_prop_score(idea)
+    assert with_divergence["delta_divergence"] is True
+    assert with_divergence["prop_signal_score"]["score"] <= without_divergence["prop_signal_score"]["score"] - 5
+    assert with_divergence["volume_delta"]["source"] == "FutureDelta"


### PR DESCRIPTION
### Motivation
- Ввести устойчивую цепочку приоритетов для расчёта Volume Delta: предпочитать реальные буферы FutureDelta, затем proxy от FutureVolume, затем proxy от MT4 tick_volume. 
- Обеспечить, чтобы Prop decision engine мог использовать CumDelta для подтверждения сигналов и отмечать расхождения цены/дельты с понижением score. 
- Показать источник CumDelta и состояние divergence в UI и сохранить совместимость с текущим FutureVolume flow.

### Description
- Добавлен модульный приоритетный снэпшот `build_volume_delta_priority_snapshot` с приоритетами: `FutureDelta` (1) → `FutureVolume` (2) → `tick_volume` (3), расчёт proxy-дельты через `body_ratio = (close - open) / max(high - low, tiny)`. (файл: `app/services/mt4_volume_cluster_bridge.py`).
- Сохранение и экспонирование стабильного `volume_delta` в MT4 ingest и options bridge; новые поля в payload/analysis: `volume_delta.source`, `volume_delta.delta`, `volume_delta.cumdelta`, `volume_delta.is_proxy`, `volume_delta.priority_used` и вспомогательные алиасы (`delta`, `cumdelta`, `volume_delta_source`, ...). (файлы: `app/main.py`, `app/services/mt4_options_bridge.py`).
- Интеграция в `prop_signal_engine`: извлечение `volume_delta`, логика подтверждения/дивергенции (BUY подтверждён если price↑ и cumdelta↑, SELL — если price↓ и cumdelta↓), установка `delta_divergence` и штрафы к score (`-5` при дивергенции, `-3` в других негативных кейсах). Поля `volume_delta`, `volume_delta_source` и `delta_divergence` добавлены в возвращаемую структуру и в runtime patch. (файлы: `app/services/prop_signal_engine.py`, `app/core/prop_score_recovery_patch.py`).
- UI: карточки и модалка показывают источник CumDelta, proxy/real, priority и индикатор Delta divergence. (файл: `app/static/ideas.js`).
- Документация: дополнен `README.md` разделом про контракт `volume_delta` и правила приоритета/подтверждения/дивергенции.
- Добавлены регрессионные тесты `tests/test_volume_delta_priority.py` на приоритеты и поведение проп-энгина.

### Testing
- Запущены целевые тесты для нового функционала: `pytest -q tests/test_mt4_options_bridge.py tests/test_mt4_volume_cluster.py tests/test_volume_delta_priority.py` — все тесты прошли успешно. 
- Запущены дополнительные интеграционные тесты: `pytest -q tests/signals/test_prop_signal_fallback.py tests/signals/test_cme_optionsfx_adapter.py` — прошли успешно, и `python -m py_compile` для изменённых модулей прошёл без ошибок. 
- Статическая проверка клиентского скрипта: `node --check app/static/ideas.js` — успешно. 
- Примечание: при запуске полного набора тестов обнаруживались ранее существующие ошибки коллекции тестов вне изменений этого PR (импорты/синтаксис в других модулях), они не связаны с внесёнными правками.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fdbc006248331bf2350e136d041cd)