### PR TITLE
Добавить Max Pain как подтверждающий слой prop score

### DIFF
--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -281,6 +281,19 @@ def _external_options_alignment(symbol: str, direction: str) -> dict[str, Any]:
     high_conflict = any(marker in raw for marker in ("HIGH CONFIDENCE", "STRONG", "СИЛЬН", "ВЫСОК", "AGGRESSIVE", "DOMINATE"))
     return {**confirmation, "used": True, "alignment": "conflict", "score_adjustment": -4, "implied_action": implied, "high_confidence_conflict": high_conflict, "text_ru": f"CME_OptionsFX против {direction}: options bias {bias} ожидает {implied}"}
 
+def _max_pain_context(idea: dict[str, Any], direction: str, external_options: dict[str, Any]) -> dict[str, Any]:
+    module = sys.modules.get("app.services.prop_signal_engine")
+    builder = getattr(module, "_max_pain_context", None) if module is not None else None
+    if callable(builder):
+        try:
+            context = builder(idea, direction, external_options)
+            if isinstance(context, dict):
+                return context
+        except Exception:
+            logger.exception("prop_score_recovery_max_pain_context_failed")
+    return {"available": False, "max_pain_price": None, "distance_to_max_pain_pips": None, "max_pain_alignment": "unavailable", "score_adjustment": 0, "max_pain_text_ru": "MaxPain недоступен; подтверждающий слой не блокирует сделку."}
+
+
 def _row(key: str, label: str, weight: int, score: int, text: str) -> dict[str, Any]:
     score = max(0, min(score, weight))
     return {"key": key, "label_ru": label, "weight": weight, "score": score, "status": "confirmed" if score >= weight * 0.7 else "partial" if score > 0 else "missing", "text_ru": text}
@@ -378,6 +391,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     volume_delta = _volume_delta_context(idea, symbol, timeframe, direction, candles)
     dpoc = _dpoc_context(idea, symbol, timeframe, direction, candles)
     margin_zone = _margin_zone_context(idea, symbol, timeframe, candles)
+    max_pain = _max_pain_context(idea, direction, external_options)
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     has_structure = any(_text_has_data(idea.get(k)) for k in ("reason_ru", "summary_ru", "market_structure", "htf_context", "entry_source"))
@@ -385,7 +399,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     has_volume = any(_text_has_data(idea.get(k)) for k in ("volume", "volume_ru", "data_status", "provider", "volume_delta")) or bool(volume_delta.get("available"))
     has_options = any(_text_has_data(idea.get(k)) for k in ("options_ru", "options_analysis", "cme"))
     options_score = 4 if has_options or external_options.get("alignment") == "aligned" else 0 if external_options.get("alignment") == "conflict" else 1
-    options_text = str(external_options.get("text_ru") or ("опционный слой есть" if has_options else "опционный слой не обязателен"))
+    options_text = " | ".join(part for part in (str(external_options.get("text_ru") or ("опционный слой есть" if has_options else "опционный слой не обязателен")), str(max_pain.get("max_pain_text_ru") or "")) if part)
     rows = [
         _row("direction", "Направление BUY/SELL", 18, 18 if direction in {"BUY", "SELL"} else 0, direction),
         _row("levels", "Entry / SL / TP", 18, 18 if valid else 0, f"уровни валидны ({level_source})" if valid else "нет валидных entry/sl/tp"),
@@ -398,8 +412,8 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         _row("sentiment", "Sentiment / новости", 5, int(sentiment.get("score") or 0), str(sentiment.get("text_ru") or "нет sentiment")),
     ]
     base_score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0)))
-    allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict and not external_options_high_conflict)
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0)))
+    allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict)
     grade = "A" if score >= 70 else "B" if score >= 55 else "C" if score >= 40 else "D"
     mode = "prop_entry" if allowed and score >= 70 else "watchlist" if allowed else "research_only" if score >= 40 else "no_trade"
     blockers = []
@@ -411,12 +425,11 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         blockers.append(f"Слабый R/R {rr:.2f}")
     if sentiment_conflict:
         blockers.append(str(sentiment.get("text_ru")))
-    if external_options_high_conflict:
-        blockers.append(str(external_options.get("text_ru")))
     if volume_delta.get("delta_divergence"):
         blockers.append("Delta divergence: цена и CumDelta расходятся")
     score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "volume_delta": volume_delta, "volume_delta_source": volume_delta.get("source"), "delta_divergence": bool(volume_delta.get("delta_divergence")), "dpoc": dpoc, "dpoc_price": dpoc.get("dpoc_price"), "distance_to_dpoc_pips": dpoc.get("distance_to_dpoc_pips")}
-    score_payload.update({"margin_lower": margin_zone.get("margin_lower"), "margin_upper": margin_zone.get("margin_upper"), "margin_zone_lower": margin_zone.get("margin_zone_lower"), "margin_zone_upper": margin_zone.get("margin_zone_upper"), "margin_source": margin_zone.get("margin_source"), "margin_zone_confluence": margin_zone})
+    score_payload.update({"margin_lower": margin_zone.get("margin_lower"), "margin_upper": margin_zone.get("margin_upper"), "margin_zone_lower": margin_zone.get("margin_zone_lower"), "margin_zone_upper": margin_zone.get("margin_zone_upper"), "margin_source": margin_zone.get("margin_source"), "margin_zone_confluence": margin_zone, "max_pain_context": max_pain, "max_pain_price": max_pain.get("max_pain_price"), "distance_to_max_pain_pips": max_pain.get("distance_to_max_pain_pips"), "max_pain_alignment": max_pain.get("max_pain_alignment"), "max_pain_text_ru": max_pain.get("max_pain_text_ru")})
+    score_payload["external_options_note"] = str(external_options.get("text_ru") or "") if external_options_high_conflict else ""
     advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "external_options_filter": external_options, "level_source": level_source}
     return score_payload, advisor
 
@@ -488,6 +501,11 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["margin_zone_upper"] = score.get("margin_zone_upper")
                     enriched["margin_source"] = score.get("margin_source")
                     enriched["margin_zone_confluence"] = score.get("margin_zone_confluence")
+                    enriched["max_pain_context"] = score.get("max_pain_context")
+                    enriched["max_pain_price"] = score.get("max_pain_price")
+                    enriched["distance_to_max_pain_pips"] = score.get("distance_to_max_pain_pips")
+                    enriched["max_pain_alignment"] = score.get("max_pain_alignment")
+                    enriched["max_pain_text_ru"] = score.get("max_pain_text_ru")
                     market_structure = dict(enriched.get("market_structure") or {})
                     market_structure["dpoc_price"] = score.get("dpoc_price")
                     market_structure["distance_to_dpoc_pips"] = score.get("distance_to_dpoc_pips")
@@ -495,7 +513,7 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["external_options_ru"] = external_options_filter.get("text_ru") or "CME_OptionsFX: нет данных"
                     enriched["external_options_bias"] = external_options_signal.get("option_bias") or external_options_filter.get("option_bias") or "neutral"
                     enriched["external_options_key_strikes"] = external_options_signal.get("key_strikes") or []
-                    enriched["external_options_max_pain"] = external_options_signal.get("max_pain")
+                    enriched["external_options_max_pain"] = external_options_signal.get("max_pain") or score.get("max_pain_price")
                     return enriched
 
                 module.build_prop_signal_score = patched_build_prop_signal_score

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -274,6 +274,124 @@ def _external_options_alignment(idea: dict[str, Any], direction: str) -> dict[st
         "text_ru": f"CME_OptionsFX против {direction}: options bias {bias} ожидает {implied}",
     }
 
+def _nested_float(payload: dict[str, Any] | None, *paths: str) -> tuple[float | None, str | None]:
+    if not isinstance(payload, dict):
+        return None, None
+    for path in paths:
+        current: Any = payload
+        for part in path.split("."):
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = current.get(part)
+        value = _to_float(current)
+        if value is not None:
+            return value, path
+    return None, None
+
+
+def _max_pain_context(
+    idea: dict[str, Any],
+    direction: str,
+    external_options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    max_pain_price, source = _nested_float(
+        idea,
+        "external_options_filter.signal.max_pain",
+        "external_options_filter.max_pain",
+        "external_options_max_pain",
+        "options_analysis.maxPain",
+        "options_analysis.max_pain",
+        "market_context.optionsAnalysis.maxPain",
+    )
+    if max_pain_price is None:
+        max_pain_price, external_source = _nested_float(external_options, "signal.max_pain", "max_pain")
+        if external_source:
+            source = f"external_options_filter.{external_source}"
+
+    candles = _candles(idea)
+    current_price, current_price_source = _nested_float(idea, "entry", "entry_price", "current_price")
+    if current_price is None and candles:
+        current_price = _to_float(candles[-1].get("close"))
+        if current_price is not None:
+            current_price_source = "candles[-1].close"
+    entry_price = _to_float(idea.get("entry") if idea.get("entry") is not None else idea.get("entry_price"))
+    if entry_price is None:
+        entry_price = current_price
+    tp_price = _to_float(idea.get("tp") if idea.get("tp") is not None else idea.get("take_profit") or idea.get("target"))
+
+    unavailable = {
+        "available": False,
+        "source": source or "unavailable",
+        "current_price": current_price,
+        "current_price_source": current_price_source or "unavailable",
+        "max_pain_price": max_pain_price,
+        "distance_to_max_pain_pips": None,
+        "max_pain_side": "unknown",
+        "max_pain_magnet_risk": False,
+        "max_pain_alignment": "unavailable",
+        "score_adjustment": 0,
+        "max_pain_text_ru": "MaxPain недоступен; подтверждающий слой не блокирует сделку.",
+    }
+    if max_pain_price is None or current_price is None:
+        if max_pain_price is not None:
+            unavailable["source"] = source or "unknown"
+            unavailable["max_pain_text_ru"] = "MaxPain доступен, но текущая цена недоступна; слой не влияет на score."
+        return unavailable
+
+    pip = _pip_size(symbol, current_price)
+    distance_pips = (max_pain_price - current_price) / pip
+    abs_distance_pips = abs(distance_pips)
+    near_threshold_pips = 10.0
+    strong_threshold_pips = 30.0
+    near_entry = entry_price is not None and abs(max_pain_price - entry_price) / pip <= near_threshold_pips
+    near_tp = tp_price is not None and abs(max_pain_price - tp_price) / pip <= near_threshold_pips
+    side = "near" if abs_distance_pips <= near_threshold_pips else "above" if distance_pips > 0 else "below"
+    alignment = "neutral"
+    score_adjustment = 0
+    magnet_risk = False
+
+    if near_entry or near_tp:
+        alignment, score_adjustment, magnet_risk = "near", 1, True
+        near_label = "entry и TP" if near_entry and near_tp else "entry" if near_entry else "TP"
+        explanation = f"{near_label} близко к MaxPain: возможен пиннинг"
+    elif direction == "BUY" and current_price < max_pain_price and entry_price is not None and entry_price < max_pain_price:
+        alignment, score_adjustment = "aligned", 3
+        explanation = "магнит вверх подтверждает BUY"
+    elif direction == "SELL" and current_price > max_pain_price and entry_price is not None and entry_price > max_pain_price:
+        alignment, score_adjustment = "aligned", 3
+        explanation = "магнит вниз подтверждает SELL"
+    elif direction == "BUY" and distance_pips < -strong_threshold_pips:
+        alignment, score_adjustment, magnet_risk = "conflict", -2, True
+        explanation = "цена сильно выше MaxPain: риск возврата вниз"
+    elif direction == "SELL" and distance_pips > strong_threshold_pips:
+        alignment, score_adjustment, magnet_risk = "conflict", -2, True
+        explanation = "цена сильно ниже MaxPain: риск возврата вверх"
+    else:
+        explanation = "MaxPain доступен без явного подтверждения направления"
+
+    text = (
+        f"MaxPain: {max_pain_price:.{_precision(symbol)}f}, distance {distance_pips:+.1f} пипс, "
+        f"alignment {alignment}; {explanation}."
+    )
+    return {
+        "available": True,
+        "source": source or "unknown",
+        "current_price": current_price,
+        "current_price_source": current_price_source or "unknown",
+        "max_pain_price": max_pain_price,
+        "distance_to_max_pain_pips": round(distance_pips, 1),
+        "max_pain_side": side,
+        "max_pain_magnet_risk": magnet_risk,
+        "max_pain_alignment": alignment,
+        "near_entry": near_entry,
+        "near_tp": near_tp,
+        "score_adjustment": score_adjustment,
+        "max_pain_text_ru": text,
+    }
+
+
 def _pip_size(symbol: str, entry: float | None = None) -> float:
     symbol = (symbol or "").upper()
     if "XAU" in symbol or "GOLD" in symbol:
@@ -876,13 +994,15 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
 
     external_options = _external_options_alignment(idea, direction)
     external_text = str(external_options.get("text_ru") or "")
+    max_pain = _max_pain_context(idea, direction, external_options)
+    max_pain_text = str(max_pain.get("max_pain_text_ru") or "")
     options_text = _first_text(idea, "options_ru", "options_analysis.summary", "options_analysis.bias")
     options_score = weights["options"] if options_text else 1
     if external_options.get("alignment") == "aligned":
         options_score = weights["options"]
     elif external_options.get("alignment") == "conflict":
         options_score = 0
-    rows.append(_row("options", options_score, weights["options"], " | ".join(part for part in (options_text, external_text) if part) or "опционный слой не обязателен для базовой идеи"))
+    rows.append(_row("options", options_score, weights["options"], " | ".join(part for part in (options_text, external_text, max_pain_text) if part) or "опционный слой не обязателен для базовой идеи"))
 
     sentiment = _sentiment_alignment(idea, direction)
     rows.append(_row("sentiment", int(sentiment.get("score") or 0), weights["sentiment"], str(sentiment.get("text_ru") or "нет sentiment")))
@@ -902,9 +1022,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     volume_delta = _volume_delta_context(safe_idea, direction)
     dpoc = _dpoc_context(safe_idea, direction)
     margin_zone = _margin_zone_context(safe_idea)
+    max_pain = _max_pain_context(safe_idea, direction, external_options)
     volume_delta_source = volume_delta.get("source")
     hft_signal = volume_delta.get("hft_signal") or _hft_signal_context(safe_idea).get("hft_signal")
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0)))
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0)))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     external_options_note = ""
@@ -1000,6 +1121,11 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "margin_zone_upper": margin_zone.get("margin_zone_upper"),
         "margin_source": margin_zone.get("margin_source"),
         "margin_zone_confluence": margin_zone,
+        "max_pain_context": max_pain,
+        "max_pain_price": max_pain.get("max_pain_price"),
+        "distance_to_max_pain_pips": max_pain.get("distance_to_max_pain_pips"),
+        "max_pain_alignment": max_pain.get("max_pain_alignment"),
+        "max_pain_text_ru": max_pain.get("max_pain_text_ru"),
         "real_candle_diagnostics": candle_diag,
         "volume_delta_source": volume_delta_source,
         "hft_signal": hft_signal,
@@ -1107,7 +1233,7 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
     enriched["external_options_ru"] = external_options_filter.get("text_ru") or "CME_OptionsFX: нет данных"
     enriched["external_options_bias"] = external_options_signal.get("option_bias") or external_options_filter.get("option_bias") or "neutral"
     enriched["external_options_key_strikes"] = external_options_signal.get("key_strikes") or []
-    enriched["external_options_max_pain"] = external_options_signal.get("max_pain")
+    enriched["external_options_max_pain"] = external_options_signal.get("max_pain") or score.get("max_pain_price")
     enriched.update(
         {
             "prop_signal_score": score,
@@ -1143,6 +1269,11 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "margin_zone_upper": score.get("margin_zone_upper"),
             "margin_source": score.get("margin_source"),
             "margin_zone_confluence": score.get("margin_zone_confluence"),
+            "max_pain_context": score.get("max_pain_context"),
+            "max_pain_price": score.get("max_pain_price"),
+            "distance_to_max_pain_pips": score.get("distance_to_max_pain_pips"),
+            "max_pain_alignment": score.get("max_pain_alignment"),
+            "max_pain_text_ru": score.get("max_pain_text_ru"),
         }
     )
     market_structure = dict(enriched.get("market_structure") or {})

--- a/tests/signals/test_prop_max_pain.py
+++ b/tests/signals/test_prop_max_pain.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import prop_signal_engine
+
+
+def _idea(direction: str = "BUY", entry: float = 1.1000) -> dict:
+    close = entry + 0.0500  # Entry must remain the preferred current-price source.
+    candles = [
+        {
+            "time": index + 1,
+            "open": close - 0.0002,
+            "high": close + 0.0004,
+            "low": close - 0.0004,
+            "close": close,
+        }
+        for index in range(30)
+    ]
+    if direction == "BUY":
+        sl, tp = entry - 0.0020, entry + 0.0040
+    else:
+        sl, tp = entry + 0.0020, entry - 0.0040
+    return {
+        "symbol": "MPTEST",
+        "action": direction,
+        "entry": entry,
+        "current_price": entry + 0.0200,
+        "sl": sl,
+        "tp": tp,
+        "candles": candles,
+    }
+
+
+@pytest.fixture(autouse=True)
+def unavailable_external_options(monkeypatch):
+    monkeypatch.setattr(
+        prop_signal_engine,
+        "get_cme_optionsfx_confirmation",
+        lambda symbol: {"source": "CME_OptionsFX", "available": False, "used": False, "signal": None},
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_source"),
+    [
+        ({"external_options_filter": {"signal": {"max_pain": 1.1100}}}, "external_options_filter.signal.max_pain"),
+        ({"external_options_filter": {"max_pain": 1.1100}}, "external_options_filter.max_pain"),
+        ({"external_options_max_pain": 1.1100}, "external_options_max_pain"),
+        ({"options_analysis": {"maxPain": 1.1100}}, "options_analysis.maxPain"),
+        ({"options_analysis": {"max_pain": 1.1100}}, "options_analysis.max_pain"),
+        ({"market_context": {"optionsAnalysis": {"maxPain": 1.1100}}}, "market_context.optionsAnalysis.maxPain"),
+    ],
+)
+def test_max_pain_is_extracted_from_supported_sources(payload, expected_source):
+    score = prop_signal_engine.build_prop_signal_score({**_idea(), **payload})
+    context = score["max_pain_context"]
+
+    assert context["available"] is True
+    assert context["source"] == expected_source
+    assert context["current_price"] == 1.1000
+    assert context["current_price_source"] == "entry"
+    assert context["max_pain_price"] == 1.1100
+    assert context["distance_to_max_pain_pips"] == 100.0
+    assert context["max_pain_side"] == "above"
+
+
+def test_buy_and_sell_max_pain_magnet_adds_confirmation_score():
+    buy_base = prop_signal_engine.build_prop_signal_score(_idea("BUY"))
+    buy = prop_signal_engine.build_prop_signal_score({**_idea("BUY"), "external_options_max_pain": 1.1100})
+    sell_base = prop_signal_engine.build_prop_signal_score(_idea("SELL"))
+    sell = prop_signal_engine.build_prop_signal_score({**_idea("SELL"), "external_options_max_pain": 1.0900})
+
+    assert buy["max_pain_context"]["score_adjustment"] == 3
+    assert buy["max_pain_alignment"] == "aligned"
+    assert buy["score"] == buy_base["score"] + 3
+    assert sell["max_pain_context"]["score_adjustment"] == 3
+    assert sell["max_pain_alignment"] == "aligned"
+    assert sell["score"] == sell_base["score"] + 3
+
+
+def test_strong_adverse_max_pain_magnet_reduces_score_without_hard_block():
+    base = prop_signal_engine.build_prop_signal_score(_idea("BUY"))
+    score = prop_signal_engine.build_prop_signal_score({**_idea("BUY"), "external_options_max_pain": 1.0900})
+
+    assert score["max_pain_context"]["score_adjustment"] == -2
+    assert score["max_pain_context"]["max_pain_magnet_risk"] is True
+    assert score["max_pain_alignment"] == "conflict"
+    assert score["score"] == base["score"] - 2
+    assert not any("MaxPain" in blocker for blocker in score["blockers"])
+
+
+def test_near_max_pain_is_warning_and_is_exposed_in_options_criteria_and_enriched_idea():
+    idea = {**_idea("BUY"), "options_analysis": {"maxPain": 1.1005}}
+    score = prop_signal_engine.build_prop_signal_score(idea)
+    enriched = prop_signal_engine.enrich_idea_with_prop_score(idea)
+    options_row = next(row for row in score["criteria"] if row["key"] == "options")
+
+    assert score["max_pain_context"]["score_adjustment"] == 1
+    assert score["max_pain_context"]["near_entry"] is True
+    assert score["max_pain_alignment"] == "near"
+    assert "MaxPain: 1.10050" in options_row["text_ru"]
+    assert "distance +5.0" in options_row["text_ru"]
+    assert "alignment near" in options_row["text_ru"]
+    assert enriched["max_pain_context"] == enriched["prop_signal_score"]["max_pain_context"]
+    assert enriched["max_pain_price"] == 1.1005
+    assert enriched["distance_to_max_pain_pips"] == 5.0
+    assert enriched["max_pain_alignment"] == "near"
+    assert enriched["max_pain_text_ru"]
+    assert enriched["external_options_max_pain"] == 1.1005
+
+
+def test_missing_max_pain_has_zero_adjustment_and_never_blocks():
+    score = prop_signal_engine.build_prop_signal_score(_idea())
+
+    assert score["max_pain_context"]["available"] is False
+    assert score["max_pain_context"]["score_adjustment"] == 0
+    assert score["max_pain_price"] is None
+    assert not any("MaxPain" in blocker for blocker in score["blockers"])


### PR DESCRIPTION
### Motivation
- Сделать так, чтобы Max Pain (CME/options) корректно подтверждал/ослаблял prop-скор, не являясь жестким блоком; учитывать данные из всех поддерживаемых источников и не ломать существующие слои DPOC/MarginZones/CME_OptionsFX/Telegram.

### Description
- Добавлен новый контекст `max_pain_context` в `app/services/prop_signal_engine.py` с функциями `_nested_float` и `_max_pain_context`, который извлекает Max Pain из: `external_options_filter.signal.max_pain`, `external_options_filter.max_pain`, `external_options_max_pain`, `options_analysis.maxPain/max_pain`, `market_context.optionsAnalysis.maxPain` и определяет `current_price` с приоритетом `entry → entry_price → current_price → last candle close`.
- Рассчитываются `max_pain_price`, `distance_to_max_pain_pips`, `max_pain_side` (`above/ below/ near`), `max_pain_magnet_risk` и `max_pain_alignment`, а также возвращается человекочитаемый `max_pain_text_ru`.
- Интеграция скоринга: добавлена мягкая корректировка в итоговый `score` (`+3` подтверждение-марГнит, `-2` при сильном adverse, `+1` при близости entry/TP) и включение `max_pain` в критерий `options` (текст критерия теперь содержит MaxPain-инфо). Изменены места: `build_prop_signal_score`, `_criterion_rows`, `enrich_idea_with_prop_score` (поля `max_pain_context`, `max_pain_price`, `distance_to_max_pain_pips`, `max_pain_alignment`, `max_pain_text_ru`, и fallback для `external_options_max_pain`).
- Обновлён runtime recovery patch в `app/core/prop_score_recovery_patch.py`, чтобы он вызывал/сохранял `max_pain_context` совместимо с новым движком и не переводил CME/Telegram conflict в hard-block.
- Добавлен набор unit-тестов `tests/signals/test_prop_max_pain.py` покрывающий источники MaxPain, подтверждение BUY/SELL, adverse/near сценарии и отсутствие данных.

### Testing
- Запущены таргетные тесты: `python -m pytest -q tests/signals/test_prop_max_pain.py tests/signals/test_cme_optionsfx_adapter.py tests/test_mt4_dpoc.py tests/test_mt4_margin_zones.py tests/test_volume_delta_priority.py` — все тесты в этой выборке прошли: `27 passed`.
- Компиляция изменённых модулей выполнена: `python -m py_compile app/services/prop_signal_engine.py app/core/prop_score_recovery_patch.py` — успешно.
- `git diff --check` не выявил проблем.
- Полный запуск `python -m pytest -q` прерывался на уже существующих проблемах в репозитории (не связанные с этим PR): отсутствующие экспорты в `app.main` и синтаксическая ошибка `from **future** import annotations` в `app/services/chart_snapshot_service.py`; эти ошибки были замечены при полной прогонке и не вызваны изменениями, внесёнными в данном PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b000fdc08331a1519b13ac7edbba)