### PR TITLE
Исправление fallback выбора DPOC/Margin в MT4 volume-cluster

### DIFF
--- a/app/services/mt4_volume_cluster_bridge.py
+++ b/app/services/mt4_volume_cluster_bridge.py
@@ -235,6 +235,49 @@ def build_volume_delta_priority_snapshot(payload: dict[str, Any], symbol: str = 
     }
 
 
+def _has_dpoc_or_margin_zone(payload: dict[str, Any] | None) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    has_dpoc = extract_dpoc_price(payload) is not None
+    has_margin = (
+        _nested_float(payload, "margin_lower", "margin_zone_lower") is not None
+        and _nested_float(payload, "margin_upper", "margin_zone_upper") is not None
+    )
+    return has_dpoc or has_margin
+
+
+def _is_fresh_payload(payload: dict[str, Any] | None) -> bool:
+    return isinstance(payload, dict) and not is_stale(payload.get("timestamp") or payload.get("received_at"))
+
+
+def _merge_missing_rich_fields(record: dict[str, Any], fallback: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(fallback, dict) or not _has_dpoc_or_margin_zone(fallback):
+        return record
+    merged = dict(record)
+    if extract_dpoc_price(merged) is None and extract_dpoc_price(fallback) is not None:
+        merged["dpoc_price"] = extract_dpoc_price(fallback)
+        merged["dpoc"] = (
+            fallback.get("dpoc")
+            if isinstance(fallback.get("dpoc"), dict)
+            else build_dpoc_context(merged, str(merged.get("symbol") or ""))
+        )
+        merged["distance_to_dpoc_pips"] = (
+            merged.get("dpoc", {}).get("distance_to_dpoc_pips")
+            if isinstance(merged.get("dpoc"), dict)
+            else fallback.get("distance_to_dpoc_pips")
+        )
+    has_margin = (
+        _nested_float(merged, "margin_lower", "margin_zone_lower") is not None
+        and _nested_float(merged, "margin_upper", "margin_zone_upper") is not None
+    )
+    if not has_margin:
+        for key in ("margin_lower", "margin_upper", "margin_zone_lower", "margin_zone_upper", "margin_source"):
+            value = fallback.get(key)
+            if value is not None:
+                merged[key] = value
+    return merged
+
+
 def save_volume_cluster_payload(payload: dict[str, Any]) -> dict[str, Any]:
     symbol = normalize_broker_symbol(payload.get("symbol") or payload.get("broker_symbol"))
     timeframe = str(payload.get("timeframe") or "H1").upper().strip()
@@ -260,19 +303,41 @@ def save_volume_cluster_payload(payload: dict[str, Any]) -> dict[str, Any]:
     record["volume_delta_is_proxy"] = record["volume_delta"].get("is_proxy")
     record["volume_delta_priority_used"] = record["volume_delta"].get("priority_used")
     record["received_at"] = datetime.now(timezone.utc).isoformat()
+
+    previous_symbol_record = _STORE.get(symbol)
     _STORE[f"{symbol}:{timeframe}"] = record
-    _STORE[symbol] = record
+    _STORE[symbol] = (
+        record
+        if _has_dpoc_or_margin_zone(record)
+        else _merge_missing_rich_fields(record, previous_symbol_record)
+    )
     return record
 
 
 def get_latest_volume_cluster(symbol: str, timeframe: str | None = None) -> dict[str, Any] | None:
     normalized = normalize_broker_symbol(symbol)
-    key = f"{normalized}:{str(timeframe or '').upper().strip()}" if timeframe else normalized
-    payload = _STORE.get(key)
-    if payload is None and timeframe:
-        payload = _STORE.get(normalized)
-    if not isinstance(payload, dict):
+    requested_timeframe = str(timeframe or "").upper().strip()
+    fallback_keys: list[str] = []
+    if requested_timeframe:
+        fallback_keys.append(f"{normalized}:{requested_timeframe}")
+    for candidate_timeframe in ("H1", "M15"):
+        key = f"{normalized}:{candidate_timeframe}"
+        if key not in fallback_keys:
+            fallback_keys.append(key)
+    if normalized not in fallback_keys:
+        fallback_keys.append(normalized)
+
+    fresh_payloads = [
+        _STORE.get(key)
+        for key in fallback_keys
+        if _is_fresh_payload(_STORE.get(key))
+    ]
+    if not fresh_payloads:
         return None
-    if is_stale(payload.get("timestamp") or payload.get("received_at")):
-        return None
-    return payload
+
+    selected = fresh_payloads[0]
+    for fallback in fresh_payloads[1:]:
+        selected = _merge_missing_rich_fields(selected, fallback)
+        if _has_dpoc_or_margin_zone(selected):
+            break
+    return selected

--- a/tests/test_mt4_margin_zones.py
+++ b/tests/test_mt4_margin_zones.py
@@ -87,6 +87,45 @@ def test_mt4_bridge_stores_margin_zone_fields_and_ingest_aliases():
     assert stored["margin_source"] == "Future_Volume_v5.00"
 
 
+def test_h1_dpoc_margin_survive_later_m15_ingest_without_rich_fields():
+    now = datetime.now(timezone.utc).isoformat()
+    save_volume_cluster_payload(
+        {
+            "symbol": "GBPJPY",
+            "timeframe": "H1",
+            "timestamp": now,
+            "close": 191.40,
+            "dpoc_price": 191.20,
+            "margin_lower": 191.10,
+            "margin_upper": 191.30,
+        }
+    )
+    save_volume_cluster_payload(
+        {
+            "symbol": "GBPJPY",
+            "timeframe": "M15",
+            "timestamp": now,
+            "close": 191.45,
+            "tick_volume": 100,
+        }
+    )
+
+    exact_m15 = get_latest_volume_cluster("GBPJPY", "M15")
+    symbol_level = get_latest_volume_cluster("GBPJPY")
+    score = build_prop_signal_score({**_idea(symbol="GBPJPY", close=191.45), "timeframe": "M15"})
+
+    assert exact_m15["dpoc_price"] == 191.20
+    assert exact_m15["margin_lower"] == 191.10
+    assert exact_m15["margin_upper"] == 191.30
+    assert symbol_level["dpoc_price"] == 191.20
+    assert symbol_level["margin_zone_lower"] == 191.10
+    assert score["dpoc_price"] == 191.20
+    assert score["distance_to_dpoc_pips"] == 25.0
+    assert score["margin_lower"] == 191.10
+    assert score["margin_upper"] == 191.30
+    assert score["margin_zone_confluence"]["available"] is True
+
+
 def test_margin_zone_confluence_adjusts_score_and_is_exposed_in_enriched_idea():
     idea = _idea()
     without_margin = build_prop_signal_score(idea)


### PR DESCRIPTION
### Motivation
- Наблюдалась потеря реальных DPOC/Margin (возвращалось `null`) при вызове `/api/ideas` из-за того, что M15-ingest без DPOC/MZ затирал H1/symbol-уровневые поля и выбор источника использовал только `symbol:timeframe` или `symbol` без правильного порядка и мерджа.
- Нужно было обеспечить корректный порядок поиска данных и не допустить перезаписи уже известных «rich» полей (DPOC/MZ) более поздними M15-записями без этих полей.

### Description
- Добавлены утилиты: `_has_dpoc_or_margin_zone`, `_is_fresh_payload` и `_merge_missing_rich_fields` для обнаружения «rich» полей и безопасного слияния fallback-данных при отсутствии DPOC/MZ в текущей записи.
- В `save_volume_cluster_payload` теперь сохраняется предыдущая symbol-запись и при отсутствии DPOC/MZ в новой записи символ-уровень получает поля из предыдущей записи вместо перезаписи пустыми значениями.
- В `get_latest_volume_cluster` реализован порядок поиска и fallback: запрошенный timeframe → `H1` → `M15` → symbol-only, с фильтрацией устаревших записей и последовательным мерджем недостающих DPOC/MZ полей из свежих fallback-пayload.
- Добавлен регрессионный тест `test_h1_dpoc_margin_survive_later_m15_ingest_without_rich_fields` в `tests/test_mt4_margin_zones.py`, проверяющий, что H1 DPOC/Margin остаются доступны и попадают в расчёт `build_prop_signal_score` для M15-идеи.

### Testing
- Прогонял тесты: `pytest -q tests/test_mt4_margin_zones.py tests/test_mt4_volume_cluster.py`, все тесты прошли (`9 passed`).
- Скомпилировал модули проверкой: `python -m compileall app/services/mt4_volume_cluster_bridge.py app/services/prop_signal_engine.py`, сборка успешна.
- Локальные unit-тесты подтверждают, что `/api/ideas` теперь получает реальные `dpoc_price`, `distance_to_dpoc_pips`, `margin_lower`, `margin_upper` и `margin_zone_confluence` при наличии H1-данных и последующем M15-ingest без rich-полей.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2209c6df348331953e425ab9563a33)