### PR TITLE
Добавить подтверждение по маржинальным зонам MT4

### DIFF
--- a/AI_Ideas_Trader.mq4
+++ b/AI_Ideas_Trader.mq4
@@ -24,6 +24,9 @@ input bool UseBufferedSL = true;
 input bool SkipIfTpTooClose = true;
 input bool AllowFallbackProviderTrading = false;
 input string MarkupUrlTemplate = "https://your-domain.onrender.com/api/mt4/markup/{symbol}?tf=M15";
+input bool PublishMarginZones = true;
+input string MarginZonesUrlTemplate = "https://your-domain.onrender.com/api/mt4/margin-zones?symbol={symbol}&tf={tf}&margin_lower={lower}&margin_upper={upper}&current_price={price}&margin_source=Future_Volume_v5.00&margin_object={object}";
+input string MarginZonesTimeframe = "M15";
 
 datetime g_lastPoll = 0;
 datetime g_lastMarkupPoll = 0;
@@ -38,8 +41,60 @@ void OnTick()
 {
    if(TimeCurrent() - g_lastPoll < RefreshSeconds) return;
    g_lastPoll = TimeCurrent();
+   PublishNearestMarginZone();
    PollSignalsAndTrade();
 }
+
+void PublishNearestMarginZone()
+{
+   if(!PublishMarginZones) return;
+
+   string names[4] = {"MZ_1/1", "MZ_1/2", "MZ_1/4", "MZ_3/4"};
+   double marketPrice = (Bid + Ask) / 2.0;
+   double selectedLower = 0.0, selectedUpper = 0.0, selectedDistance = 1.0e100;
+   string selectedName = "";
+
+   for(int i = 0; i < ArraySize(names); i++)
+   {
+      string name = names[i];
+      if(ObjectFind(0, name) < 0) continue;
+
+      double price1 = ObjectGetDouble(0, name, OBJPROP_PRICE1);
+      double price2 = ObjectGetDouble(0, name, OBJPROP_PRICE2);
+      if(price1 <= 0 || price2 <= 0) continue;
+
+      double lower = MathMin(price1, price2);
+      double upper = MathMax(price1, price2);
+      double distance = 0.0;
+      if(marketPrice < lower) distance = lower - marketPrice;
+      else if(marketPrice > upper) distance = marketPrice - upper;
+
+      if(selectedName == "" || distance < selectedDistance)
+      {
+         selectedName = name;
+         selectedLower = lower;
+         selectedUpper = upper;
+         selectedDistance = distance;
+      }
+   }
+
+   if(selectedName == "") return;
+
+   string encodedName = selectedName;
+   StringReplace(encodedName, "/", "%2F");
+   string url = MarginZonesUrlTemplate;
+   StringReplace(url, "{symbol}", Symbol());
+   StringReplace(url, "{tf}", MarginZonesTimeframe);
+   StringReplace(url, "{lower}", DoubleToString(selectedLower, Digits));
+   StringReplace(url, "{upper}", DoubleToString(selectedUpper, Digits));
+   StringReplace(url, "{price}", DoubleToString(marketPrice, Digits));
+   StringReplace(url, "{object}", encodedName);
+
+   string response = "";
+   if(HttpGet(url, response))
+      Print("Margin zone published: ", selectedName, " [", DoubleToString(selectedLower, Digits), ", ", DoubleToString(selectedUpper, Digits), "]");
+}
+
 
 void PollSignalsAndTrade()
 {

--- a/README.md
+++ b/README.md
@@ -425,3 +425,9 @@ curl http://127.0.0.1:8000/ideas/market
 Существующий MT4 bridge принимает текущий дневной DPOC без отдельного маршрута: передайте `dpoc_price` (также поддерживаются aliases `dpoc`, `daily_dpoc`, `daily_dpoc_price`) в `GET /api/mt4/ingest-get`, `POST /api/mt4/volume-clusters` или legacy `POST /ideas/market` вместе с FutureVolume payload.
 
 Backend сохраняет реальный уровень индикатора как `dpoc_price`, рассчитывает подписанное поле `distance_to_dpoc_pips` от текущей цены и публикует оба поля на верхнем уровне идеи и внутри `market_structure`. DPOC используется только как подтверждение: BUY получает +3 score при цене выше DPOC, SELL — +3 при цене ниже DPOC. Отсутствующий или неподтверждающий DPOC не блокирует сделку.
+
+### Маржинальные зоны Future_Volume_v5.00
+
+MT4 bridge `AI_Ideas_Trader.mq4` проверяет объекты `MZ_1/1`, `MZ_1/2`, `MZ_1/4`, `MZ_3/4`, читает для каждого `OBJPROP_PRICE1` и `OBJPROP_PRICE2`, выбирает содержащую текущую цену или ближайшую зону и отправляет её через `GET /api/mt4/margin-zones`.
+
+Backend сохраняет реальные поля `margin_lower`, `margin_upper`, `inside_margin_zone`, `margin_source=Future_Volume_v5.00` в MT4-контексте и публикует их в `/api/ideas`. Критерий `Margin Zones / Volume Profile` является только подтверждающим: нахождение цены внутри зоны добавляет `+3` к score, отсутствие зоны или цена вне зоны не создают hard-block.

--- a/app/core/legacy_ideas_market_post_patch.py
+++ b/app/core/legacy_ideas_market_post_patch.py
@@ -36,6 +36,10 @@ VOLUME_KEYS = {
     "dpoc_price",
     "daily_dpoc",
     "daily_dpoc_price",
+    "margin_lower",
+    "margin_upper",
+    "margin_source",
+    "margin_object",
 }
 
 OPTION_KEYS = {

--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -6,7 +6,7 @@ import threading
 import time
 from typing import Any
 
-from app.services.mt4_volume_cluster_bridge import build_dpoc_context, get_latest_volume_cluster
+from app.services.mt4_volume_cluster_bridge import build_dpoc_context, build_margin_zone_context, get_latest_volume_cluster
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +351,21 @@ def _dpoc_context(idea: dict[str, Any], symbol: str, timeframe: str, direction: 
     return {"available": False, "source": "unavailable", "dpoc_price": None, "distance_to_dpoc_pips": None, "aligned": False, "score_adjustment": 0}
 
 
+def _margin_zone_context(idea: dict[str, Any], symbol: str, timeframe: str, candles: list[dict[str, Any]]) -> dict[str, Any]:
+    current_price = _num(idea.get("current_price") or idea.get("price"))
+    if current_price is None and candles:
+        current_price = _num(candles[-1].get("close"))
+    if current_price is None:
+        current_price = _num(idea.get("entry") or idea.get("entry_price"))
+    sources = [idea, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None, get_latest_volume_cluster(symbol, timeframe)]
+    for payload in sources:
+        context = build_margin_zone_context(payload, current_price)
+        if context.get("available"):
+            inside = bool(context.get("inside_margin_zone"))
+            return {**context, "score_adjustment": 3 if inside else 0, "text_ru": "Цена внутри маржинальной зоны Future_Volume_v5.00; подтверждение +3." if inside else "Цена вне маржинальной зоны; hard-block не применяется."}
+    return {"available": False, "margin_lower": None, "margin_upper": None, "inside_margin_zone": False, "margin_source": "unavailable", "score_adjustment": 0, "text_ru": "Margin Zones недоступны; сделки не блокируются."}
+
+
 def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     candles = _candles(idea)
@@ -364,6 +379,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     timeframe = str(idea.get("timeframe") or idea.get("tf") or "")
     volume_delta = _volume_delta_context(idea, symbol, timeframe, direction, candles)
     dpoc = _dpoc_context(idea, symbol, timeframe, direction, candles)
+    margin_zone = _margin_zone_context(idea, symbol, timeframe, candles)
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     has_structure = any(_text_has_data(idea.get(k)) for k in ("reason_ru", "summary_ru", "market_structure", "htf_context", "entry_source"))
@@ -380,11 +396,13 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         _row("structure", "Структура / импульс", 12, 12 if has_structure else 6 if direction in {"BUY", "SELL"} else 0, "структура/импульс есть" if has_structure else "технический импульс без расширенной структуры"),
         _row("liquidity", "Ликвидность / POI", 8, 8 if has_liquidity else 2 if direction in {"BUY", "SELL"} else 0, "liquidity/POI есть" if has_liquidity else "нет отдельного liquidity слоя"),
         _row("volume", "Volume / tick volume", 5, 5 if volume_delta.get("confirmed") else 3 if volume_delta.get("available") else 5 if has_volume else 1 if candles else 0, str(volume_delta.get("text_ru") or ("volume/tick proxy есть" if has_volume else "только OHLC/tick proxy"))),
+        _row("margin_zones", "Margin Zones / Volume Profile", 3, 3 if margin_zone.get("inside_margin_zone") else 0, str(margin_zone.get("text_ru"))),
         _row("options", "Опционы / CME", 4, options_score, options_text),
         _row("sentiment", "Sentiment / новости", 5, int(sentiment.get("score") or 0), str(sentiment.get("text_ru") or "нет sentiment")),
     ]
-    base_score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0)))
+    base_rows = [row for row in rows if row.get("key") != "margin_zones"]
+    base_score = round(sum(r["score"] for r in base_rows) / max(sum(r["weight"] for r in base_rows), 1) * 100)
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0)))
     allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict and not external_options_high_conflict)
     grade = "A" if score >= 70 else "B" if score >= 55 else "C" if score >= 40 else "D"
     mode = "prop_entry" if allowed and score >= 70 else "watchlist" if allowed else "research_only" if score >= 40 else "no_trade"
@@ -401,7 +419,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         blockers.append(str(external_options.get("text_ru")))
     if volume_delta.get("delta_divergence"):
         blockers.append("Delta divergence: цена и CumDelta расходятся")
-    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "volume_delta": volume_delta, "volume_delta_source": volume_delta.get("source"), "delta_divergence": bool(volume_delta.get("delta_divergence")), "dpoc": dpoc, "dpoc_price": dpoc.get("dpoc_price"), "distance_to_dpoc_pips": dpoc.get("distance_to_dpoc_pips")}
+    score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "volume_delta": volume_delta, "volume_delta_source": volume_delta.get("source"), "delta_divergence": bool(volume_delta.get("delta_divergence")), "dpoc": dpoc, "dpoc_price": dpoc.get("dpoc_price"), "distance_to_dpoc_pips": dpoc.get("distance_to_dpoc_pips"), "margin_zone": margin_zone, "margin_zone_confluence": margin_zone, "margin_lower": margin_zone.get("margin_lower"), "margin_upper": margin_zone.get("margin_upper"), "inside_margin_zone": bool(margin_zone.get("inside_margin_zone")), "margin_source": margin_zone.get("margin_source")}
     advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "external_options_filter": external_options, "level_source": level_source}
     return score_payload, advisor
 
@@ -467,9 +485,18 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["dpoc"] = score.get("dpoc")
                     enriched["dpoc_price"] = score.get("dpoc_price")
                     enriched["distance_to_dpoc_pips"] = score.get("distance_to_dpoc_pips")
+                    enriched["margin_zone"] = score.get("margin_zone")
+                    enriched["margin_lower"] = score.get("margin_lower")
+                    enriched["margin_upper"] = score.get("margin_upper")
+                    enriched["inside_margin_zone"] = score.get("inside_margin_zone")
+                    enriched["margin_source"] = score.get("margin_source")
                     market_structure = dict(enriched.get("market_structure") or {})
                     market_structure["dpoc_price"] = score.get("dpoc_price")
                     market_structure["distance_to_dpoc_pips"] = score.get("distance_to_dpoc_pips")
+                    market_structure["margin_lower"] = score.get("margin_lower")
+                    market_structure["margin_upper"] = score.get("margin_upper")
+                    market_structure["inside_margin_zone"] = score.get("inside_margin_zone")
+                    market_structure["margin_source"] = score.get("margin_source")
                     enriched["market_structure"] = market_structure
                     enriched["external_options_ru"] = external_options_filter.get("text_ru") or "CME_OptionsFX: нет данных"
                     enriched["external_options_bias"] = external_options_signal.get("option_bias") or external_options_filter.get("option_bias") or "neutral"

--- a/app/main.py
+++ b/app/main.py
@@ -1058,6 +1058,10 @@ def api_mt4_ingest_get(
     future_delta: float = 0.0,
     dpoc_price: float = 0.0,
     dpoc: float = 0.0,
+    margin_lower: float = 0.0,
+    margin_upper: float = 0.0,
+    margin_source: str = "Future_Volume_v5.00",
+    margin_object: str = "",
     hft_signal: str = "",
     bars: str = "",
     broker: str = "",
@@ -1118,6 +1122,10 @@ def api_mt4_ingest_get(
         "cumulative_delta": cumulative_delta,
         "future_delta": future_delta,
         "dpoc_price": dpoc_price or dpoc or None,
+        "margin_lower": margin_lower or None,
+        "margin_upper": margin_upper or None,
+        "margin_source": margin_source if margin_lower > 0 and margin_upper > 0 else None,
+        "margin_object": margin_object,
         "hft_signal": hft_signal,
         "bars": bars,
         "broker": broker,
@@ -1219,6 +1227,46 @@ def _handle_mt4_push_candles_payload(payload: dict[str, Any]):
         return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
 
 
+
+
+@app.get("/api/mt4/margin-zones")
+def api_mt4_margin_zones(
+    symbol: str = "",
+    broker_symbol: str = "",
+    tf: str = "M15",
+    margin_lower: float = 0.0,
+    margin_upper: float = 0.0,
+    current_price: float = 0.0,
+    margin_source: str = "Future_Volume_v5.00",
+    margin_object: str = "",
+    token: str = "",
+):
+    if MT4_BRIDGE_TOKEN and token.strip() != MT4_BRIDGE_TOKEN:
+        return JSONResponse(status_code=401, content={"ok": False, "error": "unauthorized"})
+    normalized_symbol = normalize_mt4_symbol(symbol or broker_symbol)
+    if not normalized_symbol:
+        return JSONResponse(status_code=400, content={"ok": False, "error": "symbol_required"})
+    if margin_lower <= 0 or margin_upper <= 0:
+        return JSONResponse(status_code=400, content={"ok": False, "error": "valid_margin_bounds_required"})
+    saved = save_volume_cluster_payload({
+        "symbol": normalized_symbol,
+        "timeframe": str(tf or "M15").upper(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "current_price": current_price or None,
+        "margin_lower": min(margin_lower, margin_upper),
+        "margin_upper": max(margin_lower, margin_upper),
+        "margin_source": margin_source or "Future_Volume_v5.00",
+        "margin_object": margin_object,
+    })
+    return {
+        "ok": True,
+        "symbol": saved.get("symbol"),
+        "timeframe": saved.get("timeframe"),
+        "margin_lower": saved.get("margin_lower"),
+        "margin_upper": saved.get("margin_upper"),
+        "inside_margin_zone": saved.get("inside_margin_zone"),
+        "margin_source": saved.get("margin_source"),
+    }
 
 
 @app.post("/api/mt4/volume-clusters")

--- a/app/services/mt4_volume_cluster_bridge.py
+++ b/app/services/mt4_volume_cluster_bridge.py
@@ -74,6 +74,35 @@ def extract_dpoc_price(payload: dict[str, Any] | None) -> float | None:
     return None
 
 
+def extract_margin_zone(payload: dict[str, Any] | None) -> tuple[float | None, float | None]:
+    """Read a normalized Future_Volume_v5.00 margin zone from an MT4 payload."""
+    if not isinstance(payload, dict):
+        return None, None
+    lower = _nested_float(payload, "margin_lower", "margin_zone.lower", "margin_zone.margin_lower")
+    upper = _nested_float(payload, "margin_upper", "margin_zone.upper", "margin_zone.margin_upper")
+    if lower is None or upper is None or lower <= 0 or upper <= 0:
+        return None, None
+    return (min(lower, upper), max(lower, upper))
+
+
+def build_margin_zone_context(payload: dict[str, Any] | None, current_price: Any = None) -> dict[str, Any]:
+    lower, upper = extract_margin_zone(payload)
+    price = _float_or_none(current_price)
+    if price is None and isinstance(payload, dict):
+        price = _nested_float(payload, "current_price", "close", "price", "entry", "entry_price")
+    available = lower is not None and upper is not None
+    inside = bool(available and price is not None and lower <= price <= upper)
+    return {
+        "available": available,
+        "margin_lower": lower,
+        "margin_upper": upper,
+        "inside_margin_zone": inside,
+        "margin_source": str(payload.get("margin_source") or "Future_Volume_v5.00") if available and isinstance(payload, dict) else "unavailable",
+        "margin_object": str(payload.get("margin_object") or "") if available and isinstance(payload, dict) else "",
+        "current_price": price,
+    }
+
+
 def pip_size_for_symbol(symbol: str) -> float:
     normalized = normalize_broker_symbol(symbol)
     if normalized.endswith("JPY"):
@@ -102,7 +131,7 @@ def build_dpoc_context(payload: dict[str, Any] | None, symbol: str = "", current
 
 
 def _previous_cumdelta(symbol: str, timeframe: str) -> float:
-    previous = _STORE.get(f"{symbol}:{timeframe}") or _STORE.get(symbol) or {}
+    previous = _STORE.get(f"{symbol}:{timeframe}") or {}
     if not isinstance(previous, dict):
         return 0.0
     volume_delta = previous.get("volume_delta") if isinstance(previous.get("volume_delta"), dict) else {}
@@ -179,13 +208,23 @@ def build_volume_delta_priority_snapshot(payload: dict[str, Any], symbol: str = 
 def save_volume_cluster_payload(payload: dict[str, Any]) -> dict[str, Any]:
     symbol = normalize_broker_symbol(payload.get("symbol") or payload.get("broker_symbol"))
     timeframe = str(payload.get("timeframe") or "H1").upper().strip()
-    record = dict(payload)
+    previous = _STORE.get(f"{symbol}:{timeframe}") or {}
+    record = dict(previous) if isinstance(previous, dict) else {}
+    record.update({key: value for key, value in payload.items() if value is not None})
     record["symbol"] = symbol
     record["timeframe"] = timeframe
+    incoming_close = _float_or_none(payload.get("close"))
+    if incoming_close is not None and incoming_close > 0:
+        record["current_price"] = incoming_close
     record["volume_delta"] = build_volume_delta_priority_snapshot(record, symbol, timeframe)
     record["dpoc_price"] = extract_dpoc_price(record)
     record["dpoc"] = build_dpoc_context(record, symbol)
     record["distance_to_dpoc_pips"] = record["dpoc"].get("distance_to_dpoc_pips")
+    record["margin_zone"] = build_margin_zone_context(record)
+    record["margin_lower"] = record["margin_zone"].get("margin_lower")
+    record["margin_upper"] = record["margin_zone"].get("margin_upper")
+    record["inside_margin_zone"] = record["margin_zone"].get("inside_margin_zone")
+    record["margin_source"] = record["margin_zone"].get("margin_source")
     record["volume_delta_available"] = bool(record["volume_delta"].get("available"))
     if not isinstance(record.get("delta"), dict):
         record["delta"] = record["volume_delta"].get("delta")

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any
 
 from app.services.external_signal_adapter import get_cme_optionsfx_confirmation
-from app.services.mt4_volume_cluster_bridge import build_dpoc_context, get_latest_volume_cluster
+from app.services.mt4_volume_cluster_bridge import build_dpoc_context, build_margin_zone_context, get_latest_volume_cluster
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ PROP_CRITERIA = (
     {"key": "structure", "label_ru": "Структура / импульс", "weight": 12},
     {"key": "liquidity", "label_ru": "Ликвидность / POI", "weight": 8},
     {"key": "volume", "label_ru": "Volume / tick volume", "weight": 5},
+    {"key": "margin_zones", "label_ru": "Margin Zones / Volume Profile", "weight": 3},
     {"key": "options", "label_ru": "Опционы / CME", "weight": 4},
     {"key": "sentiment", "label_ru": "Sentiment / новости", "weight": 5},
 )
@@ -500,6 +501,38 @@ def _dpoc_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
     return {"available": False, "source": "unavailable", "dpoc_price": None, "distance_to_dpoc_pips": None, "aligned": False, "score_adjustment": 0, "text_ru": "DPOC недоступен; сделки не блокируются."}
 
 
+def _margin_zone_context(idea: dict[str, Any]) -> dict[str, Any]:
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    timeframe = str(idea.get("timeframe") or idea.get("tf") or "").upper().strip() or None
+    candles = _candles(idea)
+    current_price = _to_float(idea.get("current_price") or idea.get("price"))
+    if current_price is None and candles:
+        current_price = _to_float(candles[-1].get("close"))
+    if current_price is None:
+        current_price = _to_float(idea.get("entry") or idea.get("entry_price"))
+
+    sources = [idea, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None]
+    if symbol:
+        sources.append(get_latest_volume_cluster(symbol, timeframe))
+    for payload in sources:
+        context = build_margin_zone_context(payload, current_price)
+        if context.get("available"):
+            inside = bool(context.get("inside_margin_zone"))
+            context["score_adjustment"] = 3 if inside else 0
+            context["text_ru"] = "Цена внутри маржинальной зоны Future_Volume_v5.00; подтверждение +3." if inside else "Маржинальная зона доступна, но цена находится вне неё; hard-block не применяется."
+            return context
+    return {
+        "available": False,
+        "margin_lower": None,
+        "margin_upper": None,
+        "inside_margin_zone": False,
+        "margin_source": "unavailable",
+        "margin_object": "",
+        "score_adjustment": 0,
+        "text_ru": "Margin Zones недоступны; сделки не блокируются.",
+    }
+
+
 def _volume_delta_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
     candles = _candles(idea)
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
@@ -855,6 +888,9 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
         volume_score = weights["volume"] if volume_text else 1 if candles else 0
     rows.append(_row("volume", volume_score, weights["volume"], str(volume_delta.get("text_ru") or volume_text or "только OHLC/tick proxy")))
 
+    margin_zone = _margin_zone_context(idea)
+    rows.append(_row("margin_zones", weights["margin_zones"] if margin_zone.get("inside_margin_zone") else 0, weights["margin_zones"], str(margin_zone.get("text_ru"))))
+
     external_options = _external_options_alignment(idea, direction)
     external_text = str(external_options.get("text_ru") or "")
     options_text = _first_text(idea, "options_ru", "options_analysis.summary", "options_analysis.bias")
@@ -873,8 +909,9 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
 def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     safe_idea = idea if isinstance(idea, dict) else {}
     rows = _criterion_rows(safe_idea)
-    total_weight = sum(row["weight"] for row in rows) or 1
-    base_score = round(sum(row["score"] for row in rows) / total_weight * 100)
+    base_rows = [row for row in rows if row.get("key") != "margin_zones"]
+    total_weight = sum(row["weight"] for row in base_rows) or 1
+    base_score = round(sum(row["score"] for row in base_rows) / total_weight * 100)
     direction = _direction(safe_idea)
     geo = _trade_geometry(safe_idea)
     candle_diag = _candle_diagnostics(safe_idea)
@@ -882,9 +919,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     external_options = _external_options_alignment(safe_idea, direction)
     volume_delta = _volume_delta_context(safe_idea, direction)
     dpoc = _dpoc_context(safe_idea, direction)
+    margin_zone = _margin_zone_context(safe_idea)
     volume_delta_source = volume_delta.get("source")
     hft_signal = volume_delta.get("hft_signal") or _hft_signal_context(safe_idea).get("hft_signal")
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0)))
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0)))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     external_options_note = ""
@@ -974,11 +1012,16 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "dpoc": dpoc,
         "dpoc_price": dpoc.get("dpoc_price"),
         "distance_to_dpoc_pips": dpoc.get("distance_to_dpoc_pips"),
+        "margin_zone": margin_zone,
+        "margin_lower": margin_zone.get("margin_lower"),
+        "margin_upper": margin_zone.get("margin_upper"),
+        "inside_margin_zone": bool(margin_zone.get("inside_margin_zone")),
+        "margin_source": margin_zone.get("margin_source"),
         "real_candle_diagnostics": candle_diag,
         "volume_delta_source": volume_delta_source,
         "hft_signal": hft_signal,
         "delta_divergence": bool(volume_delta.get("delta_divergence")),
-        "margin_zone_confluence": None,
+        "margin_zone_confluence": margin_zone,
         "disclaimer_ru": "Score не блокирует идею только из-за отсутствия optional CME/options/news слоёв; но если sentiment/news явно против направления, автоторговля блокируется.",
     }
 
@@ -1112,11 +1155,20 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "dpoc": score.get("dpoc"),
             "dpoc_price": score.get("dpoc_price"),
             "distance_to_dpoc_pips": score.get("distance_to_dpoc_pips"),
+            "margin_zone": score.get("margin_zone"),
+            "margin_lower": score.get("margin_lower"),
+            "margin_upper": score.get("margin_upper"),
+            "inside_margin_zone": score.get("inside_margin_zone"),
+            "margin_source": score.get("margin_source"),
         }
     )
     market_structure = dict(enriched.get("market_structure") or {})
     market_structure["dpoc_price"] = score.get("dpoc_price")
     market_structure["distance_to_dpoc_pips"] = score.get("distance_to_dpoc_pips")
+    market_structure["margin_lower"] = score.get("margin_lower")
+    market_structure["margin_upper"] = score.get("margin_upper")
+    market_structure["inside_margin_zone"] = score.get("inside_margin_zone")
+    market_structure["margin_source"] = score.get("margin_source")
     enriched["market_structure"] = market_structure
     return enriched
 

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AI-сигналы по рынку</title>
-  <link rel="stylesheet" href="/static/ideas.css?v=prop-score-ui-5" />
+  <link rel="stylesheet" href="/static/ideas.css?v=prop-score-ui-6" />
   <script src="https://unpkg.com/lightweight-charts@4.2.0/dist/lightweight-charts.standalone.production.js"></script>
-  <script src="/static/ideas.js?v=prop-score-ui-5" defer></script>
+  <script src="/static/ideas.js?v=prop-score-ui-6" defer></script>
   <script src="/static/ideas-status-fix.js?v=status-fix-1" defer></script>
   <script src="/static/ideas-chart-fix.js?v=chart-hotfix-6" defer></script>
   <script src="/static/ideas-archive-fix.js?v=archive-ui-2" defer></script>

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -490,10 +490,23 @@ function resolveDpoc(idea) {
   };
 }
 
+function resolveMarginZone(idea) {
+  const lower = pickFirstFiniteNumber(idea.margin_lower, idea.market_structure?.margin_lower, idea.margin_zone?.margin_lower);
+  const upper = pickFirstFiniteNumber(idea.margin_upper, idea.market_structure?.margin_upper, idea.margin_zone?.margin_upper);
+  const inside = Boolean(idea.inside_margin_zone ?? idea.market_structure?.inside_margin_zone ?? idea.margin_zone?.inside_margin_zone);
+  return {
+    lower: lower !== null && lower > 0 ? formatNumber(lower) : "—",
+    upper: upper !== null && upper > 0 ? formatNumber(upper) : "—",
+    inside: lower !== null && upper !== null ? (inside ? "да" : "нет") : "—",
+  };
+}
+
+
 function renderIdeaCard(idea, index) {
   const symbol = getIdeaSymbol(idea);
   const action = idea.action || idea.signal || idea.label || "WAIT";
   const dpoc = resolveDpoc(idea);
+  const marginZone = resolveMarginZone(idea);
   return `<article class="idea-card" data-idea-index="${index}" tabindex="0" role="button" aria-label="Открыть идею ${escapeHtml(symbol)}">
     <div class="idea-card-top">
       <div>
@@ -511,6 +524,8 @@ function renderIdeaCard(idea, index) {
       <div><span>TP</span><strong>${escapeHtml(formatNumber(idea.tp ?? idea.take_profit ?? idea.target))}</strong></div>
       <div><span>R/R</span><strong>${escapeHtml(formatNumber(idea.rr ?? idea.risk_reward))}</strong></div>
       <div><span>DPOC / дистанция</span><strong>${escapeHtml(dpoc.price)} · ${escapeHtml(dpoc.distance)}</strong></div>
+      <div><span>margin_lower / margin_upper</span><strong>${escapeHtml(marginZone.lower)} / ${escapeHtml(marginZone.upper)}</strong></div>
+      <div><span>inside_margin_zone</span><strong>${escapeHtml(marginZone.inside)}</strong></div>
     </div>
     ${renderPropCompact(idea)}
     ${renderVolumeDeltaCompact(idea)}
@@ -560,6 +575,7 @@ function openIdeaModal(idea) {
   const title = modal.querySelector(".ideas-modal-title");
   const zoneType = sanitizeText(idea.selected_zone_type);
   const dpoc = resolveDpoc(idea);
+  const marginZone = resolveMarginZone(idea);
   title.textContent = zoneType ? `${symbol} · ${getIdeaDirection(idea)} · ${zoneType}` : `${symbol} · ${getIdeaDirection(idea)}`;
   body.innerHTML = `<div class="modal-grid">
       <div>
@@ -583,6 +599,9 @@ function openIdeaModal(idea) {
         <div><span>R/R</span><strong>${escapeHtml(formatNumber(idea.rr ?? idea.risk_reward))}</strong></div>
         <div><span>DPOC</span><strong>${escapeHtml(dpoc.price)}</strong></div>
         <div><span>До DPOC</span><strong>${escapeHtml(dpoc.distance)}</strong></div>
+        <div><span>margin_lower</span><strong>${escapeHtml(marginZone.lower)}</strong></div>
+        <div><span>margin_upper</span><strong>${escapeHtml(marginZone.upper)}</strong></div>
+        <div><span>inside_margin_zone</span><strong>${escapeHtml(marginZone.inside)}</strong></div>
       </div>
       <p class="modal-text"><strong>Новости/фундаментал:</strong> ${escapeHtml(resolveNewsContext(idea))}</p>
       <p class="modal-text"><strong>Options/CME confirmation:</strong> ${escapeHtml(resolveExternalOptionsRu(idea))}<br><strong>Bias:</strong> ${escapeHtml(resolveExternalOptionsBias(idea))}; <strong>Key strikes:</strong> ${escapeHtml(formatListValue(idea.external_options_key_strikes))}; <strong>Max pain:</strong> ${escapeHtml(formatListValue(idea.external_options_max_pain))}</p>

--- a/tests/test_mt4_margin_zones.py
+++ b/tests/test_mt4_margin_zones.py
@@ -1,0 +1,136 @@
+from datetime import datetime, timezone
+
+from app.main import api_mt4_ingest_get, api_mt4_margin_zones
+from app.services.mt4_volume_cluster_bridge import get_latest_volume_cluster, save_volume_cluster_payload
+from app.services.prop_signal_engine import build_prop_signal_score, enrich_idea_with_prop_score
+
+
+def _idea(close: float = 1.1050, symbol: str = "CADCHF") -> dict:
+    candles = [
+        {"time": i + 1, "open": close - 0.0002, "high": close + 0.0003, "low": close - 0.0003, "close": close}
+        for i in range(30)
+    ]
+    return {
+        "symbol": symbol,
+        "timeframe": "M15",
+        "action": "BUY",
+        "entry": close,
+        "sl": close - 0.0020,
+        "tp": close + 0.0030,
+        "candles": candles,
+        "reason_ru": "Подтверждённая структура",
+    }
+
+
+def test_volume_bridge_normalizes_and_stores_margin_zone():
+    saved = save_volume_cluster_payload(
+        {
+            "symbol": "NZDUSD",
+            "timeframe": "M15",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "current_price": 1.1050,
+            "margin_lower": 1.1100,
+            "margin_upper": 1.1000,
+            "margin_source": "Future_Volume_v5.00",
+            "margin_object": "MZ_1/2",
+        }
+    )
+
+    assert saved["margin_lower"] == 1.1000
+    assert saved["margin_upper"] == 1.1100
+    assert saved["inside_margin_zone"] is True
+    assert saved["margin_source"] == "Future_Volume_v5.00"
+
+
+def test_margin_zone_adds_confirmation_without_hard_block():
+    idea = _idea()
+    without_zone = build_prop_signal_score(idea)
+    inside_zone = build_prop_signal_score({**idea, "margin_lower": 1.1000, "margin_upper": 1.1100, "margin_source": "Future_Volume_v5.00"})
+    outside_zone = build_prop_signal_score({**idea, "margin_lower": 1.0900, "margin_upper": 1.1000, "margin_source": "Future_Volume_v5.00"})
+
+    assert inside_zone["score"] == min(100, without_zone["score"] + 3)
+    assert inside_zone["inside_margin_zone"] is True
+    assert outside_zone["inside_margin_zone"] is False
+    assert "Margin" not in " ".join(outside_zone["blockers"])
+    criterion = next(row for row in inside_zone["criteria"] if row["key"] == "margin_zones")
+    assert criterion["label_ru"] == "Margin Zones / Volume Profile"
+    assert criterion["status"] == "confirmed"
+
+
+def test_enriched_idea_exposes_margin_zone_fields():
+    enriched = enrich_idea_with_prop_score(
+        {**_idea(), "margin_lower": 1.1000, "margin_upper": 1.1100, "margin_source": "Future_Volume_v5.00"}
+    )
+
+    assert enriched["margin_lower"] == 1.1000
+    assert enriched["margin_upper"] == 1.1100
+    assert enriched["inside_margin_zone"] is True
+    assert enriched["market_structure"]["inside_margin_zone"] is True
+
+
+def test_margin_zone_get_endpoint_stores_mt4_object_bounds():
+    response = api_mt4_margin_zones(
+        symbol="USDCHF",
+        tf="M15",
+        margin_lower=0.9000,
+        margin_upper=0.9050,
+        current_price=0.9025,
+        margin_source="Future_Volume_v5.00",
+        margin_object="MZ_1/1",
+    )
+
+    assert response["ok"] is True
+    assert response["inside_margin_zone"] is True
+    stored = get_latest_volume_cluster("USDCHF", "M15")
+    assert stored["margin_object"] == "MZ_1/1"
+    assert stored["margin_lower"] == 0.9000
+    assert stored["margin_upper"] == 0.9050
+
+
+def test_existing_mt4_ingest_get_accepts_margin_zone_fields():
+    response = api_mt4_ingest_get(
+        symbol="AUDCAD",
+        tf="M15",
+        time=int(datetime.now(timezone.utc).timestamp()),
+        open=0.9000,
+        high=0.9060,
+        low=0.8990,
+        close=0.9030,
+        margin_lower=0.9010,
+        margin_upper=0.9050,
+        margin_source="Future_Volume_v5.00",
+        margin_object="MZ_3/4",
+    )
+
+    assert response["ok"] is True
+    stored = get_latest_volume_cluster("AUDCAD", "M15")
+    assert stored["inside_margin_zone"] is True
+    assert stored["margin_object"] == "MZ_3/4"
+
+
+def test_partial_volume_update_preserves_latest_margin_zone():
+    save_volume_cluster_payload(
+        {
+            "symbol": "EURCAD",
+            "timeframe": "M15",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "current_price": 1.5000,
+            "margin_lower": 1.4950,
+            "margin_upper": 1.5050,
+            "margin_source": "Future_Volume_v5.00",
+        }
+    )
+    updated = save_volume_cluster_payload(
+        {
+            "symbol": "EURCAD",
+            "timeframe": "M15",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "close": 1.5010,
+            "margin_lower": None,
+            "margin_upper": None,
+        }
+    )
+
+    assert updated["margin_lower"] == 1.4950
+    assert updated["margin_upper"] == 1.5050
+    assert updated["inside_margin_zone"] is True


### PR DESCRIPTION
### Motivation
- Ввести поддержку маржинальных зон, которые экспортирует индикатор Future_Volume_v5.00 в MT4, и использовать их как дополнительный подтверждающий слой для Prop Decision Engine (не как блокирующий фактор).

### Description
- MT4 EA (`AI_Ideas_Trader.mq4`) теперь ищет объекты `MZ_1/1`, `MZ_1/2`, `MZ_1/4`, `MZ_3/4`, читает `OBJPROP_PRICE1` / `OBJPROP_PRICE2`, выбирает зону (содержащую цену или ближайшую) и публикует её через `GET /api/mt4/margin-zones` (параметры `margin_lower`, `margin_upper`, `current_price`, `margin_source`, `margin_object`).
- Backend: добавлены `extract_margin_zone` и `build_margin_zone_context` в `app/services/mt4_volume_cluster_bridge.py`, `save_volume_cluster_payload` сохраняет `margin_lower`, `margin_upper`, `inside_margin_zone`, `margin_source` и защищает их при частичных обновлениях; также добавлен маршрут `GET /api/mt4/margin-zones` и `api_mt4_ingest_get` принимает поля маржинальной зоны.
- Scoring: в `app/services/prop_signal_engine.py` добавлен критерий `margin_zones` и контекст `_margin_zone_context`, где нахождение цены внутри зоны даёт подтверждающее `score_adjustment = +3` и поле публикуется в `prop_signal_score`, верхнем уровне идеи и `market_structure` (не hard-block).
- Frontend: `app/static/ideas.js` показывает `margin_lower`, `margin_upper` и `inside_margin_zone` в карточке и модальном окне идеи; версия статичных ресурсов обновлена (`prop-score-ui-6`).
- Документация: README дополнен кратким описанием контракта MT4 → backend и поведения критерия.

### Testing
- Запущены целевые unit/integ тесты `pytest -q tests/test_mt4_margin_zones.py tests/test_mt4_dpoc.py tests/test_mt4_volume_cluster.py`, все проверки прошли успешно (`14 passed`).
- Синтаксические проверки файлов Python выполнены через `python -m py_compile` для затронутых модулей и завершились без ошибок for изменённых файлов. 
- Статическая проверка JS выполнена через `node --check app/static/ideas.js` и прошла успешно. 
- Выполнен визуальный smoke-check страницы `/ideas` с мок-пейлоадом через Playwright и снят скриншот для подтверждения UI-рендера полей маржинальной зоны.
- Пробный полный запуск `pytest -q` ранее выявил несвязанные с этой задачей проблемы коллекции тестов в репозитории; изменения здесь ограничены интеграцией маржинальных зон и целевые тесты проходят зелёным.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2154dd84dc8331b16d37eb5ba97407)