### PR TITLE
Use MT4 OptionsFX data on idea cards

### DIFF
--- a/app/api/ideas_routes.py
+++ b/app/api/ideas_routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter
 
 from app.signal_aggregator import SignalAggregator
 from app.services.market_structure_overlay import attach_market_structure_overlays
+from app.services.mt4_options_bridge import get_latest_options_levels
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.signal_hub import DEFAULT_PAIRS
 from app.services.trade_idea_service import TradeIdeaService
@@ -59,6 +60,105 @@ def _localize_output_layer(payload: object) -> object:
         if ru_key:
             localized[ru_key] = localized[key]
     return localized
+
+
+def _format_options_levels(values: Any, limit: int = 6) -> str:
+    if not isinstance(values, list):
+        return "—"
+    formatted: list[str] = []
+    for value in values[:limit]:
+        try:
+            formatted.append((f"{float(value):.5f}").rstrip("0").rstrip("."))
+        except (TypeError, ValueError):
+            text = str(value or "").strip()
+            if text:
+                formatted.append(text)
+    return ", ".join(formatted) if formatted else "—"
+
+
+def _attach_mt4_optionsfx_to_idea(idea: dict) -> dict:
+    if not isinstance(idea, dict):
+        return idea
+    symbol = str(idea.get("symbol") or idea.get("pair") or idea.get("instrument") or "").upper().strip()
+    if not symbol:
+        return idea
+    try:
+        snapshot = get_latest_options_levels(symbol)
+    except Exception as exc:
+        logger.exception("ideas_mt4_optionsfx_lookup_failed symbol=%s reason=%s", symbol, exc)
+        return idea
+    if not isinstance(snapshot, dict) or not snapshot.get("available"):
+        return idea
+    analysis = snapshot.get("analysis") if isinstance(snapshot.get("analysis"), dict) else {}
+    if not analysis.get("available", True):
+        return idea
+
+    key_strikes = analysis.get("keyStrikes") or analysis.get("keyLevels") or []
+    max_pain = analysis.get("maxPain")
+    bias = analysis.get("bias") or analysis.get("prop_bias") or "neutral"
+    source = "MT4_OptionsFX"
+    summary_ru = analysis.get("summary_ru")
+    display = f"{source}: {bias} · strikes: {_format_options_levels(key_strikes)} · max pain: {_format_options_levels([max_pain] if max_pain is not None else [])}"
+
+    enriched = dict(idea)
+    enriched.update({
+        "options_source": source,
+        "optionsSource": source,
+        "options_available": True,
+        "optionsAvailable": True,
+        "options_bias": bias,
+        "optionsBias": bias,
+        "key_strikes": key_strikes,
+        "keyStrikes": key_strikes,
+        "key_levels": analysis.get("keyLevels") or key_strikes,
+        "keyLevels": analysis.get("keyLevels") or key_strikes,
+        "max_pain": max_pain,
+        "maxPain": max_pain,
+        "call_walls": analysis.get("callWalls") or [],
+        "callWalls": analysis.get("callWalls") or [],
+        "put_walls": analysis.get("putWalls") or [],
+        "putWalls": analysis.get("putWalls") or [],
+        "target_levels": analysis.get("targetLevels") or [],
+        "targetLevels": analysis.get("targetLevels") or [],
+        "hedge_levels": analysis.get("hedgeLevels") or [],
+        "hedgeLevels": analysis.get("hedgeLevels") or [],
+        "pinning_risk": analysis.get("pinningRisk"),
+        "pinningRisk": analysis.get("pinningRisk"),
+        "range_risk": analysis.get("rangeRisk"),
+        "rangeRisk": analysis.get("rangeRisk"),
+        "options_summary_ru": summary_ru,
+        "optionsSummaryRu": summary_ru,
+        "options_analysis": analysis,
+        "options_display": display,
+        "optionsDisplay": display,
+        "external_options_ru": summary_ru or display,
+        "external_options_bias": bias,
+        "external_options_key_strikes": key_strikes,
+        "external_options_max_pain": max_pain,
+        "external_options_source": source,
+        "debug_options_available": True,
+        "debug_options_source_selected": "mt4_optionsfx",
+    })
+    market_context = enriched.get("market_context") if isinstance(enriched.get("market_context"), dict) else {}
+    market_context.update({
+        "optionsAnalysis": analysis,
+        "options_available": True,
+        "options_source": source,
+        "options_summary_ru": summary_ru,
+    })
+    enriched["market_context"] = market_context
+    advisor_signal = enriched.get("advisor_signal") if isinstance(enriched.get("advisor_signal"), dict) else None
+    if advisor_signal is not None:
+        advisor_signal = dict(advisor_signal)
+        advisor_signal["external_options_source"] = source
+        enriched["advisor_signal"] = advisor_signal
+    return enriched
+
+
+def _attach_mt4_optionsfx_to_ideas(ideas: Any) -> list[dict]:
+    if not isinstance(ideas, list):
+        return []
+    return [_attach_mt4_optionsfx_to_idea(idea) for idea in ideas if isinstance(idea, dict)]
 
 
 @dataclass
@@ -113,6 +213,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             logger.exception("ideas_market_fallback_failed reason=%s fallback_error=%s", reason, exc)
             return []
 
+    @router.get("/api/ideas/market")
     @router.get("/ideas/market")
     async def market_ideas():
         try:
@@ -134,8 +235,8 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             payload["archive"] = _safe_attach_live_market_contracts(payload.get("archive") or [], field="archive")
             payload["ideas"] = enrich_ideas_with_prop_scores(payload.get("ideas") or [])
             payload["archive"] = enrich_ideas_with_prop_scores(payload.get("archive") or [])
-            payload["ideas"] = SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("ideas") or []))
-            payload["archive"] = SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("archive") or []))
+            payload["ideas"] = _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("ideas") or [])))
+            payload["archive"] = _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("archive") or [])))
             for idea in payload["ideas"]:
                 if not str(
                     idea.get("description_ru")
@@ -150,7 +251,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             logger.exception("ideas_market_failed reason=%s", exc)
             fallback_reason = f"route_exception:{type(exc).__name__}"
             return _localize_output_layer({
-                "ideas": SignalAggregator.enrich_many(attach_market_structure_overlays(_safe_fallback_ideas(reason=fallback_reason))),
+                "ideas": _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(_safe_fallback_ideas(reason=fallback_reason)))),
                 "archive": [],
                 "market": _safe_market_contracts(list(DEFAULT_PAIRS)),
                 "ok": False,
@@ -189,7 +290,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
                 fallback_reason = "no_generated_ideas_provider_or_env_issue"
                 ideas = services.trade_idea_service.fallback_ideas(reason=fallback_reason)
             ideas = enrich_ideas_with_prop_scores(ideas)
-            ideas = SignalAggregator.enrich_many(attach_market_structure_overlays(ideas))
+            ideas = _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(ideas)))
             generated_count = sum(1 for idea in ideas if str(idea.get("source")) != "fallback")
             fallback_count = len(ideas) - generated_count
             logger.info(
@@ -210,7 +311,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             logger.exception("ideas_api_failed reason=%s", exc)
             fallback_reason = f"route_exception:{type(exc).__name__}"
             return _localize_output_layer({
-                "ideas": SignalAggregator.enrich_many(attach_market_structure_overlays(services.trade_idea_service.fallback_ideas(reason=fallback_reason))),
+                "ideas": _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(services.trade_idea_service.fallback_ideas(reason=fallback_reason)))),
                 "market": market,
                 "diagnostics": {"error": str(exc), "reason": fallback_reason},
             })

--- a/app/main.py
+++ b/app/main.py
@@ -930,7 +930,7 @@ def build_market() -> dict[str, Any]:
         signals, failed_symbols = generate_trade_ideas()
 
         if signals:
-            enriched_signals = enrich_ideas_with_prop_scores(signals)
+            enriched_signals = _attach_mt4_optionsfx_display_many(enrich_ideas_with_prop_scores(signals))
             lifecycle = apply_idea_lifecycle(enriched_signals)
             return {
                 "signals": lifecycle["ideas"],
@@ -1091,6 +1091,7 @@ def _queue_market_ideas_refresh() -> bool:
     return True
 
 
+@app.get("/api/ideas/market")
 @app.get("/ideas/market")
 def ideas_market():
     with timing_log(logger, "ideas_market_request"):
@@ -4377,6 +4378,85 @@ def _extract_numeric_price(row: dict[str, Any] | None) -> tuple[float | None, st
     return None, None
 
 
+def _format_options_levels_for_display(values: Any, limit: int = 6) -> str:
+    if not isinstance(values, list):
+        return "—"
+    out: list[str] = []
+    for value in values[:limit]:
+        try:
+            out.append((f"{float(value):.5f}").rstrip("0").rstrip("."))
+        except (TypeError, ValueError):
+            text = str(value or "").strip()
+            if text:
+                out.append(text)
+    return ", ".join(out) if out else "—"
+
+
+def _attach_mt4_optionsfx_display(signal: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(signal or {})
+    symbol = normalize_symbol(str(normalized.get("symbol") or normalized.get("instrument") or normalized.get("pair") or ""))
+    if not symbol:
+        return normalized
+    try:
+        options_snapshot = get_latest_options_levels(symbol)
+    except Exception:
+        logger.exception("mt4_optionsfx_display_lookup_failed symbol=%s", symbol)
+        return normalized
+    if not isinstance(options_snapshot, dict) or not options_snapshot.get("available"):
+        return normalized
+    analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
+    key_strikes = analysis.get("keyStrikes") or analysis.get("keyLevels") or []
+    max_pain = analysis.get("maxPain")
+    bias = analysis.get("bias") or analysis.get("prop_bias") or "neutral"
+    source = "MT4_OptionsFX"
+    summary_ru = analysis.get("summary_ru")
+    display = f"{source}: {bias} · strikes: {_format_options_levels_for_display(key_strikes)} · max pain: {_format_options_levels_for_display([max_pain] if max_pain is not None else [])}"
+    normalized.update({
+        "options_source": source,
+        "optionsSource": source,
+        "options_available": True,
+        "optionsAvailable": True,
+        "options_bias": bias,
+        "optionsBias": bias,
+        "key_strikes": key_strikes,
+        "keyStrikes": key_strikes,
+        "key_levels": analysis.get("keyLevels") or key_strikes,
+        "keyLevels": analysis.get("keyLevels") or key_strikes,
+        "max_pain": max_pain,
+        "maxPain": max_pain,
+        "call_walls": analysis.get("callWalls") or [],
+        "put_walls": analysis.get("putWalls") or [],
+        "target_levels": analysis.get("targetLevels") or [],
+        "hedge_levels": analysis.get("hedgeLevels") or [],
+        "pinning_risk": analysis.get("pinningRisk"),
+        "range_risk": analysis.get("rangeRisk"),
+        "options_summary_ru": summary_ru,
+        "optionsSummaryRu": summary_ru,
+        "options_analysis": analysis,
+        "options_display": display,
+        "external_options_ru": summary_ru or display,
+        "external_options_bias": bias,
+        "external_options_key_strikes": key_strikes,
+        "external_options_max_pain": max_pain,
+        "external_options_source": source,
+        "debug_options_available": True,
+        "debug_options_source_selected": "mt4_optionsfx",
+    })
+    market_context = normalized.get("market_context") if isinstance(normalized.get("market_context"), dict) else {}
+    market_context.update({"optionsAnalysis": analysis, "options_available": True, "options_source": source, "options_summary_ru": summary_ru})
+    normalized["market_context"] = market_context
+    advisor_signal = normalized.get("advisor_signal") if isinstance(normalized.get("advisor_signal"), dict) else None
+    if advisor_signal is not None:
+        advisor_signal = dict(advisor_signal)
+        advisor_signal["external_options_source"] = source
+        normalized["advisor_signal"] = advisor_signal
+    return normalized
+
+
+def _attach_mt4_optionsfx_display_many(signals: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [_attach_mt4_optionsfx_display(signal) for signal in signals if isinstance(signal, dict)]
+
+
 def _normalize_quote_signal(signal: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(signal or {})
     symbol = normalize_symbol(str(normalized.get("symbol") or normalized.get("instrument") or ""))
@@ -4402,7 +4482,7 @@ def _normalize_quote_signal(signal: dict[str, Any]) -> dict[str, Any]:
         options_available = bool(options_snapshot.get("available"))
         analysis = options_snapshot.get("analysis") if isinstance(options_snapshot.get("analysis"), dict) else {}
         normalized["options_available"] = options_available
-        normalized["options_source"] = options_snapshot.get("source")
+        normalized["options_source"] = "MT4_OptionsFX" if options_available else options_snapshot.get("source")
         normalized["options_summary_ru"] = (
             str(analysis.get("summary_ru") or "").strip()
             if options_available
@@ -4414,7 +4494,7 @@ def _normalize_quote_signal(signal: dict[str, Any]) -> dict[str, Any]:
         market_context["options_available"] = options_available
         market_context["options_source"] = normalized["options_source"] if options_available else "unavailable"
         normalized["market_context"] = market_context
-    return normalized
+    return _attach_mt4_optionsfx_display(normalized)
 
 
 

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -111,24 +111,41 @@ function formatListValue(value) {
   return String(value);
 }
 
+function resolveOptionsSourceLabel(idea) {
+  const source = firstText(idea.options_source, idea.optionsSource, idea.external_options_source);
+  return source === "MT4_OptionsFX" || String(source).toLowerCase() === "mt4_optionsfx" ? "MT4_OptionsFX" : "CME_OptionsFX";
+}
+
 function resolveExternalOptionsRu(idea) {
   return firstText(
+    idea.options_summary_ru,
+    idea.optionsSummaryRu,
     idea.external_options_ru,
     idea.advisor_signal?.external_options_filter?.text_ru,
     idea.prop_signal_score?.external_options_filter?.text_ru,
-  ) || "CME_OptionsFX: нет данных, слой не блокирует сделку";
+  ) || `${resolveOptionsSourceLabel(idea)}: нет данных, слой не блокирует сделку`;
 }
 
 function resolveExternalOptionsBias(idea) {
   return firstText(
+    idea.options_bias,
+    idea.optionsBias,
     idea.external_options_bias,
     idea.advisor_signal?.external_options_filter?.option_bias,
     idea.prop_signal_score?.external_options_filter?.option_bias,
   ) || "neutral";
 }
 
+function resolveOptionsKeyStrikes(idea) {
+  return idea.key_strikes || idea.keyStrikes || idea.key_levels || idea.keyLevels || idea.external_options_key_strikes;
+}
+
+function resolveOptionsMaxPain(idea) {
+  return idea.max_pain ?? idea.maxPain ?? idea.external_options_max_pain;
+}
+
 function renderExternalOptionsCompact(idea) {
-  return `<div class="idea-news-line">CME_OptionsFX: <strong>${escapeHtml(resolveExternalOptionsBias(idea))}</strong> · strikes: ${escapeHtml(formatListValue(idea.external_options_key_strikes))} · max pain: ${escapeHtml(formatListValue(idea.external_options_max_pain))}</div>`;
+  return `<div class="idea-news-line">${escapeHtml(resolveOptionsSourceLabel(idea))}: <strong>${escapeHtml(resolveExternalOptionsBias(idea))}</strong> · strikes: ${escapeHtml(formatListValue(resolveOptionsKeyStrikes(idea)))} · max pain: ${escapeHtml(formatListValue(resolveOptionsMaxPain(idea)))}</div>`;
 }
 
 
@@ -585,7 +602,7 @@ function openIdeaModal(idea) {
         <div><span>До DPOC</span><strong>${escapeHtml(dpoc.distance)}</strong></div>
       </div>
       <p class="modal-text"><strong>Новости/фундаментал:</strong> ${escapeHtml(resolveNewsContext(idea))}</p>
-      <p class="modal-text"><strong>Options/CME confirmation:</strong> ${escapeHtml(resolveExternalOptionsRu(idea))}<br><strong>Bias:</strong> ${escapeHtml(resolveExternalOptionsBias(idea))}; <strong>Key strikes:</strong> ${escapeHtml(formatListValue(idea.external_options_key_strikes))}; <strong>Max pain:</strong> ${escapeHtml(formatListValue(idea.external_options_max_pain))}</p>
+      <p class="modal-text"><strong>Options confirmation:</strong> ${escapeHtml(resolveExternalOptionsRu(idea))}<br><strong>Source:</strong> ${escapeHtml(resolveOptionsSourceLabel(idea))}; <strong>Bias:</strong> ${escapeHtml(resolveExternalOptionsBias(idea))}; <strong>Key strikes:</strong> ${escapeHtml(formatListValue(resolveOptionsKeyStrikes(idea)))}; <strong>Max pain:</strong> ${escapeHtml(formatListValue(resolveOptionsMaxPain(idea)))}</p>
       <p class="modal-text"><strong>CumDelta source:</strong> ${escapeHtml(volumeDeltaSourceLabel(resolveVolumeDelta(idea).source))}; <strong>Delta divergence:</strong> ${resolveVolumeDelta(idea).divergence ? "true" : "false"}; <strong>Price/CumDelta:</strong> ${escapeHtml(resolveVolumeDelta(idea).priceTrend)} / ${escapeHtml(resolveVolumeDelta(idea).cumdeltaTrend)}</p>
       <p class="modal-text"><strong>Источник:</strong> ${escapeHtml(idea.data_provider || idea.provider || "нет данных")}</p>
       <p class="modal-text"><strong>Setup:</strong> ${escapeHtml(idea.setup_type || "—")}; <strong>BOS:</strong> ${escapeHtml(idea.market_structure?.bos || "—")}; <strong>Sweep:</strong> ${escapeHtml(idea.liquidity?.sweep || "—")}; <strong>FVG:</strong> ${escapeHtml(idea.fvg?.type || idea.selected_zone_type || "—")}; <strong>HTF bias:</strong> ${escapeHtml(idea.htf_bias || idea.market_structure?.trend_regime || "—")}</p>


### PR DESCRIPTION
### Motivation
- Корень проблемы: карточки `/ideas` брали текст из полей `external_options_*`, которые заполнялись слоем CME/Telegram после расчёта score, тогда как свежие снапшоты MT4 OptionsFX оставались в бэкенд-области и не показывались пользователю.  
- Цель изменений: минимально приоритизировать данные из `get_latest_options_levels(symbol)` (MT4 OptionsFX) для всех идей в `/ideas` и `/api/ideas(/market)`, при этом не удаляя существующий CME/Telegram fallback и не ломая логику скоринга.  
- Ограничения соблюдены: не удалял ingestion MT4, не трогал score-логику, внес минимальные изменения в pipeline и UI для корректного отображения.  

### Description
- В `app/api/ideas_routes.py` добавлены функции форматирования и приклейки MT4 OptionsFX (`_format_options_levels`, `_attach_mt4_optionsfx_to_idea`, `_attach_mt4_optionsfx_to_ideas`) и импорт `get_latest_options_levels`, после чего pipeline `/ideas/market` и `/api/ideas` обогащает идеи MT4-данными, если они доступны.  
- В `app/main.py` добавлен аналогичный MT4-override для market-пайплайна (`_format_options_levels_for_display`, `_attach_mt4_optionsfx_display`, `_attach_mt4_optionsfx_display_many`) и интеграция в `build_market`/`_normalize_quote_signal`, чтобы оба backend-пути возвращали MT4-first поля после prop-score.  
- В статических фронтенд-скриптах `app/static/ideas.js` реализовано определение `MT4_OptionsFX` как приоритетного источника (`resolveOptionsSourceLabel`, `resolveOptionsKeyStrikes`, `resolveOptionsMaxPain`) и обновлён compact/modal рендер так, чтобы отображать `MT4_OptionsFX: <bias> · strikes: <key_strikes> · max pain: <max_pain or —>` и показывать strikes даже при `maxPain == null`; CME остаётся fallback.  
- Поля, которые теперь гарантированно пробрасываются из MT4 snapshot в идею: `options_source/optionsSource`, `options_available/optionsAvailable`, `options_bias/optionsBias`, `key_strikes/keyStrikes/key_levels/keyLevels`, `max_pain/maxPain`, `call_walls/callWalls`, `put_walls/putWalls`, `target_levels/targetLevels`, `hedge_levels/hedgeLevels`, `pinning_risk/pinningRisk`, `range_risk/rangeRisk`, `options_summary_ru/optionsSummaryRu` и совместимые `external_options_*` для обратной совместимости UI.  

### Testing
- Запуск статической проверки синтаксиса `python3 -m py_compile app/main.py app/api/ideas_routes.py` прошёл успешно.  
- Прогон релевантных unit тестов `pytest -q tests/test_mt4_options_bridge.py tests/api/test_options_levels_api.py` завершился успешно (в финальном прогоне сборки все тесты прошли: `11 passed, 4 warnings`).  
- Во время разработки сначала тест `test_ideas_market_contains_options_available_after_ingest` временно падал на этапе интеграции публичного market-эндоинта из-за поведения warming cache, после корректировки интеграции в `app/main.py` и `app/api/ideas_routes.py` финальная тестовая сессия прошла зелёной.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32a948929c8331b7cc64035e1f8900)