### PR TITLE
Сделать CME/Telegram подтверждающим слоем, а не hard-block для advisor_allowed

### DIFF
--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -614,6 +614,7 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0)))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
+    external_options_note = ""
     blockers: list[str] = []
 
     if direction == "WAIT":
@@ -627,11 +628,11 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     if sentiment_conflict:
         blockers.append(str(sentiment.get("text_ru") or "Sentiment/news против направления сделки"))
     if external_options_high_conflict:
-        blockers.append(str(external_options.get("text_ru") or "CME_OptionsFX high-confidence conflict против сделки"))
+        external_options_note = str(external_options.get("text_ru") or "CME_OptionsFX high-confidence conflict против сделки")
     if volume_delta.get("delta_divergence"):
         blockers.append("Delta divergence: цена и CumDelta расходятся")
 
-    hard_blocked = direction == "WAIT" or not geo.get("has_levels") or not geo.get("valid_geometry") or geo.get("tiny_tp") or geo.get("weak_rr") or sentiment_conflict or external_options_high_conflict
+    hard_blocked = direction == "WAIT" or not geo.get("has_levels") or not geo.get("valid_geometry") or geo.get("tiny_tp") or geo.get("weak_rr") or sentiment_conflict
     if score >= 70 and not hard_blocked:
         grade, mode, decision_ru = "A", "prop_entry", "Рабочая prop-идея: есть направление, уровни, свечи, приемлемый риск/прибыль и sentiment не против сделки."
     elif score >= 55 and not hard_blocked:
@@ -655,6 +656,7 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "sentiment_filter": sentiment,
         "sentiment_used": sentiment.get("alignment") != "missing",
         "external_options_filter": external_options,
+        "external_options_note": external_options_note,
         "external_options_used": bool(external_options.get("used")),
         "external_options_alignment": external_options.get("alignment") or "neutral",
         "external_options_source": "CME_OptionsFX",
@@ -686,9 +688,11 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
         and not geo.get("tiny_tp")
         and not geo.get("weak_rr")
         and not sentiment_conflict
-        and not external_options_high_conflict
     )
-    reason = "allowed: BUY/SELL + valid levels + RR>=1.10 + TP distance ok + sentiment not against + score>=55" if allowed else "blocked: нужен BUY/SELL, валидные уровни, RR>=1.10, sentiment не против и score>=55"
+    if allowed and external_options_high_conflict:
+        reason = "allowed: BUY/SELL + valid levels + RR>=1.10 + score>=55; CME/Telegram conflict сохранён как подтверждающий слой, но не блокирует"
+    else:
+        reason = "allowed: BUY/SELL + valid levels + RR>=1.10 + TP distance ok + sentiment not against + score>=55" if allowed else "blocked: нужен BUY/SELL, валидные уровни, RR>=1.10, sentiment не против и score>=55"
     return {
         "allowed": allowed,
         "reason": reason,

--- a/tests/signals/test_cme_optionsfx_adapter.py
+++ b/tests/signals/test_cme_optionsfx_adapter.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 from app.services.external_signal_adapter import get_cme_optionsfx_signals, parse_cme_optionsfx_message
 from app.services import prop_signal_engine
 
@@ -81,3 +79,38 @@ def test_prop_score_uses_cme_optionsfx_as_confirmation_layer(monkeypatch):
     assert enriched["external_options_bias"] == "bullish"
     assert enriched["external_options_key_strikes"] == [1.08, 1.09]
     assert enriched["external_options_max_pain"] == 1.085
+
+
+def test_external_telegram_options_conflict_is_confirmation_not_hard_blocker(monkeypatch):
+    def fake_confirmation(symbol):
+        return {
+            "source": "CME_OptionsFX",
+            "available": True,
+            "used": True,
+            "option_bias": "bearish",
+            "signal": {
+                "source": "CME_OptionsFX",
+                "symbol": symbol,
+                "option_bias": "bearish",
+                "raw_text": "HIGH CONFIDENCE bearish options flow",
+            },
+        }
+
+    monkeypatch.setattr(prop_signal_engine, "get_cme_optionsfx_confirmation", fake_confirmation)
+    idea = {
+        "symbol": "EURUSD",
+        "signal": "BUY",
+        "entry": 1.1000,
+        "sl": 1.0950,
+        "tp": 1.1100,
+        "candles": [{"high": 1.1020, "low": 1.0940, "close": 1.1000}] * 80,
+        "reason_ru": "валидный импульс от MT4 свечей",
+    }
+
+    enriched = prop_signal_engine.enrich_idea_with_prop_score(idea)
+
+    assert enriched["advisor_allowed"] is True
+    assert enriched["advisor_signal"]["allowed"] is True
+    assert enriched["external_options_alignment"] == "conflict"
+    assert enriched["prop_signal_score"]["external_options_note"]
+    assert not any("CME_OptionsFX" in blocker for blocker in enriched["prop_signal_score"]["blockers"])


### PR DESCRIPTION
### Motivation
- Разрешить конфликт PR #419 так, чтобы внешние Telegram/CME опции служили только подтверждением, а не блокировали автосигнал при наличии валидных MT4-свечей и уровней. 
- Сохранить архитектуру и критичные слои: MT4 bridge, Telegram adapter, FutureDelta/FutureVolume приоритет, `prop_score_recovery_patch`, ATR fallback и sentiment как жёсткий фильтр. 

### Description
- Внесена правка в `app/services/prop_signal_engine.py`: добавлено поле `external_options_note` для хранения high-confidence конфликтов от CME/Telegram и исключено влияние `external_options_high_conflict` из вычисления `hard_blocked`. 
- Обновлена логика генерации `reason`/`allowed` в `_advisor_signal_from_idea`, чтобы при прочих валидных условиях `advisor_allowed` оставался `True` даже при наличии high-confidence конфликтов от внешних источников. 
- Добавлен регрессионный тест `test_external_telegram_options_conflict_is_confirmation_not_hard_blocker` в `tests/signals/test_cme_optionsfx_adapter.py`, покрывающий сценарий конфликтного CME-сообщения при валидном MT4-сигнале. 
- Изменения не затрагивают существующие эндпойнты, MT4 bridge, Telegram adapter, `prop_score_recovery_patch` и FutureDelta/FutureVolume логику. 

### Testing
- Запущены и прошли: `pytest tests/signals/test_cme_optionsfx_adapter.py tests/signals/test_prop_signal_fallback.py tests/test_volume_delta_priority.py` (11 passed). 
- Статический анализ и сборка: `ruff check app/services/prop_signal_engine.py tests/signals/test_cme_optionsfx_adapter.py` и `python -m compileall app/services/prop_signal_engine.py tests/signals/test_cme_optionsfx_adapter.py` успешно выполнены. 
- Полный прогон `pytest` не пройден из-за существующих ошибок вне этого PR: отсутствующие экспорты в `app.main` и синтаксическая ошибка в `app/services/chart_snapshot_service.py` (`from **future** import annotations`), которые не менялись этим PR и требуют отдельного фиксa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fe4d979d08331aab32eddd99c4cc6)