### PR TITLE
Recover signal engine with optional Telegram confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,3 +402,11 @@ curl http://127.0.0.1:8000/ideas/market
 - Если Telegram credentials не заданы (`TELEGRAM_API_ID`/`TELEGRAM_API_HASH` или `TELEGRAM_BOT_TOKEN`, также поддерживаются `TG_*` aliases), endpoint возвращает `available=false`, а scoring работает как раньше без блокировки сделок.
 - В Prop Signal Engine слой `CME_OptionsFX` используется только как confirmation layer: совпадение options bias с направлением сделки даёт `+4` к score, явный конфликт даёт `-4`, а high-confidence conflict может стать blocker.
 - В payload идеи добавлены `external_options_ru`, `external_options_bias`, `external_options_key_strikes`, `external_options_max_pain`, а `advisor_signal` содержит `external_options_used`, `external_options_alignment`, `external_options_source="CME_OptionsFX"`.
+
+
+## Signal engine recovery / Telegram optional layers
+- Создан recovery-контур для MT4: если MT4 присылает валидные свечи, engine может восстановить направление BUY/SELL по структуре свечей, рассчитать Entry/SL/TP через ATR/range fallback и пройти `advisor_allowed=true` без Telegram/CME данных.
+- `sharkfx_ru` подключён как Telegram adapter для разборки сигналов (`symbol`, `action`, `entry`, `stop_loss`, `take_profit`, `confidence`, `raw_text`) через `GET /api/external-signals/sharkfx`. Канал не открывает сделки напрямую и используется только как optional score boost/penalty.
+- `CME_OptionsFX` остаётся optional confirmation layer: отсутствие credentials или данных возвращает `available=false` и не блокирует сделку. Совпадение options bias повышает score; только явно сильный конфликт может блокировать prop advisor как риск-фильтр.
+- Добавлен FutureDelta/FutureVolume слой: реальные/bridge значения из MT4 volume cluster используются при наличии, иначе применяется явно помеченный `calculated_cum_delta_proxy` по OHLC/tick volume. Proxy-метрики маркируются `is_proxy_metric=true` и не выдаются за реальные фьючерсные данные.
+- Prop scorer recovery теперь учитывает candle direction fallback, ATR levels fallback, repaired sentiment alignment, optional SharkFX/CME confirmations и FutureDelta proxy так, чтобы отсутствие Telegram не было обязательным условием сделки.

--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -279,6 +279,42 @@ def _external_options_alignment(symbol: str, direction: str) -> dict[str, Any]:
     high_conflict = any(marker in raw for marker in ("HIGH CONFIDENCE", "STRONG", "СИЛЬН", "ВЫСОК", "AGGRESSIVE", "DOMINATE"))
     return {**confirmation, "used": True, "alignment": "conflict", "score_adjustment": -4, "implied_action": implied, "high_confidence_conflict": high_conflict, "text_ru": f"CME_OptionsFX против {direction}: options bias {bias} ожидает {implied}"}
 
+
+def _sharkfx_confirmation(symbol: str, direction: str) -> dict[str, Any]:
+    try:
+        module = sys.modules.get("app.services.prop_signal_engine")
+        getter = getattr(module, "get_sharkfx_confirmation", None) if module is not None else None
+        if callable(getter):
+            payload = getter(symbol, direction)
+            return payload if isinstance(payload, dict) else {}
+        from app.services.external_signal_adapter import get_sharkfx_confirmation
+        payload = get_sharkfx_confirmation(symbol, direction)
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _sharkfx_alignment(symbol: str, direction: str) -> dict[str, Any]:
+    payload = _sharkfx_confirmation(symbol, direction)
+    used = bool(payload.get("used") and isinstance(payload.get("signal"), dict))
+    alignment = str(payload.get("alignment") or "neutral")
+    adjustment = 3 if used and alignment == "aligned" else -2 if used and alignment == "conflict" else 0
+    text = "SharkFX: нет свежих данных по инструменту, канал не обязателен для сделки"
+    if used and alignment == "aligned":
+        text = f"SharkFX подтверждает {direction} как дополнительный Telegram-фильтр"
+    elif used and alignment == "conflict":
+        text = f"SharkFX не совпадает с {direction}, score снижен без блокировки"
+    return {**payload, "used": used, "alignment": alignment, "score_adjustment": adjustment, "text_ru": text}
+
+
+def _future_delta(symbol: str, candles: list[dict[str, Any]]) -> dict[str, Any]:
+    try:
+        from app.services.future_delta_service import get_future_delta_snapshot
+        payload = get_future_delta_snapshot(symbol, "H1", candles)
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
 def _row(key: str, label: str, weight: int, score: int, text: str) -> dict[str, Any]:
     score = max(0, min(score, weight))
     return {"key": key, "label_ru": label, "weight": weight, "score": score, "status": "confirmed" if score >= weight * 0.7 else "partial" if score > 0 else "missing", "text_ru": text}
@@ -294,6 +330,13 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     entry, sl, tp, rr, valid, level_source = _levels(symbol, direction, candles, entry, sl, tp)
     sentiment = _sentiment_alignment(idea, direction)
     external_options = _external_options_alignment(symbol, direction)
+    sharkfx = _sharkfx_alignment(symbol, direction)
+    future_delta = _future_delta(symbol, candles)
+    future_delta_adjustment = 0
+    if future_delta.get("available") and direction in {"BUY", "SELL"}:
+        bias = str(future_delta.get("bias") or "neutral").lower()
+        if (direction == "BUY" and bias == "bullish") or (direction == "SELL" and bias == "bearish"):
+            future_delta_adjustment = 2
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     has_structure = any(_text_has_data(idea.get(k)) for k in ("reason_ru", "summary_ru", "market_structure", "htf_context", "entry_source"))
@@ -314,7 +357,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         _row("sentiment", "Sentiment / новости", 5, int(sentiment.get("score") or 0), str(sentiment.get("text_ru") or "нет sentiment")),
     ]
     base_score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0)))
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(sharkfx.get("score_adjustment") or 0) + future_delta_adjustment))
     allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict and not external_options_high_conflict)
     grade = "A" if score >= 70 else "B" if score >= 55 else "C" if score >= 40 else "D"
     mode = "prop_entry" if allowed and score >= 70 else "watchlist" if allowed else "research_only" if score >= 40 else "no_trade"
@@ -329,8 +372,8 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         blockers.append(str(sentiment.get("text_ru")))
     if external_options_high_conflict:
         blockers.append(str(external_options.get("text_ru")))
-    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX"}
-    advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "external_options_filter": external_options, "level_source": level_source}
+    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "telegram_signal_filter": sharkfx, "telegram_signal_used": bool(sharkfx.get("used")), "telegram_signal_source": "sharkfx_ru", "future_delta": future_delta, "future_delta_used": bool(future_delta.get("available")), "future_delta_score_adjustment": future_delta_adjustment}
+    advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "external_options_filter": external_options, "telegram_signal_used": bool(sharkfx.get("used")), "telegram_signal_alignment": sharkfx.get("alignment") or "neutral", "telegram_signal_source": "sharkfx_ru", "telegram_signal_filter": sharkfx, "level_source": level_source}
     return score_payload, advisor
 
 
@@ -389,6 +432,11 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["external_options_used"] = score.get("external_options_used")
                     enriched["external_options_alignment"] = score.get("external_options_alignment")
                     enriched["external_options_source"] = "CME_OptionsFX"
+                    enriched["telegram_signal_filter"] = score.get("telegram_signal_filter")
+                    enriched["telegram_signal_used"] = score.get("telegram_signal_used")
+                    enriched["telegram_signal_source"] = "sharkfx_ru"
+                    enriched["future_delta"] = score.get("future_delta")
+                    enriched["future_delta_used"] = score.get("future_delta_used")
                     enriched["external_options_ru"] = external_options_filter.get("text_ru") or "CME_OptionsFX: нет данных"
                     enriched["external_options_bias"] = external_options_signal.get("option_bias") or external_options_filter.get("option_bias") or "neutral"
                     enriched["external_options_key_strikes"] = external_options_signal.get("key_strikes") or []

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.services.htf_context_filter import HtfContextFilter
 from app.services.cme_scraper import get_cme_market_snapshot
-from app.services.external_signal_adapter import get_cme_optionsfx_signals
+from app.services.external_signal_adapter import get_cme_optionsfx_signals, get_sharkfx_signals
 from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
@@ -200,6 +200,11 @@ def health(request: Request):
 @app.get("/api/external-signals/cme-optionsfx")
 def api_external_signals_cme_optionsfx(force_refresh: bool = False) -> dict[str, Any]:
     return get_cme_optionsfx_signals(force_refresh=force_refresh)
+
+
+@app.get("/api/external-signals/sharkfx")
+def api_external_signals_sharkfx(force_refresh: bool = False) -> dict[str, Any]:
+    return get_sharkfx_signals(force_refresh=force_refresh)
 
 
 @app.get("/", include_in_schema=False)

--- a/app/services/external_signal_adapter.py
+++ b/app/services/external_signal_adapter.py
@@ -23,7 +23,7 @@ EXTERNAL_SIGNAL_SOURCES = {
         "source": "sharkfx_ru",
         "kind": "trading_signal_source",
         "url": TELEGRAM_SOURCE_URLS["sharkfx_ru"],
-        "opens_trades_directly": True,
+        "opens_trades_directly": False,
     },
     "CME_OptionsFX": {
         "source": "CME_OptionsFX",
@@ -211,6 +211,54 @@ def parse_cme_optionsfx_message(raw_text: str, published_at: str | None = None) 
     return parsed
 
 
+def parse_sharkfx_message(raw_text: str, published_at: str | None = None) -> list[dict[str, Any]]:
+    text = html.unescape(str(raw_text or "")).strip()
+    if not text:
+        return []
+    symbols = _extract_symbols(text)
+    if not symbols:
+        return []
+    upper = text.upper()
+    action = "WAIT"
+    if any(marker in upper for marker in ("BUY", "LONG", "ПОКУП", "ЛОНГ")):
+        action = "BUY"
+    elif any(marker in upper for marker in ("SELL", "SHORT", "ПРОДА", "ШОРТ")):
+        action = "SELL"
+    if action == "WAIT":
+        return []
+
+    entry_values = []
+    for label in (r"entry|вход", r"buy\s+limit|sell\s+limit|buy|sell"):
+        value = _extract_first_number_after(label, text)
+        if value is not None:
+            entry_values.append(value)
+    sl = _extract_first_number_after(r"sl|s/l|stop\s*loss|стоп", text)
+    tp_values: list[float] = []
+    for match in re.finditer(r"(?:tp\d*|t/p\d*|take\s*profit|тейк)[:\s\-–]+(\d{1,5}(?:[.,]\d{1,5})?)", text, re.IGNORECASE):
+        tp_values.extend(_extract_numbers(match.group(1)))
+    confidence = _extract_first_number_after(r"confidence|score|уверенность", text)
+    parsed: list[dict[str, Any]] = []
+    for symbol in symbols:
+        parsed.append(
+            {
+                "source": "sharkfx_ru",
+                "source_kind": "trading_signal_source",
+                "symbol": symbol,
+                "pair": symbol,
+                "action": action,
+                "entry": entry_values[0] if entry_values else None,
+                "stop_loss": sl,
+                "take_profit": tp_values[0] if tp_values else None,
+                "take_profits": tp_values[:4],
+                "confidence": confidence,
+                "opens_trades_directly": False,
+                "raw_text": text,
+                "published_at": published_at,
+            }
+        )
+    return parsed
+
+
 def _fetch_public_telegram_messages(channel: str) -> list[dict[str, str]]:
     response = requests.get(
         f"https://t.me/s/{channel}",
@@ -319,3 +367,75 @@ def get_cme_optionsfx_confirmation(symbol: Any) -> dict[str, Any]:
         "option_bias": signal.get("option_bias") or "neutral",
         "signal": signal,
     }
+
+
+
+def get_sharkfx_signals(force_refresh: bool = False) -> dict[str, Any]:
+    source = EXTERNAL_SIGNAL_SOURCES["sharkfx_ru"]
+    now = time.time()
+    cached = _CACHE.get("sharkfx_ru")
+    if cached and not force_refresh and now - float(cached.get("cached_at_epoch") or 0) < TELEGRAM_CACHE_TTL_SECONDS:
+        return dict(cached["payload"])
+
+    if not _telegram_credentials_available():
+        payload = {
+            "source": "sharkfx_ru",
+            "source_kind": source["kind"],
+            "source_url": source["url"],
+            "available": False,
+            "reason": "telegram_credentials_missing",
+            "opens_trades_directly": False,
+            "signals": [],
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _CACHE["sharkfx_ru"] = {"cached_at_epoch": now, "payload": payload}
+        return payload
+
+    try:
+        messages = _fetch_public_telegram_messages("sharkfx_ru")
+        signals: list[dict[str, Any]] = []
+        for message in messages:
+            signals.extend(parse_sharkfx_message(message.get("text", ""), message.get("published_at") or None))
+        payload = {
+            "source": "sharkfx_ru",
+            "source_kind": source["kind"],
+            "source_url": source["url"],
+            "available": True,
+            "opens_trades_directly": False,
+            "signals": signals,
+            "messages_checked": len(messages),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    except Exception as exc:  # pragma: no cover
+        logger.warning("sharkfx_fetch_failed: %s", exc)
+        payload = {
+            "source": "sharkfx_ru",
+            "source_kind": source["kind"],
+            "source_url": source["url"],
+            "available": False,
+            "reason": "telegram_fetch_failed",
+            "error": str(exc)[:240],
+            "opens_trades_directly": False,
+            "signals": [],
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    _CACHE["sharkfx_ru"] = {"cached_at_epoch": now, "payload": payload}
+    return payload
+
+
+def get_sharkfx_confirmation(symbol: Any, action: Any = None) -> dict[str, Any]:
+    normalized = _normalize_symbol(symbol)
+    desired_action = str(action or "").upper().strip()
+    payload = get_sharkfx_signals()
+    signals = payload.get("signals") if isinstance(payload.get("signals"), list) else []
+    matches = [item for item in signals if isinstance(item, dict) and _normalize_symbol(item.get("symbol") or item.get("pair")) == normalized]
+    if not payload.get("available") or not normalized:
+        return {"source": "sharkfx_ru", "available": False, "used": False, "alignment": "neutral", "reason": payload.get("reason") or "unavailable", "signal": None}
+    if not matches:
+        return {"source": "sharkfx_ru", "available": True, "used": False, "alignment": "neutral", "reason": "no_symbol_match", "signal": None}
+    signal = matches[-1]
+    signal_action = str(signal.get("action") or "WAIT").upper()
+    alignment = "neutral"
+    if desired_action in {"BUY", "SELL"} and signal_action in {"BUY", "SELL"}:
+        alignment = "aligned" if desired_action == signal_action else "conflict"
+    return {"source": "sharkfx_ru", "available": True, "used": True, "alignment": alignment, "signal_action": signal_action, "signal": signal}

--- a/app/services/future_delta_service.py
+++ b/app/services/future_delta_service.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.mt4_volume_cluster_bridge import get_latest_volume_cluster, normalize_broker_symbol
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value in (None, "", "—"):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_candles(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    for key in ("candles", "chartData", "chart_data", "market_data"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [row for row in value if isinstance(row, dict)]
+        if isinstance(value, dict) and isinstance(value.get("candles"), list):
+            return [row for row in value.get("candles", []) if isinstance(row, dict)]
+    return []
+
+
+def calculate_cum_delta_from_candles(candles: list[dict[str, Any]]) -> dict[str, Any]:
+    """Calculate a labelled proxy CumDelta from OHLC + tick volume candles.
+
+    This is not real futures tape. It is used only as a fallback when MT4/CME delta is absent.
+    """
+    rows = [row for row in candles if isinstance(row, dict)]
+    if len(rows) < 3:
+        return {
+            "available": False,
+            "source": "calculated_cum_delta_proxy",
+            "is_proxy_metric": True,
+            "reason": "insufficient_candles",
+        }
+
+    deltas: list[float] = []
+    cumulative = 0.0
+    for row in rows[-80:]:
+        open_price = _to_float(row.get("open"))
+        close = _to_float(row.get("close"))
+        high = _to_float(row.get("high"))
+        low = _to_float(row.get("low"))
+        tick_volume = _to_float(row.get("tick_volume") or row.get("volume") or row.get("real_volume"))
+        if close is None or high is None or low is None:
+            continue
+        if open_price is None:
+            open_price = close
+        volume = tick_volume if tick_volume is not None and tick_volume > 0 else max(abs(high - low), 1e-9) * 100000
+        body = close - open_price
+        candle_range = max(high - low, 1e-9)
+        signed_delta = (body / candle_range) * volume
+        cumulative += signed_delta
+        deltas.append(signed_delta)
+
+    if not deltas:
+        return {
+            "available": False,
+            "source": "calculated_cum_delta_proxy",
+            "is_proxy_metric": True,
+            "reason": "no_valid_candles",
+        }
+
+    recent = sum(deltas[-8:])
+    previous = sum(deltas[-16:-8]) if len(deltas) >= 16 else 0.0
+    if recent > max(abs(previous) * 0.2, 1e-9):
+        trend = "rising"
+        bias = "bullish"
+    elif recent < -max(abs(previous) * 0.2, 1e-9):
+        trend = "falling"
+        bias = "bearish"
+    else:
+        trend = "flat"
+        bias = "neutral"
+
+    return {
+        "available": True,
+        "source": "calculated_cum_delta_proxy",
+        "is_proxy_metric": True,
+        "label_ru": "Расчётный CumDelta proxy по OHLC/tick volume, не реальная фьючерсная лента",
+        "cum_delta": round(cumulative, 6),
+        "recent_delta": round(recent, 6),
+        "previous_delta": round(previous, 6),
+        "delta_trend": trend,
+        "bias": bias,
+        "candles_used": len(deltas),
+    }
+
+
+def get_future_delta_snapshot(symbol: str, timeframe: str | None = None, candles: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    normalized = normalize_broker_symbol(symbol)
+    cluster = get_latest_volume_cluster(normalized, timeframe)
+    if isinstance(cluster, dict):
+        delta = cluster.get("delta") if isinstance(cluster.get("delta"), dict) else {}
+        volume = cluster.get("future_volume") or cluster.get("volume") or cluster.get("futures_volume")
+        if delta or volume is not None:
+            return {
+                "available": True,
+                "source": cluster.get("source") or "mt4_future_delta",
+                "is_proxy_metric": False,
+                "delta": delta,
+                "future_volume": volume,
+                "future_volume_source": "real_or_bridge_payload" if volume is not None else "unavailable",
+                "delta_trend": delta.get("delta_trend") or delta.get("trend") or "unknown",
+                "bias": delta.get("bias") or "neutral",
+            }
+        cluster_candles = _extract_candles(cluster)
+        if cluster_candles:
+            fallback = calculate_cum_delta_from_candles(cluster_candles)
+            fallback["future_volume"] = sum(_to_float(row.get("tick_volume") or row.get("volume")) or 0.0 for row in cluster_candles[-80:])
+            fallback["future_volume_source"] = "tick_volume_proxy"
+            return fallback
+
+    fallback = calculate_cum_delta_from_candles(candles or [])
+    if fallback.get("available"):
+        fallback["future_volume"] = sum(_to_float(row.get("tick_volume") or row.get("volume")) or 0.0 for row in (candles or [])[-80:])
+        fallback["future_volume_source"] = "tick_volume_proxy"
+    return fallback

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import sys
 from typing import Any
 
-from app.services.external_signal_adapter import get_cme_optionsfx_confirmation
+from app.services.external_signal_adapter import get_cme_optionsfx_confirmation, get_sharkfx_confirmation
+from app.services.future_delta_service import get_future_delta_snapshot
 
 try:
     from app.services.openai_idea_narrative import enrich_idea_with_openai_narrative
@@ -178,6 +179,34 @@ def _external_options_alignment(idea: dict[str, Any], direction: str) -> dict[st
         "high_confidence_conflict": high_conflict,
         "text_ru": f"CME_OptionsFX против {direction}: options bias {bias} ожидает {implied}",
     }
+
+
+def _sharkfx_alignment(idea: dict[str, Any], direction: str) -> dict[str, Any]:
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    try:
+        confirmation = get_sharkfx_confirmation(symbol, direction)
+    except Exception:
+        confirmation = {"source": "sharkfx_ru", "available": False, "used": False, "alignment": "neutral", "reason": "adapter_error", "signal": None}
+    used = bool(confirmation.get("used") and isinstance(confirmation.get("signal"), dict))
+    alignment = str(confirmation.get("alignment") or "neutral")
+    adjustment = 0
+    if used and alignment == "aligned":
+        adjustment = 3
+    elif used and alignment == "conflict":
+        adjustment = -2
+    text = "SharkFX: нет свежих данных по инструменту, канал не обязателен для сделки"
+    if used and alignment == "aligned":
+        text = f"SharkFX подтверждает {direction} как дополнительный Telegram-фильтр"
+    elif used and alignment == "conflict":
+        text = f"SharkFX не совпадает с {direction}, score снижен без блокировки"
+    return {**confirmation, "used": used, "alignment": alignment, "score_adjustment": adjustment, "text_ru": text}
+
+
+def _future_delta_context(idea: dict[str, Any]) -> dict[str, Any]:
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    timeframe = str(idea.get("timeframe") or idea.get("tf") or "H1").upper()
+    return get_future_delta_snapshot(symbol, timeframe, _candles(idea))
+
 
 def _pip_size(symbol: str, entry: float | None = None) -> float:
     symbol = (symbol or "").upper()
@@ -467,7 +496,12 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
     liquidity_text = _first_text(idea, "selected_zone_type", "selected_zone_low", "liquidity", "liquidity_zones", "liquidity_levels")
     rows.append(_row("liquidity", weights["liquidity"] if liquidity_text else 2 if direction in {"BUY", "SELL"} else 0, weights["liquidity"], liquidity_text or "нет отдельного liquidity слоя"))
 
-    volume_text = _first_text(idea, "volume", "volume_ru", "data_status", "provider")
+    volume_text = _first_text(idea, "volume", "volume_ru", "future_volume", "future_delta", "data_status", "provider")
+    future_delta = _future_delta_context(idea)
+    if future_delta.get("available"):
+        delta_bias = future_delta.get("bias") or future_delta.get("delta_trend") or "neutral"
+        proxy_label = "proxy" if future_delta.get("is_proxy_metric") else "real/bridge"
+        volume_text = volume_text or f"FutureDelta {proxy_label}: {delta_bias}, FutureVolume={future_delta.get('future_volume', 'n/a')}"
     rows.append(_row("volume", weights["volume"] if volume_text else 1 if candles else 0, weights["volume"], volume_text or "только OHLC/tick proxy"))
 
     external_options = _external_options_alignment(idea, direction)
@@ -478,7 +512,8 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
         options_score = weights["options"]
     elif external_options.get("alignment") == "conflict":
         options_score = 0
-    rows.append(_row("options", options_score, weights["options"], " | ".join(part for part in (options_text, external_text) if part) or "опционный слой не обязателен для базовой идеи"))
+    sharkfx = _sharkfx_alignment(idea, direction)
+    rows.append(_row("options", options_score, weights["options"], " | ".join(part for part in (options_text, external_text, sharkfx.get("text_ru")) if part) or "опционный слой не обязателен для базовой идеи"))
 
     sentiment = _sentiment_alignment(idea, direction)
     rows.append(_row("sentiment", int(sentiment.get("score") or 0), weights["sentiment"], str(sentiment.get("text_ru") or "нет sentiment")))
@@ -494,7 +529,14 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     geo = _trade_geometry(safe_idea)
     sentiment = _sentiment_alignment(safe_idea, direction)
     external_options = _external_options_alignment(safe_idea, direction)
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0)))
+    sharkfx = _sharkfx_alignment(safe_idea, direction)
+    future_delta = _future_delta_context(safe_idea)
+    future_delta_adjustment = 0
+    if future_delta.get("available") and direction in {"BUY", "SELL"}:
+        bias = str(future_delta.get("bias") or "neutral").lower()
+        if (direction == "BUY" and bias == "bullish") or (direction == "SELL" and bias == "bearish"):
+            future_delta_adjustment = 2
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(sharkfx.get("score_adjustment") or 0) + future_delta_adjustment))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     blockers: list[str] = []
@@ -539,7 +581,13 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "external_options_used": bool(external_options.get("used")),
         "external_options_alignment": external_options.get("alignment") or "neutral",
         "external_options_source": "CME_OptionsFX",
-        "delta_divergence": None,
+        "telegram_signal_filter": sharkfx,
+        "telegram_signal_used": bool(sharkfx.get("used")),
+        "telegram_signal_source": "sharkfx_ru",
+        "future_delta": future_delta,
+        "future_delta_used": bool(future_delta.get("available")),
+        "future_delta_score_adjustment": future_delta_adjustment,
+        "delta_divergence": future_delta.get("delta", {}).get("divergence") if isinstance(future_delta.get("delta"), dict) else None,
         "margin_zone_confluence": None,
         "disclaimer_ru": "Score не блокирует идею только из-за отсутствия optional CME/options/news слоёв; но если sentiment/news явно против направления, автоторговля блокируется.",
     }
@@ -553,6 +601,7 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
     mode = str(score.get("mode") or "").lower()
     sentiment_filter = score.get("sentiment_filter") if isinstance(score.get("sentiment_filter"), dict) else {}
     external_options_filter = score.get("external_options_filter") if isinstance(score.get("external_options_filter"), dict) else {}
+    telegram_signal_filter = score.get("telegram_signal_filter") if isinstance(score.get("telegram_signal_filter"), dict) else {}
     sentiment_conflict = sentiment_filter.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options_filter.get("alignment") == "conflict" and external_options_filter.get("high_confidence_conflict"))
     allowed = (
@@ -587,6 +636,10 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
         "external_options_alignment": external_options_filter.get("alignment") or "neutral",
         "external_options_source": "CME_OptionsFX",
         "external_options_filter": external_options_filter,
+        "telegram_signal_used": bool(telegram_signal_filter.get("used")),
+        "telegram_signal_alignment": telegram_signal_filter.get("alignment") or "neutral",
+        "telegram_signal_source": "sharkfx_ru",
+        "telegram_signal_filter": telegram_signal_filter,
         "level_source": geo.get("level_source"),
     }
 
@@ -638,6 +691,11 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "external_options_used": score.get("external_options_used"),
             "external_options_alignment": score.get("external_options_alignment"),
             "external_options_source": "CME_OptionsFX",
+            "telegram_signal_filter": score.get("telegram_signal_filter"),
+            "telegram_signal_used": score.get("telegram_signal_used"),
+            "telegram_signal_source": "sharkfx_ru",
+            "future_delta": score.get("future_delta"),
+            "future_delta_used": score.get("future_delta_used"),
         }
     )
     return enriched

--- a/backend/analysis/volume_cluster_adapter.py
+++ b/backend/analysis/volume_cluster_adapter.py
@@ -3,11 +3,27 @@ from __future__ import annotations
 from typing import Any
 
 from app.services.mt4_volume_cluster_bridge import get_latest_volume_cluster
+from app.services.future_delta_service import get_future_delta_snapshot
 
 
 def build_volume_cluster_analysis(symbol: str, timeframe: str, action: str, entry: float | None, price: float | None) -> dict[str, Any]:
     payload = get_latest_volume_cluster(symbol, timeframe)
     if not payload:
+        fallback = get_future_delta_snapshot(symbol, timeframe, [])
+        if fallback.get("available"):
+            bias = str(fallback.get("bias") or "neutral")
+            action_upper = str(action or "WAIT").upper()
+            aligned = (action_upper == "BUY" and bias == "bullish") or (action_upper == "SELL" and bias == "bearish")
+            score = 4 if aligned else 0
+            return {
+                "available": True,
+                "source": fallback.get("source") or "calculated_cum_delta_proxy",
+                "is_proxy_metric": True,
+                "scoreImpact": score,
+                "future_delta": fallback,
+                "signals": {"volume_confirmation": "proxy", "cluster_bias": bias},
+                "summary_ru": "Кластерный слой недоступен; используется расчётный CumDelta/FutureVolume proxy без подмены реальной ленты.",
+            }
         return {"available": False, "reason": "MT4 volume cluster data is not available", "scoreImpact": 0}
 
     vp = payload.get("volume_profile") if isinstance(payload.get("volume_profile"), dict) else {}

--- a/backend/signal_engine.py
+++ b/backend/signal_engine.py
@@ -15,6 +15,7 @@ from backend.sentiment_provider import build_sentiment_provider
 from backend.core.scoring.weighted_confluence_model import WeightedConfluenceModel
 from app.services.cme_scraper import get_cme_market_snapshot
 from app.services.mt4_options_bridge import get_latest_options_levels
+from app.services.future_delta_service import get_future_delta_snapshot
 from backend.signals import build_trade_levels, default_invalidation_text, has_minimum_confluence, infer_action
 
 SUPPORTED_TIMEFRAMES = ["M15", "M30", "H1", "H4", "D1", "W1"]
@@ -349,6 +350,7 @@ class SignalEngine:
         data_quality = analysis_contract["data_quality"]
         analysis_mode = analysis_contract["analysis_mode"]
         is_fallback_mode = analysis_mode == "directional_fallback"
+        mt4_recovery_mode = analysis_contract.get("data_provider") == "mt4_bridge"
         policy_mode = "strict_smc" if analysis_contract["analysis_mode"] == "professional" else "fallback_directional"
         mtf_patterns = mtf_features.get("chart_patterns", [])
         mtf_pattern_summary = mtf_features.get("pattern_summary", self.pattern_detector.detect([])["summary"])
@@ -401,10 +403,18 @@ class SignalEngine:
         price = float(mtf.get("close") or 0.0)
         if price <= 0:
             return self._no_trade(symbol=symbol, timeframe=timeframe, snapshot=mtf, reason="WAIT: нет валидной цены.")
+        valid_data_exists = mtf.get("data_status") in {"real", "delayed"}
+        mt4_candle_recovery = bool(mt4_recovery_mode and valid_data_exists and len(mtf.get("candles", []) or []) >= PROFESSIONAL_MIN_CANDLES and mtf_features.get("trend") in {"up", "down"})
+        if mt4_candle_recovery and not htf_zone["exists"]:
+            htf_zone = self._fallback_htf_zone_from_candles(htf or mtf, price)
+        if mt4_candle_recovery and not ltf_confirmation["has_structure"]:
+            ltf_confirmation = {**ltf_confirmation, "has_structure": True, "local_impulse": True, "fallback_from_candles": True}
         in_htf_zone = bool(htf_zone["exists"] and (htf_zone["bottom"] <= price <= htf_zone["top"]))
         base_setup_valid = bool(htf_zone["exists"] and atr_ok and in_htf_zone and ltf_confirmation["has_structure"])
-        valid_data_exists = mtf.get("data_status") in {"real", "delayed"}
-        if valid_data_exists and analysis_mode == "professional" and not base_setup_valid:
+        if mt4_candle_recovery and not base_setup_valid and atr_ok and htf_zone["exists"]:
+            base_setup_valid = True
+            in_htf_zone = True
+        if valid_data_exists and analysis_mode == "professional" and not base_setup_valid and not mt4_candle_recovery:
             return self._no_trade(
                 symbol=symbol,
                 timeframe=timeframe,
@@ -448,6 +458,13 @@ class SignalEngine:
             stop = max(1e-6, abs(price) * 0.95)
         if take <= 0:
             take = max(1e-6, abs(price) * 1.05)
+        if mt4_candle_recovery:
+            recovery_risk = abs(price - stop) if action == "BUY" else abs(stop - price)
+            min_reward = recovery_risk * 1.45
+            if action == "BUY" and take - price < min_reward:
+                take = price + min_reward
+            elif action == "SELL" and price - take < min_reward:
+                take = max(1e-6, price - min_reward)
         risk_value = abs(price - stop) if action == "BUY" else abs(stop - price)
         reward_value = abs(take - price) if action == "BUY" else abs(price - take)
         rr = reward_value / max(risk_value, 1e-9)
@@ -466,6 +483,10 @@ class SignalEngine:
         if confluence_flags["htf_alignment"]:
             confidence += 7
             bonuses.append({"key": "htf_alignment", "delta": 7, "reason_ru": "HTF и MTF в одном направлении"})
+        if mt4_candle_recovery:
+            confidence += 8
+            confluence_flags["mt4_candle_recovery"] = True
+            bonuses.append({"key": "mt4_candle_recovery", "delta": 8, "reason_ru": "MT4 прислал валидные свечи: включён recovery по направлению, ATR и структуре свечей"})
         else:
             penalties.append({"key": "htf_alignment", "delta": -4, "reason_ru": "Частичное расхождение HTF/MTF"})
         if confluence_flags["ltf_pattern_confirmation"] and ltf_features.get("pattern") == "engulfing":
@@ -493,7 +514,7 @@ class SignalEngine:
                 confidence_percent=confidence,
                 htf_conflict=trend_conflict,
                 volatility_percent=mtf_features.get("atr_percent", 0.0),
-                min_confidence_percent=PROFESSIONAL_MIN_CONFIDENCE if analysis_mode == "professional" else FALLBACK_MIN_CONFIDENCE,
+                min_confidence_percent=FALLBACK_MIN_CONFIDENCE if mt4_candle_recovery else (PROFESSIONAL_MIN_CONFIDENCE if analysis_mode == "professional" else FALLBACK_MIN_CONFIDENCE),
             )
         confluence_flags["risk_filter_passed"] = bool(risk.get("allowed"))
         weak_reasons: list[str] = []
@@ -518,12 +539,21 @@ class SignalEngine:
             ai_adjustment = 2
         elif mtf_pattern_summary.get("patternBias") in {"bullish", "bearish"}:
             ai_adjustment = -2
+        future_delta = get_future_delta_snapshot(symbol, timeframe, mtf.get("candles", []))
+        future_delta_aligned = (
+            future_delta.get("available")
+            and ((action == "BUY" and future_delta.get("bias") == "bullish") or (action == "SELL" and future_delta.get("bias") == "bearish"))
+        )
+        if future_delta_aligned:
+            confidence += 2
+            bonuses.append({"key": "future_delta", "delta": 2, "reason_ru": "FutureDelta/CumDelta proxy совпадает с направлением"})
+
         weighted_result = self.weighted_confluence.calculate(
             base_setup_valid=base_setup_valid,
             smc_alignment=bool(strict_confluence or directional_structure),
             options_support=bool(options_available),
-            futures_confirmation=bool(options_snapshot.get("futures")),
-            volume_confirmation=bool(mtf_features.get("displacement")),
+            futures_confirmation=bool(options_snapshot.get("futures") or future_delta.get("available")),
+            volume_confirmation=bool(mtf_features.get("displacement") or future_delta.get("available")),
             htf_aligned=bool(confluence_flags["htf_alignment"]),
             high_impact_news=high_impact_news,
             countertrend=bool(trend_conflict),
@@ -697,6 +727,8 @@ class SignalEngine:
             "idea_id": self._idea_id(symbol, timeframe, action, mtf_pattern_summary),
             "sentiment": sentiment,
             "smart_money_context": smart_money_context,
+            "future_delta": future_delta,
+            "future_delta_used": bool(future_delta.get("available")),
             "chart_patterns": mtf_patterns,
             "pattern_summary": mtf_pattern_summary,
             "pattern_signal_impact": pattern_impact,
@@ -725,6 +757,8 @@ class SignalEngine:
                 "bonuses": bonuses,
                 "signal_grade": signal_grade,
                 "relaxed_mode_used": relaxed_mode_used,
+                "mt4_candle_recovery": mt4_candle_recovery,
+                "future_delta_used": bool(future_delta.get("available")),
             },
             "penalties": penalties,
             "bonuses": bonuses,
@@ -759,6 +793,8 @@ class SignalEngine:
                 "sentimentAlignment": sentiment_alignment,
                 "sentimentImpact": round(sentiment_delta / 100, 4),
                 "smart_money_context": smart_money_context,
+                "future_delta": future_delta,
+                "future_delta_used": bool(future_delta.get("available")),
                 "setup_quality": validation_state,
                 "optionsImpact": options_applied.get("options_impact", 0),
                 "optionsSummaryRu": options_applied.get("options_summary_ru"),
@@ -1350,6 +1386,26 @@ class SignalEngine:
             "risk_reward_score": 40.0,
         }
 
+
+    @staticmethod
+    def _fallback_htf_zone_from_candles(snapshot: dict, price: float) -> dict:
+        candles = [row for row in (snapshot.get("candles") or []) if isinstance(row, dict)]
+        highs: list[float] = []
+        lows: list[float] = []
+        for row in candles[-24:]:
+            try:
+                highs.append(float(row.get("high")))
+                lows.append(float(row.get("low")))
+            except (TypeError, ValueError):
+                continue
+        if not highs or not lows or price <= 0:
+            pad = max(price * 0.003, 1e-6)
+            return {"exists": True, "top": price + pad, "bottom": max(1e-6, price - pad), "liquidity_top": price + pad * 2, "liquidity_bottom": max(1e-6, price - pad * 2), "source": "mt4_candle_range_fallback"}
+        top = max(max(highs), price)
+        bottom = min(min(lows), price)
+        pad = max((top - bottom) * 0.75, price * 0.0015, 1e-6)
+        return {"exists": True, "top": top + pad, "bottom": max(1e-6, bottom - pad), "liquidity_top": top + pad * 2, "liquidity_bottom": max(1e-6, bottom - pad * 2), "source": "mt4_candle_range_fallback"}
+
     def _resolve_htf_zone(self, htf_features: dict) -> dict:
         ob_zone = htf_features.get("order_block_zone") or {}
         fvg_zone = htf_features.get("fvg_zone") or {}
@@ -1453,12 +1509,22 @@ class SignalEngine:
         return "weak"
 
     def _sentiment_alignment(self, action: str, sentiment: dict) -> str:
-        bias = sentiment.get("contrarian_bias", "neutral")
-        if action == "BUY" and bias == "bullish":
+        bias = str(sentiment.get("contrarian_bias") or sentiment.get("bias") or "neutral").lower()
+        if bias in {"bullish_usd", "bearish_usd"}:
+            symbol = str(sentiment.get("symbol") or "").upper().replace("/", "")
+            if bias == "bullish_usd":
+                implied = "BUY" if symbol.startswith("USD") else "SELL" if symbol.endswith("USD") or symbol.startswith("XAU") else "neutral"
+            else:
+                implied = "SELL" if symbol.startswith("USD") else "BUY" if symbol.endswith("USD") or symbol.startswith("XAU") else "neutral"
+            if implied == action:
+                return "aligns"
+            if implied in {"BUY", "SELL"} and action in {"BUY", "SELL"}:
+                return "conflicts"
+        if action == "BUY" and bias in {"bullish", "buy", "crowd_short"}:
             return "aligns"
-        if action == "SELL" and bias == "bearish":
+        if action == "SELL" and bias in {"bearish", "sell", "crowd_long"}:
             return "aligns"
-        if action in {"BUY", "SELL"} and bias in {"bullish", "bearish"}:
+        if action in {"BUY", "SELL"} and bias in {"bullish", "bearish", "buy", "sell", "crowd_long", "crowd_short"}:
             return "conflicts"
         return "neutral"
 

--- a/tests/signals/test_cme_optionsfx_adapter.py
+++ b/tests/signals/test_cme_optionsfx_adapter.py
@@ -81,3 +81,44 @@ def test_prop_score_uses_cme_optionsfx_as_confirmation_layer(monkeypatch):
     assert enriched["external_options_bias"] == "bullish"
     assert enriched["external_options_key_strikes"] == [1.08, 1.09]
     assert enriched["external_options_max_pain"] == 1.085
+
+from app.services.external_signal_adapter import parse_sharkfx_message
+
+
+def test_parse_sharkfx_message_contract():
+    parsed = parse_sharkfx_message("EURUSD BUY entry 1.0800 SL 1.0750 TP1 1.0920 confidence 70")
+
+    assert parsed[0]["source"] == "sharkfx_ru"
+    assert parsed[0]["source_kind"] == "trading_signal_source"
+    assert parsed[0]["symbol"] == "EURUSD"
+    assert parsed[0]["action"] == "BUY"
+    assert parsed[0]["entry"] == 1.08
+    assert parsed[0]["stop_loss"] == 1.075
+    assert parsed[0]["take_profit"] == 1.092
+    assert parsed[0]["opens_trades_directly"] is False
+
+
+def test_prop_score_uses_sharkfx_only_as_optional_boost(monkeypatch):
+    def fake_cme(symbol):
+        return {"source": "CME_OptionsFX", "available": False, "used": False, "reason": "telegram_credentials_missing", "signal": None}
+
+    def fake_shark(symbol, action=None):
+        return {"source": "sharkfx_ru", "available": True, "used": True, "alignment": "aligned", "signal": {"action": action, "symbol": symbol}}
+
+    monkeypatch.setattr(prop_signal_engine, "get_cme_optionsfx_confirmation", fake_cme)
+    monkeypatch.setattr(prop_signal_engine, "get_sharkfx_confirmation", fake_shark)
+    idea = {
+        "symbol": "EURUSD",
+        "signal": "BUY",
+        "entry": 1.08,
+        "sl": 1.07,
+        "tp": 1.10,
+        "candles": [{"open": 1.07, "high": 1.10, "low": 1.06, "close": 1.08, "tick_volume": 100}] * 40,
+        "reason_ru": "технический импульс",
+    }
+
+    score = prop_signal_engine.build_prop_signal_score(idea)
+
+    assert score["telegram_signal_used"] is True
+    assert score["telegram_signal_filter"]["alignment"] == "aligned"
+    assert score["score"] >= 55

--- a/tests/signals/test_future_delta_service.py
+++ b/tests/signals/test_future_delta_service.py
@@ -1,0 +1,17 @@
+from app.services.future_delta_service import calculate_cum_delta_from_candles
+
+
+def test_calculated_cum_delta_proxy_is_labelled():
+    candles = []
+    price = 1.1000
+    for _ in range(30):
+        candles.append({"open": price, "high": price + 0.0005, "low": price - 0.0002, "close": price + 0.0003, "tick_volume": 100})
+        price += 0.0002
+
+    payload = calculate_cum_delta_from_candles(candles)
+
+    assert payload["available"] is True
+    assert payload["source"] == "calculated_cum_delta_proxy"
+    assert payload["is_proxy_metric"] is True
+    assert payload["bias"] == "bullish"
+    assert "proxy" in payload["label_ru"]

--- a/tests/signals/test_signal_engine_resilience.py
+++ b/tests/signals/test_signal_engine_resilience.py
@@ -351,3 +351,60 @@ def test_generate_live_signals_keeps_scenario_if_htf_or_ltf_missing(monkeypatch)
     assert signals
     assert signals[0]["action"] in {"BUY", "SELL"}
     assert signals[0]["structure_state"] == "analyzable"
+
+
+def test_mt4_valid_candles_recover_trade_without_telegram(monkeypatch) -> None:
+    engine = SignalEngine()
+    monkeypatch.setattr(
+        engine,
+        "_resolve_options_analysis",
+        lambda options_snapshot, symbol=None: {"available": False, "source": "unavailable"},
+    )
+    base = {
+        "timeframe": "H1",
+        "data_status": "real",
+        "source": "mt4_bridge",
+        "source_symbol": "EURUSD",
+        "last_updated_utc": "2026-06-03T12:00:00+00:00",
+        "is_live_market_data": True,
+        "message": "MT4 candles",
+        "close": 1.1123,
+        "candles": _candles(count=40),
+    }
+    weak_directional = {
+        "status": "ready",
+        "trend": "up",
+        "bos": False,
+        "liquidity_sweep": False,
+        "order_block": None,
+        "fvg": False,
+        "choch": False,
+        "divergence": "none",
+        "pattern": "none",
+        "delta_percent": 0.05,
+        "atr_percent": 0.3,
+        "pattern_summary": {"patternSummaryRu": "MT4 свечи дают направленный импульс."},
+        "chart_patterns": [],
+    }
+
+    signal = engine._build_signal(
+        "EURUSD",
+        "M15",
+        base,
+        {**base, "timeframe": "M15"},
+        {**base, "timeframe": "M15"},
+        weak_directional,
+        weak_directional,
+        weak_directional,
+        {"data_status": "unavailable", "confidence": 0.0},
+        {"available": False},
+    )
+
+    assert signal["action"] in {"BUY", "SELL"}
+    assert signal["entry"] is not None
+    assert signal["stop_loss"] is not None
+    assert signal["take_profit"] is not None
+    assert signal["confidence_percent"] > 55
+    assert signal["advisor_allowed"] is True
+    assert signal["confluence_flags"]["mt4_candle_recovery"] is True
+    assert signal["options_available"] is False


### PR DESCRIPTION
### Motivation
- Обеспечить работу engine без обязательных Telegram/CME слоёв: при наличии валидных MT4 свечей система должна генерировать BUY/SELL, Entry/SL/TP, score>55 и `advisor_allowed=true` без внешних Telegram подтверждений.
- Добавить опциональные подтверждающие источники (SharkFX Telegram, CME_OptionsFX, FutureDelta) которые усиливают/понижают score, но не блокируют базовую сделку.

### Description
- Добавлен Telegram adapter `sharkfx_ru` и парсер `parse_sharkfx_message` с endpoint `GET /api/external-signals/sharkfx`, при этом `opens_trades_directly=false` чтобы канал был только подтверждающим/информативным (файлы: `app/services/external_signal_adapter.py`, `app/main.py`).
- Введён `FutureDelta`/`FutureVolume` слой с реализацией `get_future_delta_snapshot` и расчётом явного `calculated_cum_delta_proxy` из OHLC+tick-volume как пометочного proxy-метрика (`is_proxy_metric=true`), используемого как fallback при отсутствии MT4 volume cluster (файл: `app/services/future_delta_service.py`, изменения в `backend/analysis/volume_cluster_adapter.py`).
- Восстановлен recovery-паттерн в `SignalEngine`: при валидных MT4 свечах включается `mt4_candle_recovery` — восстанавливается HTF zone/ltf confirmation, вычисляются ATR-fallback уровни Entry/SL/TP, корректируется TP для обеспечения минимального RR и добавляются бонусы к уверенности (файл: `backend/signal_engine.py`).
- Обновлён prop scorer и recovery patch: добавлены опциональные бусты/штрафы от SharkFX, интеграция `future_delta` в расчёт объёма/score, пометки `telegram_signal_*` и `future_delta_*` в payload; SharkFX только улучшает/понижает score и не блокирует сделку по умолчанию (файл: `app/services/prop_signal_engine.py`, `app/core/prop_score_recovery_patch.py`).
- Мелкие правки README и тестов: добавлены unit-тесты для SharkFX парсинга, MT4 recovery сценария и CumDelta proxy; внесены defensive правки в `backend/analysis/volume_cluster_adapter.py` и связующие места.

### Testing
- Скомпилированы модули через `python -m py_compile` для изменённых файлов без синтаксических ошибок. (успех)
- Прогон целевых тестов: `pytest -q tests/signals/test_prop_signal_fallback.py tests/signals/test_cme_optionsfx_adapter.py tests/signals/test_signal_engine_resilience.py tests/signals/test_future_delta_service.py` — все тесты в наборе прошли: `17 passed`.
- Полный запуск `pytest -q` завершился ошибками на этапе collection, которые не связаны с этими изменениями (существующие проблемы с экспортами из `app.main` и опечаткой в старом `app/services/chart_snapshot_service.py`), поэтому полный suite не учитывается для этого PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fdc557a348331b531c121e91c5c40)