### PR TITLE
Устранить таймауты /ideas/market и добавить timing logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,3 +425,9 @@ curl http://127.0.0.1:8000/ideas/market
 Существующий MT4 bridge принимает текущий дневной DPOC без отдельного маршрута: передайте `dpoc_price` (также поддерживаются aliases `dpoc`, `daily_dpoc`, `daily_dpoc_price`) в `GET /api/mt4/ingest-get`, `POST /api/mt4/volume-clusters` или legacy `POST /ideas/market` вместе с FutureVolume payload.
 
 Backend сохраняет реальный уровень индикатора как `dpoc_price`, рассчитывает подписанное поле `distance_to_dpoc_pips` от текущей цены и публикует оба поля на верхнем уровне идеи и внутри `market_structure`. DPOC используется только как подтверждение: BUY получает +3 score при цене выше DPOC, SELL — +3 при цене ниже DPOC. Отсутствующий или неподтверждающий DPOC не блокирует сделку.
+
+## Диагностика таймаутов `/ideas/market`
+
+Маршрут `/ideas/market` использует stale-while-revalidate кэш (TTL задаётся через `MARKET_IDEAS_CACHE_TTL_SECONDS`, по умолчанию 60 секунд). Построение рынка запускается в фоне при старте приложения и при устаревании кэша, поэтому внешний HTTP/LLM provider больше не блокирует основной запрос Render.
+
+Для потенциально медленных этапов пишутся парные структурированные записи `START` / `END` с `elapsed_ms` и флагом `slow_over_5s`. В Render logs можно фильтровать `timing operation=` и отдельно проверять `build_market`, `generate_trade_ideas`, `enrich_ideas_with_prop_scores`, `enrich_idea_with_openai_narrative`, `options_analysis`, `CME_OptionsFX` и `chart_endpoint`.

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,8 @@ import time
 import asyncio
 import re
 import concurrent.futures
+from copy import deepcopy
+from threading import Lock
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -29,6 +31,7 @@ from app.services.mt4_options_bridge import get_latest_options_levels, save_opti
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_stats
 from app.services.signal_audit_logger import log_signal_audit
+from app.services.timing import timing_log
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -101,6 +104,11 @@ MT4_BRIDGE_FRESH_SECONDS = int(os.getenv("MT4_BRIDGE_FRESH_SECONDS", "180"))
 ALLOW_EXTERNAL_FALLBACK = os.getenv("ALLOW_EXTERNAL_FALLBACK", "1") == "1"
 SENTIMENT_CACHE: dict[str, dict[str, Any]] = {}
 SENTIMENT_CACHE_TTL_SECONDS = 900
+MARKET_IDEAS_CACHE_TTL_SECONDS = int(os.getenv("MARKET_IDEAS_CACHE_TTL_SECONDS", "60"))
+MARKET_IDEAS_CACHE: dict[str, Any] = {"updated_at_epoch": 0.0, "payload": None}
+MARKET_IDEAS_REFRESH_LOCK = Lock()
+MARKET_IDEAS_REFRESH_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="market-ideas-refresh")
+MARKET_IDEAS_REFRESH_IN_PROGRESS = False
 
 ACTIVE_FILE = Path("active_trades.json")
 ARCHIVE_FILE = Path("archive.json")
@@ -178,6 +186,7 @@ if STATIC_DIR.exists():
 @app.on_event("startup")
 def startup() -> None:
     twelvedata_ws_service.start()
+    _queue_market_ideas_refresh()
 
 
 @app.on_event("shutdown")
@@ -777,63 +786,73 @@ def api_heatmap(mode: str = "core", tf: str = "M15"):
     return build_currency_heatmap(mode=mode, tf=tf)
 
 
-@app.get("/api/signals")
-def api_signals():
+def generate_trade_ideas() -> tuple[list[dict[str, Any]], list[str]]:
     signals: list[dict[str, Any]] = []
     failed_symbols: list[str] = []
-
-    for symbol in SYMBOLS:
-        try:
-            signal = build_signal_from_candles(symbol, "M15")
-            if isinstance(signal, dict) and signal:
-                signals.append(_normalize_quote_signal(signal))
-            else:
+    with timing_log(logger, "generate_trade_ideas", symbols_count=len(SYMBOLS)):
+        for symbol in SYMBOLS:
+            try:
+                signal = build_signal_from_candles(symbol, "M15")
+                if isinstance(signal, dict) and signal:
+                    signals.append(_normalize_quote_signal(signal))
+                else:
+                    failed_symbols.append(symbol)
+                    logger.error("generate_trade_ideas invalid_signal_payload symbol=%s", symbol)
+            except Exception:
                 failed_symbols.append(symbol)
-                logger.exception("api_signals: invalid signal payload for %s", symbol)
-        except Exception:
-            failed_symbols.append(symbol)
-            logger.exception("api_signals: failed to build signal for %s", symbol)
+                logger.exception("generate_trade_ideas failed symbol=%s", symbol)
+    return signals, failed_symbols
 
-    if signals:
-        enriched_signals = enrich_ideas_with_prop_scores(signals)
-        lifecycle = apply_idea_lifecycle(enriched_signals)
+
+def build_market() -> dict[str, Any]:
+    with timing_log(logger, "build_market"):
+        signals, failed_symbols = generate_trade_ideas()
+
+        if signals:
+            enriched_signals = enrich_ideas_with_prop_scores(signals)
+            lifecycle = apply_idea_lifecycle(enriched_signals)
+            return {
+                "signals": lifecycle["ideas"],
+                "ideas": lifecycle["ideas"],
+                "archive": lifecycle["archive"],
+                "statistics": lifecycle["statistics"],
+                "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
+                "updated_at_utc": now_utc(),
+                "ai_provider": "signal_engine",
+                "ai_model_used": "",
+                "ai_status": "not_used",
+                "ai_error": None,
+            }
+
         return {
-            "signals": lifecycle["ideas"],
-            "ideas": lifecycle["ideas"],
-            "archive": lifecycle["archive"],
-            "statistics": lifecycle["statistics"],
+            "signals": [],
+            "ideas": [],
+            "archive": [],
+            "statistics": {
+                "total": 0,
+                "buy": 0,
+                "sell": 0,
+                "wait": 0,
+                "active": 0,
+                "blocked": 0,
+            },
             "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
             "updated_at_utc": now_utc(),
             "ai_provider": "signal_engine",
             "ai_model_used": "",
             "ai_status": "not_used",
             "ai_error": None,
+            "ok": False,
+            "diagnostics": {
+                "error": "Не удалось сформировать сигналы ни по одному символу.",
+                "failed_symbols": failed_symbols,
+            },
         }
 
-    return {
-        "signals": [],
-        "ideas": [],
-        "archive": [],
-        "statistics": {
-            "total": 0,
-            "buy": 0,
-            "sell": 0,
-            "wait": 0,
-            "active": 0,
-            "blocked": 0,
-        },
-        "metric_warning_ru": "Proxy — это расчётная метрика, не реальная рыночная котировка.",
-        "updated_at_utc": now_utc(),
-        "ai_provider": "signal_engine",
-        "ai_model_used": "",
-        "ai_status": "not_used",
-        "ai_error": None,
-        "ok": False,
-        "diagnostics": {
-            "error": "Не удалось сформировать сигналы ни по одному символу.",
-            "failed_symbols": failed_symbols,
-        },
-    }
+
+@app.get("/api/signals")
+def api_signals():
+    return build_market()
 
 
 @app.get("/api/ideas")
@@ -927,9 +946,54 @@ def api_ideas():
     }
 
 
+def _refresh_market_ideas_cache() -> None:
+    global MARKET_IDEAS_REFRESH_IN_PROGRESS
+    try:
+        payload = build_market()
+        with MARKET_IDEAS_REFRESH_LOCK:
+            MARKET_IDEAS_CACHE["payload"] = deepcopy(payload)
+            MARKET_IDEAS_CACHE["updated_at_epoch"] = time.time()
+    except Exception:
+        logger.exception("market_ideas_background_refresh_failed")
+    finally:
+        with MARKET_IDEAS_REFRESH_LOCK:
+            MARKET_IDEAS_REFRESH_IN_PROGRESS = False
+
+
+def _queue_market_ideas_refresh() -> bool:
+    global MARKET_IDEAS_REFRESH_IN_PROGRESS
+    with MARKET_IDEAS_REFRESH_LOCK:
+        if MARKET_IDEAS_REFRESH_IN_PROGRESS:
+            return False
+        MARKET_IDEAS_REFRESH_IN_PROGRESS = True
+    MARKET_IDEAS_REFRESH_EXECUTOR.submit(_refresh_market_ideas_cache)
+    return True
+
+
 @app.get("/ideas/market")
 def ideas_market():
-    return api_signals()
+    with timing_log(logger, "ideas_market_request"):
+        with MARKET_IDEAS_REFRESH_LOCK:
+            cached = deepcopy(MARKET_IDEAS_CACHE.get("payload"))
+            age_seconds = time.time() - float(MARKET_IDEAS_CACHE.get("updated_at_epoch") or 0.0)
+        if cached is not None:
+            if age_seconds >= MARKET_IDEAS_CACHE_TTL_SECONDS:
+                _queue_market_ideas_refresh()
+            cached["cache_status"] = "fresh" if age_seconds < MARKET_IDEAS_CACHE_TTL_SECONDS else "stale_refreshing"
+            cached["cache_age_seconds"] = round(age_seconds, 3)
+            return cached
+
+        _queue_market_ideas_refresh()
+        return {
+            "signals": [],
+            "ideas": [],
+            "archive": [],
+            "statistics": {"total": 0, "buy": 0, "sell": 0, "wait": 0, "active": 0, "blocked": 0},
+            "updated_at_utc": now_utc(),
+            "cache_status": "warming",
+            "ok": False,
+            "diagnostics": {"reason": "market_refresh_running_in_background"},
+        }
 
 
 @app.post("/ideas/market")
@@ -1495,7 +1559,8 @@ def api_candles(symbol: str, tf: str = "M15", limit: int = 160):
 
 @app.get("/api/chart/{symbol}")
 def api_chart(symbol: str, tf: str = "M15", limit: int = 160):
-    return get_candles_with_markup(symbol, tf, limit)
+    with timing_log(logger, "chart_endpoint", symbol=symbol, timeframe=tf, limit=limit):
+        return get_candles_with_markup(symbol, tf, limit)
 
 
 @app.get("/api/canonical/chart/{symbol}/{tf}")

--- a/app/services/external_signal_adapter.py
+++ b/app/services/external_signal_adapter.py
@@ -8,6 +8,8 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
+from app.services.timing import timing_log
+
 import requests
 from bs4 import BeautifulSoup
 
@@ -233,6 +235,11 @@ def _fetch_public_telegram_messages(channel: str) -> list[dict[str, str]]:
 
 
 def get_cme_optionsfx_signals(force_refresh: bool = False) -> dict[str, Any]:
+    with timing_log(logger, "CME_OptionsFX", force_refresh=force_refresh):
+        return _get_cme_optionsfx_signals(force_refresh)
+
+
+def _get_cme_optionsfx_signals(force_refresh: bool = False) -> dict[str, Any]:
     source = EXTERNAL_SIGNAL_SOURCES["CME_OptionsFX"]
     now = time.time()
     cached = _CACHE.get("CME_OptionsFX")

--- a/app/services/openai_idea_narrative.py
+++ b/app/services/openai_idea_narrative.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import requests
 from app.services.signal_audit_logger import log_signal_audit
+from app.services.timing import timing_log
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,11 @@ _OPENAI_COOLDOWN_UNTIL = 0.0
 
 
 def enrich_idea_with_openai_narrative(payload: dict[str, Any]) -> dict[str, Any]:
+    with timing_log(logger, "enrich_idea_with_openai_narrative", symbol=payload.get("symbol"), timeframe=payload.get("timeframe") or payload.get("tf")):
+        return _enrich_idea_with_openai_narrative(payload)
+
+
+def _enrich_idea_with_openai_narrative(payload: dict[str, Any]) -> dict[str, Any]:
     global _OPENAI_COOLDOWN_UNTIL
 
     result = deepcopy(payload if isinstance(payload, dict) else {})

--- a/app/services/options_analysis.py
+++ b/app/services/options_analysis.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
+import logging
+
+from app.services.timing import timing_log
+
+logger = logging.getLogger(__name__)
+
 SUPPORTED_TYPES = {
     "call",
     "put",
@@ -27,6 +33,11 @@ def _safe_float(value: Any) -> float | None:
 
 
 def analyze_options(levels: list[dict[str, Any]] | None, price: float | int | None, symbol: str = "EURUSD") -> dict[str, Any]:
+    with timing_log(logger, "options_analysis", symbol=symbol, levels_count=len(levels) if isinstance(levels, list) else 0):
+        return _analyze_options(levels, price, symbol)
+
+
+def _analyze_options(levels: list[dict[str, Any]] | None, price: float | int | None, symbol: str = "EURUSD") -> dict[str, Any]:
     rows = [row for row in (levels or []) if isinstance(row, dict)]
     parsed_price = _safe_float(price)
     tolerance = 0.0005 if str(symbol).upper() == "EURUSD" else 0.001

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from app.services.external_signal_adapter import get_cme_optionsfx_confirmation
 from app.services.mt4_volume_cluster_bridge import build_dpoc_context, build_margin_zone_context, get_latest_volume_cluster
+from app.services.timing import timing_log
 
 logger = logging.getLogger(__name__)
 
@@ -1284,12 +1285,13 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
 
 
 def enrich_ideas_with_prop_scores(ideas: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    if not isinstance(ideas, list):
-        return []
-    enriched_ideas: list[dict[str, Any]] = []
-    for idea in ideas:
-        if not isinstance(idea, dict):
-            continue
-        scored = enrich_idea_with_prop_score(idea)
-        enriched_ideas.append(enrich_idea_with_openai_narrative(scored))
-    return enriched_ideas
+    with timing_log(logger, "enrich_ideas_with_prop_scores", ideas_count=len(ideas) if isinstance(ideas, list) else 0):
+        if not isinstance(ideas, list):
+            return []
+        enriched_ideas: list[dict[str, Any]] = []
+        for idea in ideas:
+            if not isinstance(idea, dict):
+                continue
+            scored = enrich_idea_with_prop_score(idea)
+            enriched_ideas.append(enrich_idea_with_openai_narrative(scored))
+        return enriched_ideas

--- a/app/services/timing.py
+++ b/app/services/timing.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+
+SLOW_OPERATION_MS = 5_000.0
+
+
+@contextmanager
+def timing_log(logger: logging.Logger, operation: str, **context: Any) -> Iterator[None]:
+    """Log START/END and elapsed time for a potentially slow operation."""
+    started = time.perf_counter()
+    suffix = " ".join(f"{key}={value}" for key, value in context.items() if value is not None)
+    logger.info("timing operation=%s event=START%s", operation, f" {suffix}" if suffix else "")
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.perf_counter() - started) * 1_000
+        log = logger.warning if elapsed_ms > SLOW_OPERATION_MS else logger.info
+        log(
+            "timing operation=%s event=END elapsed_ms=%.2f slow_over_5s=%s%s",
+            operation,
+            elapsed_ms,
+            elapsed_ms > SLOW_OPERATION_MS,
+            f" {suffix}" if suffix else "",
+        )

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -92,42 +92,20 @@ def _enrich_idea(card: dict[str, Any]) -> dict[str, Any]:
     existing = _clean(out.get("unified_narrative") or out.get("idea_article_ru") or out.get("description") or out.get("summary"))
     is_bad = (not existing) or ("fallback" in str(out.get("narrative_source") or out.get("text_source") or "").lower())
     if is_bad:
-        prompt = (
-            "Объясни торговую идею как institutional Forex prop desk analyst. Верни JSON: "
-            "unified_narrative, idea_article_ru, trade_logic, risk_logic. Не меняй signal/entry/SL/TP.\n\nIDEA:\n"
-            + json.dumps(out, ensure_ascii=False, default=str)
-        )
-        result = _call_openrouter(
-            "Ты institutional Forex trader (SMC/ICT + options). Пиши по-русски, конкретно, без обещаний прибыли.",
-            prompt,
-            primary_model=os.getenv("OPENROUTER_MODEL"),
-            max_tokens=900,
-        )
-        if result.get("ok"):
-            data = result.get("data") if isinstance(result.get("data"), dict) else {}
-            text = _clean(data.get("unified_narrative") or data.get("idea_article_ru") or result.get("text"))
-            out.update(data)
-            out["unified_narrative"] = text
-            out["idea_article_ru"] = _clean(data.get("idea_article_ru") or text)
-            out["description"] = text
-            out["summary"] = text
-            out["text_source"] = out["textSource"] = "grok"
-            out["narrative_source"] = out["narrativeSource"] = "grok"
-            out["ai_provider"] = "grok"
-            out["grok_used"] = out["grokUsed"] = True
-            out["fallback"] = out["fallback_text"] = out["is_fallback_text"] = False
-            out["ai_model_used"] = result.get("model")
-        else:
-            text = _fallback_idea_text(out)
-            out.setdefault("unified_narrative", text)
-            out.setdefault("idea_article_ru", text)
-            out.setdefault("description", text)
-            out.setdefault("summary", text)
-            out["text_source"] = out["textSource"] = "local_safe"
-            out["narrative_source"] = out["narrativeSource"] = "local_safe"
-            out["fallback"] = False
-            out["fallback_text"] = False
-            out["is_fallback_text"] = False
+        # JSONResponse.render runs on the request critical path. Never perform an
+        # external LLM request here: Render/client timeouts cancel the response
+        # before a 30-second OpenRouter call can complete. Narrative generation
+        # remains available in the background market build pipeline.
+        text = _fallback_idea_text(out)
+        out.setdefault("unified_narrative", text)
+        out.setdefault("idea_article_ru", text)
+        out.setdefault("description", text)
+        out.setdefault("summary", text)
+        out["text_source"] = out["textSource"] = "local_safe"
+        out["narrative_source"] = out["narrativeSource"] = "local_safe"
+        out["fallback"] = False
+        out["fallback_text"] = False
+        out["is_fallback_text"] = False
     try:
         from app.services.prop_engine import prop_engine
         out = prop_engine.enrich_idea(out)

--- a/tests/test_market_ideas_timeout.py
+++ b/tests/test_market_ideas_timeout.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.services.timing import timing_log
+
+
+def test_ideas_market_returns_immediately_while_cache_warms(monkeypatch) -> None:
+    monkeypatch.setattr(main, "_queue_market_ideas_refresh", lambda: True)
+    monkeypatch.setitem(main.MARKET_IDEAS_CACHE, "payload", None)
+    monkeypatch.setitem(main.MARKET_IDEAS_CACHE, "updated_at_epoch", 0.0)
+
+    response = TestClient(main.app).get("/ideas/market")
+
+    assert response.status_code == 200
+    assert response.json()["cache_status"] == "warming"
+    assert response.json()["diagnostics"]["reason"] == "market_refresh_running_in_background"
+
+
+def test_ideas_market_serves_stale_cache_and_queues_refresh(monkeypatch) -> None:
+    queued: list[bool] = []
+    monkeypatch.setattr(main, "_queue_market_ideas_refresh", lambda: queued.append(True) or True)
+    monkeypatch.setitem(main.MARKET_IDEAS_CACHE, "payload", {"ideas": [{"symbol": "EURUSD", "signal": "WAIT"}], "archive": []})
+    monkeypatch.setitem(main.MARKET_IDEAS_CACHE, "updated_at_epoch", 1.0)
+
+    response = TestClient(main.app).get("/ideas/market")
+
+    assert response.status_code == 200
+    assert response.json()["cache_status"] == "stale_refreshing"
+    assert response.json()["ideas"][0]["symbol"] == "EURUSD"
+    assert queued == [True]
+
+
+def test_timing_log_emits_start_end_and_elapsed(caplog) -> None:
+    test_logger = logging.getLogger("timing-test")
+    with caplog.at_level(logging.INFO):
+        with timing_log(test_logger, "build_market"):
+            pass
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("operation=build_market event=START" in message for message in messages)
+    assert any("operation=build_market event=END elapsed_ms=" in message for message in messages)
+
+
+def test_json_render_enrichment_never_calls_external_llm(monkeypatch) -> None:
+    import sitecustomize
+
+    monkeypatch.setattr(sitecustomize, "_call_openrouter", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("network call")))
+
+    enriched = sitecustomize._enrich_idea({"symbol": "EURUSD", "signal": "WAIT"})
+
+    assert enriched["narrative_source"] == "local_safe"
+    assert enriched["unified_narrative"]


### PR DESCRIPTION
### Motivation

- Найдена причина долгих ответов: `JSONResponse.render` выполнял синхронный внешний LLM-запрос (OpenRouter) в критическом пути рендера, что приводило к 25–30s задержкам и 499 на Render.
- Нужно быстро вернуть результат `/ideas/market` и иметь структурированные метрики времени для поиска функций, занимающих >5s, без изменения логики сигналов.

### Description

- Добавлен утилитарный timing helper `app/services/timing.py` и запись парных логов `START` / `END` с `elapsed_ms` и флагом `slow_over_5s` для диагностирования медленных участков.
- Внедрены timing-спаны вокруг ключевых этапов: `build_market`, `generate_trade_ideas`, `enrich_ideas_with_prop_scores`, `enrich_idea_with_openai_narrative`, `options_analysis`, `CME_OptionsFX` и `chart_endpoint`.
- Убран сетевой LLM-вызов из JSON render path (`sitecustomize.py`): теперь при отсутствии narrative возвращается локальный безопасный текст, а генерация narrative выполняется вне критического пути (в фоне/во время сборки рынка).
- `/ideas/market` переведён на стратегию stale-while-revalidate: добавлен процесс фонового построения рынка с кэшем `MARKET_IDEAS_CACHE`, функция очереди `_queue_market_ideas_refresh()`, автозапуск при старте и быстрые ответы `warming`/`stale_refreshing` без блокирования HTTP-запроса.
- Обновлены места интеграции: `app/main.py`, `app/services/prop_signal_engine.py`, `app/services/openai_idea_narrative.py`, `app/services/options_analysis.py`, `app/services/external_signal_adapter.py`, а также README с инструкцией по диагностике логов.
- Добавлен тест `tests/test_market_ideas_timeout.py`, который проверяет поведение кэша/прогрева, выдачу stale-кэша и формат timing-логов.

### Testing

- Запущены юнит-тесты для набора, затрагивающего изменения: `tests/test_market_ideas_timeout.py`, `tests/test_openai_idea_narrative.py`, `tests/test_mt4_options_bridge.py` и связанные проверки; все прогнанные тесты успешно прошли (в сумме по запускам — 17 passed, 4 warnings).
- Выполнена статическая компиляция: `python -m py_compile` для изменённых модулей — пройдено.
- Проверен `git diff --check` — проблем не найдено.
- Примечание: полный `pytest -q` сборка проекта прерывается на существующих в репозитории, не связанных с этими изменениями, ошибках импорта/синтаксиса (отсутствующие экспорты `canonical_market_service`/`trade_idea_service`/`signal_analytics_service` из `app.main` и некорректный `from **future** import annotations` в `app/services/chart_snapshot_service.py`), поэтому выполнены целевые тесты, покрывающие изменения и регрессию по времени ответа.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21bc9299308331aef8fdf76a4cdcf9)