### PR TITLE
Fix MT4 market_context propagation to `/api/ideas`

### DIFF
--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -342,7 +342,8 @@ def _dpoc_context(idea: dict[str, Any], symbol: str, timeframe: str, direction: 
         current_price = _num(candles[-1].get("close"))
     if current_price is None:
         current_price = _num(idea.get("entry") or idea.get("entry_price"))
-    sources = [idea, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None, get_latest_volume_cluster(symbol, timeframe)]
+    market_context = idea.get("market_context") if isinstance(idea.get("market_context"), dict) else None
+    sources = [idea, market_context, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None, get_latest_volume_cluster(symbol, timeframe)]
     for payload in sources:
         context = build_dpoc_context(payload, symbol, current_price)
         if context.get("available"):
@@ -356,7 +357,8 @@ def _margin_zone_context(idea: dict[str, Any], symbol: str, timeframe: str, cand
     if current_price is None and candles:
         current_price = _num(candles[-1].get("close"))
     entry_price = _num(idea.get("entry") or idea.get("entry_price"))
-    sources = [idea, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None, get_latest_volume_cluster(symbol, timeframe)]
+    market_context = idea.get("market_context") if isinstance(idea.get("market_context"), dict) else None
+    sources = [idea, market_context, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None, get_latest_volume_cluster(symbol, timeframe)]
     for payload in sources:
         context = build_margin_zone_context(payload, symbol, current_price, entry_price)
         if context.get("available"):

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -486,7 +486,8 @@ def _dpoc_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
     if current_price is None:
         current_price = _to_float(idea.get("entry") or idea.get("entry_price"))
 
-    sources = [idea, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None]
+    market_context = idea.get("market_context") if isinstance(idea.get("market_context"), dict) else None
+    sources = [idea, market_context, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None]
     if symbol:
         sources.append(get_latest_volume_cluster(symbol, timeframe))
     for payload in sources:
@@ -509,7 +510,8 @@ def _margin_zone_context(idea: dict[str, Any]) -> dict[str, Any]:
         current_price = _to_float(candles[-1].get("close"))
     entry_price = _to_float(idea.get("entry") or idea.get("entry_price"))
 
-    sources = [idea, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None]
+    market_context = idea.get("market_context") if isinstance(idea.get("market_context"), dict) else None
+    sources = [idea, market_context, idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None]
     if symbol:
         sources.append(get_latest_volume_cluster(symbol, timeframe))
     for payload in sources:
@@ -1078,6 +1080,14 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
 def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(idea, dict):
         return idea
+    market_context = idea.get("market_context") if isinstance(idea.get("market_context"), dict) else {}
+    logger.debug(
+        "prop_signal_market_context_before_score symbol=%s dpoc_price=%s margin_lower=%s margin_upper=%s",
+        idea.get("symbol") or idea.get("pair") or idea.get("instrument"),
+        market_context.get("dpoc_price"),
+        market_context.get("margin_lower"),
+        market_context.get("margin_upper"),
+    )
     score = build_prop_signal_score(idea)
     advisor_signal = _advisor_signal_from_idea(idea, score)
     enriched = dict(idea)

--- a/tests/test_mt4_margin_zones.py
+++ b/tests/test_mt4_margin_zones.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 from app.main import api_mt4_ingest_get
@@ -104,6 +105,34 @@ def test_margin_zone_confluence_adjusts_score_and_is_exposed_in_enriched_idea():
     assert "distance_to_dpoc_pips" in enriched
 
 
+def test_market_context_fields_feed_score_and_enriched_idea(caplog):
+    idea = {
+        **_idea(symbol="AUDCAD", close=0.9100),
+        "market_context": {
+            "dpoc_price": 0.9080,
+            "margin_lower": 0.9090,
+            "margin_upper": 0.9110,
+            "margin_zone_lower": 0.9090,
+            "margin_zone_upper": 0.9110,
+        },
+    }
+
+    score = build_prop_signal_score(idea)
+    with caplog.at_level(logging.DEBUG, logger="app.services.prop_signal_engine"):
+        enriched = enrich_idea_with_prop_score(idea)
+
+    for payload in (score, enriched):
+        assert payload["dpoc_price"] == 0.9080
+        assert payload["margin_lower"] == 0.9090
+        assert payload["margin_upper"] == 0.9110
+        assert payload["margin_zone_lower"] == 0.9090
+        assert payload["margin_zone_upper"] == 0.9110
+
+    assert "dpoc_price=0.908" in caplog.text
+    assert "margin_lower=0.909" in caplog.text
+    assert "margin_upper=0.911" in caplog.text
+
+
 def test_api_ideas_exposes_dpoc_and_margin_zone_fields(monkeypatch):
     from app import main
 
@@ -111,9 +140,13 @@ def test_api_ideas_exposes_dpoc_and_margin_zone_fields(monkeypatch):
         return {
             **_idea(symbol=symbol),
             "timeframe": timeframe,
-            "dpoc_price": 0.6080,
-            "margin_lower": 0.6090,
-            "margin_upper": 0.6110,
+            "market_context": {
+                "dpoc_price": 0.6080,
+                "margin_lower": 0.6090,
+                "margin_upper": 0.6110,
+                "margin_zone_lower": 0.6090,
+                "margin_zone_upper": 0.6110,
+            },
         }
 
     monkeypatch.setattr(main, "build_signal_from_candles", signal)


### PR DESCRIPTION
### Motivation
- Исправить потерю полей DPOC / Margin (например `dpoc_price`, `margin_lower`, `margin_upper`, `margin_zone_*`) при прохождении данных от `/api/mt4/ingest-get` через `market_context` в `build_prop_signal_score()` и далее в `/api/ideas`.
- Добавить диагностическое логирование, чтобы видно было, какие значения приходят в `market_context` перед расчётом score.

### Description
- Добавлен учёт `market_context` как дополнительного источника для поиска DPOC и Margin Zone в `app/services/prop_signal_engine.py` (функции `_dpoc_context` и `_margin_zone_context`) без изменения существующей логики расчёта; приоритет существующих источников сохранён.
- То же исправление внесено в recovery-патч `app/core/prop_score_recovery_patch.py`, чтобы fallback-путь также не терял реальные MT4-поля.
- Перед вызовом `build_prop_signal_score()` добавлено DEBUG-логирование полей `market_context.dpoc_price`, `market_context.margin_lower` и `market_context.margin_upper` в `enrich_idea_with_prop_score()` (логгер модуля `app.services.prop_signal_engine`).
- Обновлены/добавлены регрессионные тесты в `tests/test_mt4_margin_zones.py`, чтобы проверять передачу полей из `market_context` в возвращаемый `score`, в обогащённую идею и в ответ `api_ideas`.

### Testing
- Запущены `pytest -q tests/test_mt4_dpoc.py tests/test_mt4_margin_zones.py`, результат: `9 passed` and no failures.
- Проверен синтаксис компиляцией: `python -m py_compile app/services/prop_signal_engine.py app/core/prop_score_recovery_patch.py tests/test_mt4_margin_zones.py` — успешно.
- Выполнена проверка `git diff --check` — конфликтов/whitespace-ошибок не обнаружено.
- Полный `pytest -q` не был успешен на этапе collection по причинам, не связанным с изменениями в этом PR: в репозитории есть незавершённые ошибки импорта/синтаксиса (отдельные модули экспортов и `from **future** import annotations`), которые требуют отдельного исправления.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b5fbcfa48331948a27a1bbf39249)