### PR TITLE
Добавить слой SignalAggregator для компактных сигналов

### DIFF
--- a/app/api/ideas_routes.py
+++ b/app/api/ideas_routes.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from fastapi import APIRouter
 
+from app.signal_aggregator import SignalAggregator
 from app.services.market_structure_overlay import attach_market_structure_overlays
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.signal_hub import DEFAULT_PAIRS
@@ -133,8 +134,8 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             payload["archive"] = _safe_attach_live_market_contracts(payload.get("archive") or [], field="archive")
             payload["ideas"] = enrich_ideas_with_prop_scores(payload.get("ideas") or [])
             payload["archive"] = enrich_ideas_with_prop_scores(payload.get("archive") or [])
-            payload["ideas"] = attach_market_structure_overlays(payload.get("ideas") or [])
-            payload["archive"] = attach_market_structure_overlays(payload.get("archive") or [])
+            payload["ideas"] = SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("ideas") or []))
+            payload["archive"] = SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("archive") or []))
             for idea in payload["ideas"]:
                 if not str(
                     idea.get("description_ru")
@@ -149,7 +150,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             logger.exception("ideas_market_failed reason=%s", exc)
             fallback_reason = f"route_exception:{type(exc).__name__}"
             return _localize_output_layer({
-                "ideas": attach_market_structure_overlays(_safe_fallback_ideas(reason=fallback_reason)),
+                "ideas": SignalAggregator.enrich_many(attach_market_structure_overlays(_safe_fallback_ideas(reason=fallback_reason))),
                 "archive": [],
                 "market": _safe_market_contracts(list(DEFAULT_PAIRS)),
                 "ok": False,
@@ -188,7 +189,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
                 fallback_reason = "no_generated_ideas_provider_or_env_issue"
                 ideas = services.trade_idea_service.fallback_ideas(reason=fallback_reason)
             ideas = enrich_ideas_with_prop_scores(ideas)
-            ideas = attach_market_structure_overlays(ideas)
+            ideas = SignalAggregator.enrich_many(attach_market_structure_overlays(ideas))
             generated_count = sum(1 for idea in ideas if str(idea.get("source")) != "fallback")
             fallback_count = len(ideas) - generated_count
             logger.info(
@@ -209,7 +210,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             logger.exception("ideas_api_failed reason=%s", exc)
             fallback_reason = f"route_exception:{type(exc).__name__}"
             return _localize_output_layer({
-                "ideas": attach_market_structure_overlays(services.trade_idea_service.fallback_ideas(reason=fallback_reason)),
+                "ideas": SignalAggregator.enrich_many(attach_market_structure_overlays(services.trade_idea_service.fallback_ideas(reason=fallback_reason))),
                 "market": market,
                 "diagnostics": {"error": str(exc), "reason": fallback_reason},
             })

--- a/app/services/idea_narrative_llm.py
+++ b/app/services/idea_narrative_llm.py
@@ -11,6 +11,7 @@ from typing import Any
 import requests
 
 from app.core.env import get_openrouter_api_key, get_openrouter_model
+from app.signal_aggregator import SignalAggregator
 
 
 logger = logging.getLogger(__name__)
@@ -450,21 +451,64 @@ class IdeaNarrativeLLMService:
 
     @staticmethod
     def _compact_facts(facts: dict[str, Any]) -> dict[str, Any]:
-        compact = dict(facts or {})
+        source = facts or {}
+        aggregation = SignalAggregator.aggregate(source)
+        compact_keys = (
+            "symbol",
+            "pair",
+            "timeframe",
+            "tf",
+            "signal",
+            "final_signal",
+            "direction",
+            "bias",
+            "entry",
+            "sl",
+            "stop_loss",
+            "tp",
+            "take_profit",
+            "rr",
+            "risk_reward",
+            "current_price",
+            "price",
+            "data_status",
+            "provider",
+            "entry_source",
+            "selected_zone_type",
+            "selected_zone_low",
+            "selected_zone_high",
+            "confidence",
+            "trade_permission",
+            "prop_score",
+            "prop_grade",
+            "prop_mode",
+            "prop_decision_ru",
+            "advisor_allowed",
+            "structure_state",
+            "key_zone",
+            "headline",
+            "summary",
+            "summary_ru",
+            "warnings",
+        )
+        compact = {key: source.get(key) for key in compact_keys if source.get(key) not in (None, "", "—")}
+        compact["symbol"] = aggregation.get("symbol") or compact.get("symbol") or compact.get("pair")
+        compact["timeframe"] = aggregation.get("timeframe") or compact.get("timeframe") or compact.get("tf")
+        compact["direction"] = aggregation.get("direction") or compact.get("direction")
+        compact["score"] = aggregation.get("score")
+        compact["signals"] = aggregation.get("signals") or {}
 
-        candles = compact.get("candles")
+        candles = source.get("candles")
         if isinstance(candles, list):
-            compact["candles"] = candles[-80:]
+            compact["candles"] = candles[-20:]
 
-        for key in (
-            "raw",
-            "debug",
-            "logs",
-            "diagnostics",
-            "prompt",
-            "system",
-        ):
-            compact.pop(key, None)
+        overlays = source.get("chart_overlays")
+        if isinstance(overlays, dict):
+            compact["chart_overlays"] = {
+                key: value[:6] if isinstance(value, list) else value
+                for key, value in overlays.items()
+                if key in {"order_blocks", "fvg", "liquidity", "levels"}
+            }
 
         return compact
 

--- a/app/services/openai_idea_narrative.py
+++ b/app/services/openai_idea_narrative.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from typing import Any
 
 import requests
+from app.signal_aggregator import SignalAggregator
 from app.services.signal_audit_logger import log_signal_audit
 from app.services.timing import timing_log
 
@@ -444,11 +445,13 @@ def _build_facts_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if isinstance(row, dict):
             prop_criteria.append({"key": row.get("key"), "status": row.get("status"), "score": row.get("score"), "text_ru": row.get("text_ru")})
 
+    aggregated = SignalAggregator.aggregate(payload)
+
     return {
-        "symbol": payload.get("symbol") or payload.get("pair"),
+        "symbol": aggregated.get("symbol") or payload.get("symbol") or payload.get("pair"),
         "timeframe": payload.get("timeframe") or payload.get("tf"),
         "signal": payload.get("signal"),
-        "direction": payload.get("direction"),
+        "direction": aggregated.get("direction") or payload.get("direction"),
         "entry": payload.get("entry"),
         "sl": payload.get("sl") or payload.get("stop_loss"),
         "tp": payload.get("tp") or payload.get("take_profit"),
@@ -485,6 +488,7 @@ def _build_facts_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "maxPain": options_analysis.get("maxPain"),
             "summary_ru": options_analysis.get("summary_ru"),
         },
+        "signals": aggregated.get("signals") or {},
         "warnings": _compact_warnings(payload),
     }
 

--- a/app/signal_aggregator.py
+++ b/app/signal_aggregator.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class SignalAggregator:
+    """Safe raw-market-data compressor for LLM/API signal features.
+
+    The aggregator never mutates the original idea and never removes raw data.
+    It only extracts compact feature signals that are safe to send to narrative
+    models or expose as a lightweight response enrichment.
+    """
+
+    @classmethod
+    def aggregate(cls, idea: dict[str, Any] | None) -> dict[str, Any]:
+        payload = idea if isinstance(idea, dict) else {}
+        return {
+            "symbol": cls._first(payload, "symbol", "pair"),
+            "timeframe": cls._first(payload, "timeframe", "tf"),
+            "direction": cls._direction(payload),
+            "score": cls._score(payload),
+            "signals": {
+                "options": cls._options(payload),
+                "delta": cls._delta(payload),
+                "future_volume": cls._future_volume(payload),
+                "liquidity_mz": cls._liquidity_mz(payload),
+                "dpoc": cls._dpoc(payload),
+                "margin": cls._margin(payload),
+            },
+        }
+
+    @classmethod
+    def enrich(cls, idea: dict[str, Any] | None, *, field: str = "signal_aggregation") -> dict[str, Any]:
+        result = dict(idea or {}) if isinstance(idea, dict) else {}
+        result[field] = cls.aggregate(result)
+        return result
+
+    @classmethod
+    def enrich_many(cls, ideas: Any, *, field: str = "signal_aggregation") -> list[dict[str, Any]]:
+        if not isinstance(ideas, list):
+            return []
+        return [cls.enrich(item, field=field) for item in ideas if isinstance(item, dict)]
+
+    @staticmethod
+    def _first(payload: dict[str, Any], *keys: str, default: Any = None) -> Any:
+        for key in keys:
+            value = payload.get(key)
+            if value not in (None, "", "—"):
+                return value
+        return default
+
+    @staticmethod
+    def _nested(payload: dict[str, Any], *keys: str) -> dict[str, Any]:
+        for key in keys:
+            value = payload.get(key)
+            if isinstance(value, dict):
+                return value
+        return {}
+
+    @staticmethod
+    def _num(value: Any) -> float | None:
+        try:
+            if value in (None, "", "—"):
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _score(cls, payload: dict[str, Any]) -> float | None:
+        return cls._num(cls._first(payload, "score", "prop_score", "confidence", "quality_score"))
+
+    @classmethod
+    def _direction(cls, payload: dict[str, Any]) -> str | None:
+        direction = str(cls._first(payload, "direction", "bias", "signal", "final_signal", "action", default="") or "").strip()
+        return direction or None
+
+    @classmethod
+    def _options(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        data = cls._nested(payload, "options_analysis", "options", "option_metrics", "options_context")
+        current_price = cls._num(cls._first(payload, "current_price", "price", "entry"))
+        max_pain = cls._num(cls._first(data, "maxPain", "max_pain", "max_pain_price"))
+        distance = cls._num(cls._first(data, "max_pain_distance", "distance_to_max_pain"))
+        if distance is None and current_price is not None and max_pain is not None:
+            distance = current_price - max_pain
+        return {
+            "bias": cls._first(data, "bias", "prop_bias", default=cls._first(payload, "options_bias")),
+            "max_pain_distance": distance,
+            "call_walls": cls._compact_levels(cls._first(data, "call_walls", "callWalls", "calls", "keyStrikes", default=[])),
+            "put_walls": cls._compact_levels(cls._first(data, "put_walls", "putWalls", "puts", "keyStrikes", default=[])),
+            "pinning_risk": cls._first(data, "pinning_risk", "pinningRisk", default=payload.get("pinning_risk")),
+            "range_risk": cls._first(data, "range_risk", "rangeRisk", default=payload.get("range_risk")),
+        }
+
+    @classmethod
+    def _delta(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        data = cls._nested(payload, "volume_delta", "delta", "future_delta", "orderflow")
+        cumulative = cls._num(cls._first(data, "cumulative_delta", "cumdelta", "cum_delta", "delta", default=payload.get("cumulative_delta")))
+        bias = cls._first(data, "bias", "hft_signal", "cumdelta_trend", default=None)
+        if not bias and cumulative is not None:
+            bias = "bullish" if cumulative > 0 else "bearish" if cumulative < 0 else "neutral"
+        return {
+            "cumulative_delta": cumulative,
+            "bias": bias,
+            "divergence": bool(cls._first(data, "divergence", "delta_divergence", default=payload.get("delta_divergence") or False)),
+        }
+
+    @classmethod
+    def _future_volume(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        data = cls._nested(payload, "future_volume", "volume", "volume_profile", "volume_delta")
+        return {
+            "spike": cls._first(data, "spike", "volume_spike", default=payload.get("volume_spike")),
+            "absorption": cls._first(data, "absorption", "absorption_detected", default=payload.get("absorption")),
+            "trend": cls._first(data, "trend", "volume_trend", "cumdelta_trend", default=payload.get("volume_trend")),
+        }
+
+    @classmethod
+    def _liquidity_mz(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        data = cls._nested(payload, "liquidity", "liquidity_mz", "market_structure", "mz", "margin_zones")
+        support = cls._first(payload, "support", "support_level", "selected_zone_low", default=data.get("support"))
+        resistance = cls._first(payload, "resistance", "resistance_level", "selected_zone_high", default=data.get("resistance"))
+        return {
+            "sweep": cls._first(data, "sweep", "liquidity_sweep", default=payload.get("liquidity_sweep")),
+            "nearest_zone": cls._compact_zone(cls._first(data, "nearest_zone", "zone", default=payload.get("selected_zone_type"))),
+            "support_resistance": {"support": support, "resistance": resistance},
+        }
+
+    @classmethod
+    def _dpoc(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        data = cls._nested(payload, "dpoc", "dpoc_context")
+        current_price = cls._num(cls._first(payload, "current_price", "price", "entry"))
+        dpoc_price = cls._num(cls._first(data, "dpoc_price", "price", default=payload.get("dpoc_price")))
+        distance = cls._num(cls._first(data, "distance", "distance_to_dpoc_pips", default=payload.get("distance_to_dpoc_pips")))
+        return {
+            "distance": distance,
+            "price_above_dpoc": None if current_price is None or dpoc_price is None else current_price > dpoc_price,
+        }
+
+    @classmethod
+    def _margin(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        data = cls._nested(payload, "margin_zone_confluence", "margin", "margin_zones")
+        return {
+            "level": cls._first(data, "level", "nearest_level", "margin_level", default=payload.get("margin_level")),
+            "zones": cls._compact_levels(cls._first(data, "zones", "levels", default=[
+                {"type": "lower", "price": cls._first(payload, "margin_lower", "margin_zone_lower")},
+                {"type": "upper", "price": cls._first(payload, "margin_upper", "margin_zone_upper")},
+            ])),
+        }
+
+    @classmethod
+    def _compact_levels(cls, value: Any, limit: int = 6) -> list[Any]:
+        if value in (None, "", "—"):
+            return []
+        items = value if isinstance(value, list) else [value]
+        compact: list[Any] = []
+        for item in items[:limit]:
+            if isinstance(item, dict):
+                compact.append({k: item.get(k) for k in ("type", "side", "price", "strike", "level", "size", "score") if item.get(k) is not None})
+            else:
+                compact.append(item)
+        return compact
+
+    @classmethod
+    def _compact_zone(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {k: value.get(k) for k in ("type", "price", "low", "high", "distance", "strength") if value.get(k) is not None}
+        return value
+
+
+def aggregate_signal(idea: dict[str, Any] | None) -> dict[str, Any]:
+    return SignalAggregator.aggregate(idea)


### PR DESCRIPTION
### Motivation
- Устранить падения и HTTP 400 при отправке в LLM из‑за слишком больших payload с сырыми рыночными дампами (options, future volume, delta, margin, MZ, DPOC). 
- Не менять логику `PropEngine`, мост MT4 или существующие фичи, а добавить безопасную предобработку перед вызовами LLM и при отдаче `/ideas`.

### Description
- Добавлен новый файл `app/signal_aggregator.py` с классом `SignalAggregator`, реализующим `aggregate`, `enrich` и `enrich_many`, возвращающим компактную структуру `symbol`, `timeframe`, `direction`, `score`, `signals` с секциями `options`, `delta`, `future_volume`, `liquidity_mz`, `dpoc`, `margin` и безопасными fallback-значениями. 
- В `app/services/openai_idea_narrative.py` факты для OpenAI теперь собираются с использованием `SignalAggregator.aggregate(...)` и включают только `signals` вместо больших raw-дампов, при этом оригинальные сырые данные не удаляются и остаются доступными в других местах. 
- В `app/services/idea_narrative_llm.py` метод `_compact_facts` заменён на whitelist‑компактизацию и добавляет `signal_aggregation`/`signals` из `SignalAggregator`, а также сокращает отправляемые `candles` и `chart_overlays` для уменьшения объёма. 
- В маршрутах `app/api/ideas_routes.py` ответы `/ideas/market` и `/api/ideas` теперь обогащаются компактным полем `signal_aggregation` через `SignalAggregator.enrich_many(...)` после существующих шагов `prop` и `attach_market_structure_overlays`, сохраняя совместимость и не убирая raw-данные. 
- Реализованы безопасные механизмы: ничего не ломается при отсутствии полей, всегда возвращается словарь, лимитируются списки уровней/зон, и агрегатор не мутирует исходный `idea` (только предобработка/обогащение). 
- Интеграционный хинт: вызывать `SignalAggregator.aggregate(payload)` перед сборкой фактов для LLM/OpenAI и использовать `SignalAggregator.enrich_many(ideas)` для лёгкого обогащения API-ответов без удаления исходных данных.

### Testing
- Выполнена компиляция изменённых модулей командой `python3 -m compileall app/signal_aggregator.py app/services/openai_idea_narrative.py app/services/idea_narrative_llm.py app/api/ideas_routes.py` и она прошла успешно. 
- Запущен smoke‑тест: `python3 - <<'PY' ...` с примером payload и assertion‑проверками `SignalAggregator.aggregate(...)` и тесты прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3250df9d308331bd590d82ffacd555)