### PR TITLE
Добавить страницы статистики и архива сигналов

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,3 +413,9 @@ curl http://127.0.0.1:8000/ideas/market
 - Если Telegram credentials не заданы (`TELEGRAM_API_ID`/`TELEGRAM_API_HASH` или `TELEGRAM_BOT_TOKEN`, также поддерживаются `TG_*` aliases), endpoint возвращает `available=false`, а scoring работает как раньше без блокировки сделок.
 - В Prop Signal Engine слой `CME_OptionsFX` используется только как confirmation layer: совпадение options bias с направлением сделки даёт `+4` к score, явный конфликт даёт `-4`, а high-confidence conflict может стать blocker.
 - В payload идеи добавлены `external_options_ru`, `external_options_bias`, `external_options_key_strikes`, `external_options_max_pain`, а `advisor_signal` содержит `external_options_used`, `external_options_alignment`, `external_options_source="CME_OptionsFX"`.
+
+## Статистика и архив сигналов
+
+- Страница `/stats` показывает общие показатели жизненного цикла идей, WinRate, средний плановый RR и результаты TP/SL за текущий UTC-день из `/api/stats`.
+- Страница `/archive` показывает журнал идей из `/api/archive`, поддерживает фильтры по основным инструментам и открывает подробности архивной идеи в модальном окне.
+- Существующие поля и маршруты API сохранены; в `/api/stats` добавлены совместимые поля `total_ideas`, `average_rr`, `today_tp` и `today_sl`.

--- a/app/main.py
+++ b/app/main.py
@@ -228,6 +228,16 @@ def analytics_page():
     return FileResponse(STATIC_DIR / "analytics.html")
 
 
+@app.get("/stats", include_in_schema=False)
+def stats_page():
+    return FileResponse(STATIC_DIR / "stats.html")
+
+
+@app.get("/archive", include_in_schema=False)
+def archive_page():
+    return FileResponse(STATIC_DIR / "archive.html")
+
+
 @app.post("/api/chat")
 async def api_chat(payload: ChatRequest):
     use_fundamental = bool(getattr(payload, "context", {}).get("use_fundamental", False))
@@ -1375,9 +1385,14 @@ def api_mt4_markup(symbol: str, tf: str = "M15"):
     }
     return payload
 @app.get("/api/archive")
-def api_archive():
-    archive = apply_idea_lifecycle([])["archive"]
-    return {"archive": archive, "total": len(archive)}
+def api_archive(include_active: bool = False):
+    lifecycle = apply_idea_lifecycle([])
+    archive = lifecycle["archive"]
+    payload = {"archive": archive, "total": len(archive)}
+    if include_active:
+        active = lifecycle["active"]
+        payload.update({"active": active, "items": [*active, *archive]})
+    return payload
 
 
 @app.get("/api/stats")

--- a/app/services/idea_lifecycle.py
+++ b/app/services/idea_lifecycle.py
@@ -220,6 +220,25 @@ def build_lifecycle_stats(active: dict[str, Any] | None = None, archive: list[di
     total = len(archive)
     wins = sum(1 for x in archive if x.get("status") == "tp_hit" or x.get("result") == "TP")
     losses = sum(1 for x in archive if x.get("status") == "sl_hit" or x.get("result") == "SL")
+    today = datetime.now(timezone.utc).date().isoformat()
+    today_tp = sum(
+        1 for x in archive
+        if str(x.get("closed_at_utc") or "").startswith(today) and (x.get("status") == "tp_hit" or x.get("result") == "TP")
+    )
+    today_sl = sum(
+        1 for x in archive
+        if str(x.get("closed_at_utc") or "").startswith(today) and (x.get("status") == "sl_hit" or x.get("result") == "SL")
+    )
+
+    rr_values: list[float] = []
+    for item in [*active.values(), *archive]:
+        entry = _num(item.get("entry"))
+        sl = _num(item.get("sl") or item.get("final_sl"))
+        tp = _num(item.get("tp") or item.get("final_tp"))
+        if entry is not None and sl is not None and tp is not None and abs(entry - sl) > 0:
+            rr_values.append(abs(tp - entry) / abs(entry - sl))
+    average_rr = round(sum(rr_values) / len(rr_values), 2) if rr_values else 0.0
+
     by_symbol: dict[str, dict[str, int]] = {}
     for item in archive:
         symbol = normalize_symbol(item.get("symbol")) or "UNKNOWN"
@@ -229,4 +248,17 @@ def build_lifecycle_stats(active: dict[str, Any] | None = None, archive: list[di
             row["tp"] += 1
         if item.get("status") == "sl_hit" or item.get("result") == "SL":
             row["sl"] += 1
-    return {"total": total, "active": len(active), "archived": total, "tp": wins, "sl": losses, "winrate": round(wins / total * 100, 2) if total else 0.0, "by_symbol": by_symbol, "updated_at_utc": now_utc()}
+    return {
+        "total": total,
+        "total_ideas": total + len(active),
+        "active": len(active),
+        "archived": total,
+        "tp": wins,
+        "sl": losses,
+        "winrate": round(wins / total * 100, 2) if total else 0.0,
+        "average_rr": average_rr,
+        "today_tp": today_tp,
+        "today_sl": today_sl,
+        "by_symbol": by_symbol,
+        "updated_at_utc": now_utc(),
+    }

--- a/app/static/archive.html
+++ b/app/static/archive.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Архив сигналов</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body data-page="archive">
+  <div class="page-shell">
+    <header class="site-header">
+      <div><p class="eyebrow">Журнал идей</p><h1>Архив сигналов</h1><p class="lead">Активные и закрытые идеи с фактическим итогом TP/SL.</p></div>
+      <nav class="top-nav"><a href="/">Главная</a><a href="/ideas">Сигналы</a><a href="/stats">Статистика</a><a href="/archive">Архив</a><a href="/analytics">Аналитика</a><a href="/news">Новости</a></nav>
+    </header>
+    <main class="content-stack"><section class="panel">
+      <div class="panel-heading compact"><div><p class="section-kicker">История сделок</p><h2>Все торговые идеи</h2><p class="section-text" id="archiveMeta">Загрузка архива…</p></div></div>
+      <div class="archive-filters" id="archiveFilters" aria-label="Фильтр по символу"></div>
+      <div class="archive-table-wrap"><table class="archive-table"><thead><tr><th>Дата</th><th>Символ</th><th>Направление</th><th>Entry</th><th>SL</th><th>TP</th><th>Результат</th></tr></thead><tbody id="archiveRows"></tbody></table></div>
+    </section></main>
+  </div>
+  <div class="archive-modal" id="archiveModal" hidden><div class="archive-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="archiveModalTitle"><button class="archive-modal__close" id="archiveModalClose" type="button" aria-label="Закрыть">×</button><div id="archiveModalBody"></div></div></div>
+  <script src="/static/archive.js"></script><script src="/static/nav.js"></script>
+</body>
+</html>

--- a/app/static/archive.js
+++ b/app/static/archive.js
@@ -1,0 +1,72 @@
+const rows = document.getElementById('archiveRows');
+const filters = document.getElementById('archiveFilters');
+const meta = document.getElementById('archiveMeta');
+const modal = document.getElementById('archiveModal');
+const modalBody = document.getElementById('archiveModalBody');
+const symbols = ['Все', 'EURUSD', 'GBPUSD', 'USDJPY', 'XAUUSD'];
+let items = [];
+let selectedSymbol = 'Все';
+
+const esc = (value) => String(value ?? '—').replace(/[&<>"']/g, (char) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[char]));
+const number = (value) => value == null || Number.isNaN(Number(value)) ? '—' : Number(value).toFixed(5).replace(/0+$/, '').replace(/\.$/, '');
+const idea = (item) => item.idea && typeof item.idea === 'object' ? item.idea : item;
+const value = (item, ...keys) => {
+  const source = idea(item);
+  for (const key of keys) if (item[key] != null) return item[key]; else if (source[key] != null) return source[key];
+  return null;
+};
+const status = (item) => {
+  const result = String(item.result || '').toUpperCase();
+  if (result === 'TP' || item.status === 'tp_hit') return { code: 'TP', label: 'TP ✅', className: 'tp' };
+  if (result === 'SL' || item.status === 'sl_hit') return { code: 'SL', label: 'SL ❌', className: 'sl' };
+  return { code: 'ACTIVE', label: 'ACTIVE ⏳', className: 'active' };
+};
+const date = (raw) => {
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? '—' : parsed.toLocaleString('ru-RU', { dateStyle: 'short', timeStyle: 'short', timeZone: 'UTC' }) + ' UTC';
+};
+const rr = (item) => {
+  const entry = Number(value(item, 'entry', 'entry_price'));
+  const sl = Number(value(item, 'sl', 'stop_loss', 'final_sl'));
+  const tp = Number(value(item, 'tp', 'take_profit', 'final_tp'));
+  return [entry, sl, tp].every(Number.isFinite) && entry !== sl ? `1:${(Math.abs(tp - entry) / Math.abs(entry - sl)).toFixed(2)}` : '—';
+};
+function chart(item) {
+  const source = idea(item);
+  const payload = source.candles || source.chartData || source.chart_data || [];
+  const candles = Array.isArray(payload) ? payload : Array.isArray(payload.candles) ? payload.candles : [];
+  if (!candles.length) return '<div class="archive-chart-empty">График недоступен: свечи не сохранены в архивной идее.</div>';
+  const sample = candles.slice(-50);
+  const values = sample.flatMap((c) => [c.open, c.high, c.low, c.close].map(Number)).filter(Number.isFinite);
+  const min = Math.min(...values), max = Math.max(...values), range = max - min || 1;
+  const width = 760, height = 260, pad = 18, step = (width - pad * 2) / sample.length;
+  const y = (price) => pad + ((max - Number(price)) / range) * (height - pad * 2);
+  const bars = sample.map((c, index) => {
+    const x = pad + index * step + step / 2, up = Number(c.close) >= Number(c.open), color = up ? '#22c55e' : '#ef4444';
+    return `<line x1="${x}" y1="${y(c.high)}" x2="${x}" y2="${y(c.low)}" stroke="${color}"/><rect x="${x - Math.max(2, step * .28)}" y="${Math.min(y(c.open), y(c.close))}" width="${Math.max(4, step * .56)}" height="${Math.max(2, Math.abs(y(c.open) - y(c.close)))}" fill="${color}" rx="1"/>`;
+  }).join('');
+  return `<div class="archive-chart"><svg viewBox="0 0 ${width} ${height}" role="img" aria-label="График архивной идеи">${bars}</svg></div>`;
+}
+function render() {
+  filters.innerHTML = symbols.map((symbol) => `<button type="button" class="archive-filter ${selectedSymbol === symbol ? 'is-active' : ''}" data-symbol="${symbol}">${symbol}</button>`).join('');
+  const visible = selectedSymbol === 'Все' ? items : items.filter((item) => String(value(item, 'symbol', 'pair', 'instrument') || '').replace('/', '').toUpperCase() === selectedSymbol);
+  rows.innerHTML = visible.length ? visible.map((item, index) => {
+    const result = status(item);
+    return `<tr tabindex="0" data-index="${items.indexOf(item)}"><td>${esc(date(value(item, 'created_at_utc', 'created_at', 'signal_time_utc')))}</td><td><strong>${esc(value(item, 'symbol', 'pair', 'instrument'))}</strong></td><td><span class="archive-direction archive-direction--${String(value(item, 'action', 'signal', 'direction') || '').toLowerCase()}">${esc(value(item, 'action', 'signal', 'direction'))}</span></td><td>${number(value(item, 'entry', 'entry_price'))}</td><td>${number(value(item, 'sl', 'stop_loss', 'final_sl'))}</td><td>${number(value(item, 'tp', 'take_profit', 'final_tp'))}</td><td><span class="archive-result archive-result--${result.className}">${result.label}</span></td></tr>`;
+  }).join('') : '<tr><td colspan="7" class="archive-empty">Для выбранного инструмента идей пока нет.</td></tr>';
+  meta.textContent = `Показано: ${visible.length} · Всего: ${items.length}`;
+}
+function openItem(item) {
+  const source = idea(item), result = status(item);
+  const fullText = value(item, 'unified_narrative', 'full_text', 'description_ru', 'narrative', 'summary_ru') || 'Полный текст идеи не был сохранён.';
+  const reason = value(item, 'entry_reason_ru', 'reason_ru', 'entry_reason', 'setup_reason', 'why_entry') || 'Причина входа не указана.';
+  modalBody.innerHTML = `<p class="section-kicker">${esc(value(item, 'symbol', 'pair', 'instrument'))} · ${esc(result.label)}</p><h2 id="archiveModalTitle">Архивная торговая идея</h2><div class="archive-modal__metrics"><div><span>Score</span><strong>${esc(value(item, 'prop_score', 'score'))}</strong></div><div><span>Grade</span><strong>${esc(value(item, 'prop_grade', 'grade'))}</strong></div><div><span>RR</span><strong>${esc(rr(item))}</strong></div><div><span>Итог</span><strong>${esc(result.label)}</strong></div><div><span>Дата открытия</span><strong>${esc(date(value(item, 'created_at_utc', 'created_at')))}</strong></div><div><span>Дата закрытия</span><strong>${esc(date(value(item, 'closed_at_utc', 'closed_at')))}</strong></div></div>${chart(item)}<section class="archive-modal__text"><h3>Полный текст идеи</h3><p>${esc(fullText)}</p><h3>Причина входа</h3><p>${esc(reason)}</p></section>`;
+  modal.hidden = false; document.body.style.overflow = 'hidden';
+}
+filters.addEventListener('click', (event) => { const button = event.target.closest('[data-symbol]'); if (button) { selectedSymbol = button.dataset.symbol; render(); } });
+rows.addEventListener('click', (event) => { const row = event.target.closest('tr[data-index]'); if (row) openItem(items[Number(row.dataset.index)]); });
+rows.addEventListener('keydown', (event) => { if (event.key === 'Enter') { const row = event.target.closest('tr[data-index]'); if (row) openItem(items[Number(row.dataset.index)]); } });
+function closeModal() { modal.hidden = true; document.body.style.overflow = ''; }
+document.getElementById('archiveModalClose').addEventListener('click', closeModal); modal.addEventListener('click', (event) => { if (event.target === modal) closeModal(); }); document.addEventListener('keydown', (event) => { if (event.key === 'Escape') closeModal(); });
+async function loadArchive() { try { const response = await fetch('/api/archive?include_active=true', { cache: 'no-store' }); if (!response.ok) throw new Error(`HTTP ${response.status}`); const data = await response.json(); items = Array.isArray(data.items) ? data.items : Array.isArray(data.archive) ? data.archive : []; render(); } catch (error) { rows.innerHTML = '<tr><td colspan="7" class="archive-empty">Архив временно недоступен.</td></tr>'; meta.textContent = `Ошибка загрузки: ${error.message}`; } }
+loadArchive();

--- a/app/static/home-stats.js
+++ b/app/static/home-stats.js
@@ -1,0 +1,12 @@
+(async function loadHomeStats() {
+  try {
+    const response = await fetch('/api/stats', { cache: 'no-store' });
+    if (!response.ok) return;
+    const stats = await response.json();
+    document.getElementById('homeTodayTp').textContent = String(stats.today_tp ?? 0);
+    document.getElementById('homeTodaySl').textContent = String(stats.today_sl ?? 0);
+    document.getElementById('homeWinrate').textContent = `${stats.winrate ?? 0}%`;
+  } catch (_) {
+    // Keep unavailable values explicit instead of inventing market results.
+  }
+})();

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -104,6 +104,8 @@
         <div class="signals-nav-links">
           <a href="/">Главная</a>
           <a href="/ideas" class="is-active" aria-current="page">Сигналы</a>
+          <a href="/stats">Статистика</a>
+          <a href="/archive">Архив</a>
           <a href="/analytics">Аналитика</a>
           <a href="/news">Новости</a>
           <a href="/calendar">Календарь</a>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -20,6 +20,8 @@
         <nav class="top-nav">
           <a href="/">Главная</a>
           <a href="/ideas">Сигналы</a>
+          <a href="/stats">Статистика</a>
+          <a href="/archive">Архив</a>
           <a href="/analytics">Аналитика</a>
           <a href="/news">Новости</a>
           <a href="/calendar">Календарь</a>
@@ -41,6 +43,12 @@
       </section>
 
       <main class="content-stack">
+        <section class="panel today-signal-summary" aria-label="Результаты сигналов сегодня">
+          <div><p class="section-kicker">Сигналы</p><h2>Сегодня:</h2></div>
+          <div class="today-signal-summary__metric"><span>TP</span><strong id="homeTodayTp">—</strong></div>
+          <div class="today-signal-summary__metric"><span>SL</span><strong id="homeTodaySl">—</strong></div>
+          <div class="today-signal-summary__metric"><span>WinRate</span><strong id="homeWinrate">—</strong></div>
+        </section>
         <section class="panel">
           <div class="panel-heading compact">
             <div>
@@ -53,6 +61,14 @@
             <a class="nav-card" href="/ideas">
               <strong>Сигналы</strong>
               <span>AI-сигналы, торговые сценарии и prop setup'ы.</span>
+            </a>
+            <a class="nav-card" href="/stats">
+              <strong>Статистика</strong>
+              <span>WinRate, средний RR и результаты за сегодня.</span>
+            </a>
+            <a class="nav-card" href="/archive">
+              <strong>Архив</strong>
+              <span>История активных и закрытых торговых идей.</span>
             </a>
             <a class="nav-card" href="/analytics">
               <strong>Аналитика</strong>
@@ -76,6 +92,7 @@
     </div>
 
     <script src="/static/landing.js"></script>
+    <script src="/static/home-stats.js"></script>
     <script src="/static/nav.js"></script>
     <div class="app-version-block">
       <div class="app-version-line">

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -5,14 +5,20 @@
   const currentPath = window.location.pathname.replace(/\/+$/, '') || '/';
   const normalize = (path) => (path || '/').replace(/\/+$/, '') || '/';
 
+  const analyticsLink = nav.querySelector('a[href="/analytics"]');
+  [['/stats', 'Статистика'], ['/archive', 'Архив']].forEach(([href, label]) => {
+    if (nav.querySelector(`a[href="${href}"]`)) return;
+    const link = document.createElement('a');
+    link.href = href;
+    link.textContent = label;
+    nav.insertBefore(link, analyticsLink);
+  });
+
   nav.querySelectorAll('a[href]').forEach((link) => {
     const linkPath = normalize(link.getAttribute('href'));
     const isActive = linkPath === currentPath;
     link.classList.toggle('is-active', isActive);
-    if (isActive) {
-      link.setAttribute('aria-current', 'page');
-    } else {
-      link.removeAttribute('aria-current');
-    }
+    if (isActive) link.setAttribute('aria-current', 'page');
+    else link.removeAttribute('aria-current');
   });
 })();

--- a/app/static/stats.html
+++ b/app/static/stats.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Статистика сигналов</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body data-page="stats">
+  <div class="page-shell">
+    <header class="site-header">
+      <div><p class="eyebrow">Журнал результатов</p><h1>Статистика сигналов</h1><p class="lead">Фактические результаты зафиксированных торговых идей.</p></div>
+      <nav class="top-nav"><a href="/">Главная</a><a href="/ideas">Сигналы</a><a href="/stats">Статистика</a><a href="/archive">Архив</a><a href="/analytics">Аналитика</a><a href="/news">Новости</a></nav>
+    </header>
+    <main class="content-stack">
+      <section class="panel">
+        <div class="panel-heading compact"><div><p class="section-kicker">Результативность</p><h2>Ключевые показатели</h2><p class="section-text" id="statsUpdatedAt">Загрузка данных…</p></div><a class="archive-link-button" href="/archive">Открыть архив</a></div>
+        <div class="stats-page-grid" id="statsPageGrid" aria-live="polite"></div>
+      </section>
+    </main>
+  </div>
+  <script src="/static/stats.js"></script><script src="/static/nav.js"></script>
+</body>
+</html>

--- a/app/static/stats.js
+++ b/app/static/stats.js
@@ -1,0 +1,20 @@
+const statsGrid = document.getElementById('statsPageGrid');
+const updatedAt = document.getElementById('statsUpdatedAt');
+const cards = [
+  ['Всего идей', 'total_ideas'], ['Активные идеи', 'active'], ['Закрыто по TP', 'tp'], ['Закрыто по SL', 'sl'],
+  ['WinRate', 'winrate', '%'], ['Средний RR', 'average_rr', '', 'rr'], ['Сегодня TP', 'today_tp'], ['Сегодня SL', 'today_sl'],
+];
+const safe = (value) => String(value ?? '—').replace(/[&<>"']/g, (char) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[char]));
+async function loadStats() {
+  try {
+    const response = await fetch('/api/stats', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    statsGrid.innerHTML = cards.map(([label, key, suffix = '', type = '']) => `<article class="stats-page-card stats-page-card--${key}"><span>${label}</span><strong>${type === 'rr' ? `1:${safe(data[key] ?? 0)}` : `${safe(data[key] ?? 0)}${suffix}`}</strong></article>`).join('');
+    updatedAt.textContent = `Обновлено: ${new Date(data.updated_at_utc).toLocaleString('ru-RU', { timeZone: 'UTC' })} UTC`;
+  } catch (error) {
+    statsGrid.innerHTML = '<article class="empty-state"><h3>Статистика временно недоступна</h3><p>Не удалось получить данные из /api/stats.</p></article>';
+    updatedAt.textContent = `Ошибка загрузки: ${error.message}`;
+  }
+}
+loadStats();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2133,3 +2133,44 @@ body[data-page="home"] .home-link:hover {
   box-shadow: 0 18px 42px rgba(69, 202, 255, 0.22);
   border-color: rgba(69, 202, 255, 0.7);
 }
+
+/* Statistics and archive pages */
+.stats-page-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:16px; }
+.stats-page-card { min-height:132px; display:flex; flex-direction:column; justify-content:space-between; padding:20px; border-radius:20px; border:1px solid rgba(104,143,191,.22); background:linear-gradient(155deg,rgba(15,32,56,.98),rgba(8,20,37,.92)); transition:transform .2s ease,border-color .2s ease; }
+.stats-page-card:hover { transform:translateY(-3px); border-color:rgba(76,201,240,.52); }
+.stats-page-card span { color:var(--muted); font-weight:700; }
+.stats-page-card strong { font-size:clamp(1.8rem,4vw,2.8rem); }
+.stats-page-card--tp strong,.stats-page-card--today_tp strong { color:var(--green); }
+.stats-page-card--sl strong,.stats-page-card--today_sl strong { color:var(--red); }
+.archive-link-button,.archive-filter { color:#dff7ff; text-decoration:none; font:inherit; font-weight:800; padding:11px 16px; border-radius:14px; border:1px solid rgba(76,201,240,.3); background:rgba(11,27,48,.9); cursor:pointer; }
+.archive-filters { display:flex; flex-wrap:wrap; gap:10px; margin-bottom:18px; }
+.archive-filter.is-active { color:#04111e; background:var(--accent); border-color:var(--accent); }
+.archive-table-wrap { overflow-x:auto; border:1px solid var(--line); border-radius:18px; }
+.archive-table { width:100%; min-width:850px; border-collapse:collapse; }
+.archive-table th,.archive-table td { padding:15px 14px; text-align:left; border-bottom:1px solid var(--line); }
+.archive-table th { color:var(--muted); font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; }
+.archive-table tbody tr { cursor:pointer; transition:background .18s ease; }
+.archive-table tbody tr:hover,.archive-table tbody tr:focus { outline:none; background:rgba(76,201,240,.08); }
+.archive-direction,.archive-result { display:inline-flex; padding:6px 10px; border-radius:999px; font-weight:800; font-size:.8rem; background:rgba(144,164,195,.12); }
+.archive-direction--buy,.archive-direction--long,.archive-result--tp { color:#75f0a0; background:rgba(34,197,94,.13); }
+.archive-direction--sell,.archive-direction--short,.archive-result--sl { color:#ff9090; background:rgba(239,68,68,.13); }
+.archive-result--active { color:#ffe18a; background:rgba(251,191,36,.13); }
+.archive-empty { color:var(--muted); text-align:center!important; padding:30px!important; }
+.archive-modal[hidden] { display:none; }
+.archive-modal { position:fixed; inset:0; z-index:1000; padding:24px; overflow:auto; background:rgba(1,7,15,.84); backdrop-filter:blur(10px); }
+.archive-modal__dialog { position:relative; width:min(1000px,100%); margin:20px auto; padding:28px; border:1px solid rgba(76,201,240,.28); border-radius:26px; background:#09182b; box-shadow:var(--shadow); }
+.archive-modal__close { position:absolute; top:16px; right:16px; width:42px; height:42px; border-radius:50%; border:1px solid var(--line); color:var(--text); background:#10243e; font-size:1.6rem; cursor:pointer; }
+.archive-modal__metrics { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:12px; margin:20px 0; }
+.archive-modal__metrics div { display:grid; gap:6px; padding:14px; border:1px solid var(--line); border-radius:15px; background:rgba(13,28,49,.85); }
+.archive-modal__metrics span { color:var(--muted); font-size:.78rem; }
+.archive-chart,.archive-chart-empty { margin:20px 0; padding:14px; border:1px solid var(--line); border-radius:18px; background:#06111f; }
+.archive-chart svg { display:block; width:100%; height:auto; }
+.archive-chart-empty { color:var(--muted); text-align:center; }
+.archive-modal__text p { color:#c3d2e8; line-height:1.7; white-space:pre-wrap; }
+.today-signal-summary { display:grid; grid-template-columns:auto repeat(3,minmax(110px,1fr)); gap:14px; align-items:center; }
+.today-signal-summary h2 { margin:0; }
+.today-signal-summary__metric { display:grid; gap:5px; padding:14px 16px; border:1px solid var(--line); border-radius:16px; background:rgba(12,27,47,.86); }
+.today-signal-summary__metric span { color:var(--muted); font-size:.82rem; }
+.today-signal-summary__metric strong { font-size:1.45rem; }
+@media (max-width:900px) { .stats-page-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.archive-modal__metrics{grid-template-columns:repeat(2,minmax(0,1fr))}.today-signal-summary{grid-template-columns:1fr 1fr} }
+@media (max-width:560px) { .stats-page-grid,.archive-modal__metrics,.today-signal-summary{grid-template-columns:1fr}.archive-modal{padding:8px}.archive-modal__dialog{padding:20px;margin:8px auto} }

--- a/tests/test_lifecycle_stats.py
+++ b/tests/test_lifecycle_stats.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from app.services.idea_lifecycle import build_lifecycle_stats
+
+
+def test_lifecycle_stats_adds_dashboard_fields_without_changing_legacy_total() -> None:
+    active = {"EURUSD": {"entry": 1.10, "sl": 1.09, "tp": 1.12}}
+    archive = [
+        {"symbol": "GBPUSD", "entry": 1.25, "sl": 1.24, "tp": 1.27, "result": "TP", "closed_at_utc": "2026-06-04T08:00:00+00:00"},
+        {"symbol": "USDJPY", "entry": 150.0, "sl": 151.0, "tp": 148.0, "result": "SL", "closed_at_utc": "2020-01-01T08:00:00+00:00"},
+    ]
+
+    stats = build_lifecycle_stats(active, archive)
+
+    assert stats["total"] == 2
+    assert stats["total_ideas"] == 3
+    assert stats["active"] == 1
+    assert stats["tp"] == 1
+    assert stats["sl"] == 1
+    assert stats["average_rr"] == 2.0
+    assert "today_tp" in stats
+    assert "today_sl" in stats
+
+
+def test_archive_can_optionally_include_active_without_changing_default(monkeypatch) -> None:
+    from app import main
+
+    lifecycle = {"active": [{"symbol": "EURUSD", "status": "active"}], "archive": [{"symbol": "GBPUSD", "result": "TP"}]}
+    monkeypatch.setattr(main, "apply_idea_lifecycle", lambda ideas: lifecycle)
+
+    assert main.api_archive() == {"archive": lifecycle["archive"], "total": 1}
+    assert main.api_archive(include_active=True) == {
+        "archive": lifecycle["archive"],
+        "total": 1,
+        "active": lifecycle["active"],
+        "items": [*lifecycle["active"], *lifecycle["archive"]],
+    }


### PR DESCRIPTION
### Motivation
- Добавить пользовательские страницы для просмотра метрик и истории сигналов без изменения существующей архитектуры и API-контрактов.
- Отобразить ключевые KPI (winrate, средний RR, итоги за сегодня) и предоставить удобный архив с фильтрами по инструментам и подробной карточкой идеи.
- Сохранить обратную совместимость существующих маршрутов `GET /api/stats` и `GET /api/archive` и не ломать `/ideas`/`/signals`/MT4 bridge.

### Description
- Добавлены публичные страницы `GET /stats` и `GET /archive` и соответствующие статические файлы `app/static/stats.html`, `app/static/stats.js`, `app/static/archive.html`, `app/static/archive.js` и `app/static/home-stats.js` для UI в тёмной теме.
- Расширен сервис статистики: в `app/services/idea_lifecycle.py::build_lifecycle_stats` добавлены совместимые поля `total_ideas`, `average_rr`, `today_tp`, `today_sl` и расчёт среднего планового RR на основе активных и архивных идей.
- Маршрут `GET /api/archive` расширен опциональным параметром `include_active=true`, при этом поведение по умолчанию не изменено (`archive` и `total` возвращаются как раньше).
- На главной странице и в навигации добавлен блок «Сегодня» и ссылки на «Статистика»/«Архив», плюс стили для карточек статистики, таблицы архива и модального окна в `app/static/styles.css`.

### Testing
- Запущены модульные тесты `tests/test_lifecycle_stats.py` и `tests/test_idea_lifecycle_api.py`, все тесты прошли успешно (`6 passed`).
- Проверены синтаксические проверки JS (`node --check app/static/*.js`) — пройдены, и сделаны HTTP-проверки `curl` для `/`, `/stats`, `/archive`, `/ideas`, `/api/archive` (200 OK), а также сняты скриншоты страниц через headless браузер локально.
- Выполнена базовая проверка компиляции Python для изменённых файлов (`python -m py_compile`) и проверка `git diff --check` без ошибок.
- Полный запуск `python -m pytest -q` прерывается на существующих в репо ошибках, не связанных с внесёнными изменениями (отсутствующие экспорты в `app.main` и синтаксическая ошибка в `app/services/chart_snapshot_service.py`), поэтому это не блокирует интеграцию правок, но отмечено как известное ограничение.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a210fd5625083319498f5cee3f37877)