### PR TITLE
Подключить lifecycle торговых идей к API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
+from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_stats
 from app.services.signal_audit_logger import log_signal_audit
 from backend.chat_service import ChatRequest, ForexChatService
 
@@ -785,12 +786,12 @@ def api_signals():
 
     if signals:
         enriched_signals = enrich_ideas_with_prop_scores(signals)
-        archive = load_json(ARCHIVE_FILE)
+        lifecycle = apply_idea_lifecycle(enriched_signals)
         return {
-            "signals": enriched_signals,
-            "ideas": enriched_signals,
-            "archive": archive,
-            "statistics": build_stats(),
+            "signals": lifecycle["ideas"],
+            "ideas": lifecycle["ideas"],
+            "archive": lifecycle["archive"],
+            "statistics": lifecycle["statistics"],
             "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
             "updated_at_utc": now_utc(),
             "ai_provider": "signal_engine",
@@ -884,12 +885,12 @@ def api_ideas():
 
     if signals:
         enriched_signals = enrich_ideas_with_prop_scores(signals)
-        archive = load_json(ARCHIVE_FILE)
+        lifecycle = apply_idea_lifecycle(enriched_signals)
         return {
-            "signals": enriched_signals,
-            "ideas": enriched_signals,
-            "archive": archive,
-            "statistics": build_stats(),
+            "signals": lifecycle["ideas"],
+            "ideas": lifecycle["ideas"],
+            "archive": lifecycle["archive"],
+            "statistics": lifecycle["statistics"],
             "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
             "updated_at_utc": now_utc(),
         }
@@ -1375,13 +1376,13 @@ def api_mt4_markup(symbol: str, tf: str = "M15"):
     return payload
 @app.get("/api/archive")
 def api_archive():
-    archive = load_json(ARCHIVE_FILE)
+    archive = apply_idea_lifecycle([])["archive"]
     return {"archive": archive, "total": len(archive)}
 
 
 @app.get("/api/stats")
 def api_stats():
-    return build_stats()
+    return build_lifecycle_stats()
 
 
 @app.get("/api/news")

--- a/tests/test_idea_lifecycle_api.py
+++ b/tests/test_idea_lifecycle_api.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app import main
+from app.services import idea_lifecycle
+
+
+def _lifecycle_payload() -> dict:
+    ideas = [{"symbol": "EURUSD", "signal": "BUY", "lifecycle_status": "active"}]
+    archive = [{"symbol": "GBPUSD", "result": "TP"}]
+    statistics = {"total": 1, "active": 1, "tp": 1, "sl": 0}
+    return {"ideas": ideas, "active": [], "archive": archive, "statistics": statistics}
+
+
+def test_api_signals_returns_lifecycle_payload(monkeypatch) -> None:
+    payload = _lifecycle_payload()
+    monkeypatch.setattr(main, "SYMBOLS", ["EURUSD"])
+    monkeypatch.setattr(main, "build_signal_from_candles", lambda symbol, tf: {"symbol": symbol, "signal": "BUY"})
+    monkeypatch.setattr(main, "enrich_ideas_with_prop_scores", lambda signals: signals)
+    monkeypatch.setattr(main, "apply_idea_lifecycle", lambda ideas: payload)
+
+    response = main.api_signals()
+
+    assert response["signals"] == payload["ideas"]
+    assert response["ideas"] == payload["ideas"]
+    assert response["archive"] == payload["archive"]
+    assert response["statistics"] == payload["statistics"]
+
+
+def test_api_ideas_returns_lifecycle_payload(monkeypatch) -> None:
+    payload = _lifecycle_payload()
+    monkeypatch.setattr(main, "build_signal_from_candles", lambda symbol, tf: {"symbol": symbol, "signal": "BUY"})
+    monkeypatch.setattr(main, "enrich_ideas_with_prop_scores", lambda signals: signals)
+    monkeypatch.setattr(main, "apply_idea_lifecycle", lambda ideas: payload)
+    monkeypatch.setattr(main, "log_signal_audit", lambda entry: None)
+
+    response = main.api_ideas()
+
+    assert response["signals"] == payload["ideas"]
+    assert response["ideas"] == payload["ideas"]
+    assert response["archive"] == payload["archive"]
+    assert response["statistics"] == payload["statistics"]
+
+
+def test_archive_and_stats_endpoints_use_lifecycle_service(monkeypatch) -> None:
+    payload = _lifecycle_payload()
+    monkeypatch.setattr(main, "apply_idea_lifecycle", lambda ideas: payload)
+    monkeypatch.setattr(main, "build_lifecycle_stats", lambda: payload["statistics"])
+
+    assert main.api_archive() == {"archive": payload["archive"], "total": 1}
+    assert main.api_stats() == payload["statistics"]
+
+
+def test_active_idea_is_locked_until_tp_or_sl(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(idea_lifecycle, "ACTIVE_FILE", tmp_path / "active_ideas.json")
+    monkeypatch.setattr(idea_lifecycle, "ARCHIVE_FILE", tmp_path / "archive.json")
+
+    original = {
+        "symbol": "EURUSD",
+        "signal": "BUY",
+        "current_price": 1.10,
+        "entry": 1.10,
+        "sl": 1.09,
+        "tp": 1.20,
+        "advisor_allowed": True,
+    }
+    recalculated = {
+        "symbol": "EURUSD",
+        "signal": "SELL",
+        "current_price": 1.15,
+        "entry": 1.15,
+        "sl": 1.25,
+        "tp": 1.05,
+        "advisor_allowed": True,
+    }
+
+    first = idea_lifecycle.apply_idea_lifecycle([original])
+    locked = idea_lifecycle.apply_idea_lifecycle([recalculated])
+
+    assert locked["ideas"][0]["idea_id"] == first["ideas"][0]["idea_id"]
+    assert locked["ideas"][0]["signal"] == "BUY"
+    assert locked["archive"] == []
+
+    recalculated["current_price"] = 1.20
+    replaced = idea_lifecycle.apply_idea_lifecycle([recalculated])
+
+    assert replaced["ideas"][0]["idea_id"] != first["ideas"][0]["idea_id"]
+    assert replaced["ideas"][0]["signal"] == "SELL"
+    assert replaced["archive"][0]["result"] == "TP"


### PR DESCRIPTION
### Motivation
- Интегрировать сервис lifecycle идей (`idea_lifecycle`) чтобы API возвращал уже зафиксированные активные идеи и корректно управлял заменой идей по символу только после TP/SL.
- Сохранить существующие контракты маршрутов и не нарушать текущую архивацию в `archive.json`.
- Предоставить статистику и архив через единый lifecycle-интерфейс для согласованности данных.

### Description
- Добавлен импорт `from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_stats` в `app/main.py`.
- В `api_signals()` и `api_ideas()` вместо прямого возврата обогащённого списка теперь вызывается `apply_idea_lifecycle(enriched_signals)` и из результата возвращаются `ideas`, `archive` и `statistics`.
- Эндпоинт `/api/archive` теперь читает архив через `apply_idea_lifecycle([])["archive"]`, а `/api/stats` возвращает `build_lifecycle_stats()` без изменения путей и контрактов.
- Добавлен интеграционный тест `tests/test_idea_lifecycle_api.py`, который проверяет поведение `/api/signals`, `/api/ideas`, `/api/archive`, `/api/stats` и логику блокировки активной идеи по символу до достижения TP/SL.
- Архитектура и существующий файл архива `archive.json` не удалялись и не менялись семантически.

### Testing
- Собрана компиляция с `python -m compileall -q app/main.py app/services/idea_lifecycle.py tests/test_idea_lifecycle_api.py`, компиляция выполнена успешно.
- Запуск целевого набора тестов `python -m pytest -q tests/test_idea_lifecycle_api.py` прошёл успешно (`4 passed`).
- Локальные проверки с `python -m pytest -q tests/test_idea_lifecycle_api.py tests/test_auto_archive_logic.py` показали, что тесты lifecycle проходят, при этом существующий тест вне области этого PR (`test_evaluate_trade_result_by_price_buy_and_sell`) упал и считается нерелевантным для текущих изменений.
- Полный запуск `python -m pytest -q` прерван из-за уже существующих проблем в проекте (ошибки коллекции из-за отсутствующих экспортов `signal_analytics_service`, `canonical_market_service`, `trade_idea_service` и синтаксическая ошибка в `app/services/chart_snapshot_service.py`), которые не затрагиваются этим PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a210021b8a08331a56c7628a0ab45e6)