### PR TITLE
Интеграция новостного календаря и блокировка сделок в lifecycle идей

### DIFF
--- a/app/api/ideas_routes.py
+++ b/app/api/ideas_routes.py
@@ -17,6 +17,7 @@ from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.prop_desk_filters import PropDeskFilterService
 from app.services.signal_hub import DEFAULT_PAIRS
 from app.services.trade_idea_service import TradeIdeaService
+from app.services.idea_lifecycle import enrich_ideas_with_news_calendar
 from backend.market.services.snapshot_service import MarketSnapshotService
 
 logger = logging.getLogger(__name__)
@@ -271,6 +272,7 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
             payload["ideas"] = _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("ideas") or [])))
             payload["archive"] = _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(payload.get("archive") or [])))
             payload["ideas"] = _apply_prop_desk_filters(payload.get("ideas") or [], archive=payload.get("archive") or [])
+            payload["ideas"] = enrich_ideas_with_news_calendar(payload.get("ideas") or [])
             for idea in payload["ideas"]:
                 if not str(
                     idea.get("description_ru")
@@ -284,8 +286,11 @@ def build_ideas_router(services: IdeasRouteServices) -> APIRouter:
         except Exception as exc:
             logger.exception("ideas_market_failed reason=%s", exc)
             fallback_reason = f"route_exception:{type(exc).__name__}"
+            fallback_ideas = _attach_mt4_optionsfx_to_ideas(
+                SignalAggregator.enrich_many(attach_market_structure_overlays(_safe_fallback_ideas(reason=fallback_reason)))
+            )
             return _localize_output_layer({
-                "ideas": _attach_mt4_optionsfx_to_ideas(SignalAggregator.enrich_many(attach_market_structure_overlays(_safe_fallback_ideas(reason=fallback_reason)))),
+                "ideas": enrich_ideas_with_news_calendar(fallback_ideas),
                 "archive": [],
                 "market": _safe_market_contracts(list(DEFAULT_PAIRS)),
                 "ok": False,

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.prop_desk_filters import PropDeskFilterService
-from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_stats
+from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_stats, enrich_ideas_with_news_calendar
 from app.services.signal_audit_logger import log_signal_audit
 from app.services.timing import timing_log
 from backend.chat_service import ChatRequest, ForexChatService
@@ -985,6 +985,7 @@ def build_market() -> dict[str, Any]:
             enriched_signals = _attach_mt4_optionsfx_display_many(enrich_ideas_with_prop_scores(signals))
             lifecycle = apply_idea_lifecycle(enriched_signals)
             lifecycle["ideas"] = _apply_prop_desk_execution(lifecycle["ideas"], lifecycle.get("archive") or [])
+            lifecycle["ideas"] = enrich_ideas_with_news_calendar(lifecycle["ideas"])
             return {
                 "signals": lifecycle["ideas"],
                 "ideas": lifecycle["ideas"],
@@ -1090,6 +1091,7 @@ def api_ideas():
         enriched_signals = enrich_ideas_with_prop_scores(signals)
         lifecycle = apply_idea_lifecycle(enriched_signals)
         lifecycle["ideas"] = _apply_prop_desk_execution(lifecycle["ideas"], lifecycle.get("archive") or [])
+        lifecycle["ideas"] = enrich_ideas_with_news_calendar(lifecycle["ideas"])
         return {
             "signals": lifecycle["ideas"],
             "ideas": lifecycle["ideas"],

--- a/app/services/idea_lifecycle.py
+++ b/app/services/idea_lifecycle.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from app.services.news_calendar import nearest_news_for_symbol
+
 ACTIVE_FILE = Path("active_ideas.json")
 ARCHIVE_FILE = Path("archive.json")
 
@@ -167,6 +169,82 @@ def _sentiment_and_fundamental_fields(idea: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+
+def enrich_idea_with_news_calendar(idea: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(idea, dict):
+        return idea
+    symbol = normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    try:
+        news = nearest_news_for_symbol(symbol) if symbol else {}
+    except Exception:
+        news = {
+            "news_event": None,
+            "news_currency": None,
+            "news_impact": None,
+            "news_time_utc": None,
+            "minutes_to_event": None,
+            "news_lock_active": False,
+            "news_source": "unavailable",
+        }
+
+    for key in (
+        "news_event",
+        "news_currency",
+        "news_impact",
+        "news_time_utc",
+        "minutes_to_event",
+        "news_lock_active",
+        "news_source",
+    ):
+        idea[key] = news.get(key)
+
+    if bool(news.get("news_lock_active")):
+        capped_score = _int_score(idea.get("score"))
+        if capped_score is None:
+            capped_score = _int_score(idea.get("prop_score"))
+        if capped_score is None:
+            advisor = idea.get("advisor_signal") if isinstance(idea.get("advisor_signal"), dict) else {}
+            capped_score = _int_score(advisor.get("score"))
+        if capped_score is None:
+            prop = idea.get("prop_signal_score") if isinstance(idea.get("prop_signal_score"), dict) else {}
+            capped_score = _int_score(prop.get("score"))
+        capped_score = min(capped_score if capped_score is not None else 54, 54)
+
+        idea["trade_permission"] = False
+        idea["advisor_allowed"] = False
+        idea["mode"] = "NO TRADE"
+        idea["prop_mode"] = "no_trade"
+        idea["grade"] = "C"
+        idea["prop_grade"] = "C"
+        idea["score"] = capped_score
+        idea["confidence"] = capped_score
+        idea["prop_score"] = capped_score
+        idea["propScore"] = capped_score
+        idea["propConfidence"] = capped_score
+
+        advisor = idea.get("advisor_signal") if isinstance(idea.get("advisor_signal"), dict) else None
+        if advisor is not None:
+            advisor["allowed"] = False
+            advisor["mode"] = "no_trade"
+            advisor["grade"] = "C"
+            advisor["score"] = capped_score
+
+        prop = idea.get("prop_signal_score") if isinstance(idea.get("prop_signal_score"), dict) else None
+        if prop is not None:
+            prop["mode"] = "no_trade"
+            prop["grade"] = "C"
+            prop["score"] = capped_score
+
+    return idea
+
+
+def enrich_ideas_with_news_calendar(ideas: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    enriched: list[dict[str, Any]] = []
+    for idea in ideas or []:
+        if isinstance(idea, dict):
+            enriched.append(_with_advisor_compat_fields(enrich_idea_with_news_calendar(dict(idea))))
+    return enriched
+
 def _with_advisor_compat_fields(idea: dict[str, Any]) -> dict[str, Any]:
     """Expose flat advisor fields first so MT4's simple parser sees them before candles."""
     if not isinstance(idea, dict):
@@ -302,7 +380,7 @@ def _active_view(active: dict[str, Any], live_idea: dict[str, Any] | None = None
         idea["live_price"] = price_of(live_idea)
         idea["live_score"] = live_idea.get("prop_score")
         idea["live_grade"] = live_idea.get("prop_grade")
-    return _with_advisor_compat_fields(idea)
+    return _with_advisor_compat_fields(enrich_idea_with_news_calendar(idea))
 
 
 def _hit_status(active: dict[str, Any], current_price: float | None) -> tuple[str | None, float | None]:
@@ -369,7 +447,7 @@ def apply_idea_lifecycle(ideas: list[dict[str, Any]]) -> dict[str, Any]:
     for idea in ideas:
         if not isinstance(idea, dict):
             continue
-        idea = _with_advisor_compat_fields(idea)
+        idea = _with_advisor_compat_fields(enrich_idea_with_news_calendar(dict(idea)))
         symbol = normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
         if not symbol:
             output.append(idea)

--- a/tests/test_idea_lifecycle_api.py
+++ b/tests/test_idea_lifecycle_api.py
@@ -88,3 +88,54 @@ def test_active_idea_is_locked_until_tp_or_sl(tmp_path: Path, monkeypatch) -> No
     assert replaced["ideas"][0]["idea_id"] != first["ideas"][0]["idea_id"]
     assert replaced["ideas"][0]["signal"] == "SELL"
     assert replaced["archive"][0]["result"] == "TP"
+
+
+def test_news_lock_adds_calendar_fields_and_blocks_trade(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(idea_lifecycle, "ACTIVE_FILE", tmp_path / "active_ideas.json")
+    monkeypatch.setattr(idea_lifecycle, "ARCHIVE_FILE", tmp_path / "archive.json")
+    monkeypatch.setattr(
+        idea_lifecycle,
+        "nearest_news_for_symbol",
+        lambda symbol: {
+            "news_event": "CPI",
+            "news_currency": "USD",
+            "news_impact": "High",
+            "news_time_utc": "2026-06-18T12:30:00+00:00",
+            "minutes_to_event": 12.0,
+            "news_lock_active": True,
+            "news_source": "forexfactory_faireconomy_xml",
+        },
+    )
+
+    payload = idea_lifecycle.apply_idea_lifecycle(
+        [
+            {
+                "symbol": "EURUSD",
+                "signal": "BUY",
+                "entry": 1.1,
+                "sl": 1.09,
+                "tp": 1.12,
+                "advisor_allowed": True,
+                "prop_mode": "prop_entry",
+                "prop_grade": "A",
+                "prop_score": 83,
+                "advisor_signal": {"allowed": True, "mode": "prop_entry", "grade": "A", "score": 83},
+            }
+        ]
+    )
+
+    idea = payload["ideas"][0]
+    assert idea["news_event"] == "CPI"
+    assert idea["news_currency"] == "USD"
+    assert idea["news_impact"] == "High"
+    assert idea["news_time_utc"] == "2026-06-18T12:30:00+00:00"
+    assert idea["minutes_to_event"] == 12.0
+    assert idea["news_lock_active"] is True
+    assert idea["news_source"] == "forexfactory_faireconomy_xml"
+    assert idea["trade_permission"] is False
+    assert idea["advisor_allowed"] is False
+    assert idea["mode"] == "NO TRADE"
+    assert idea["prop_mode"] == "no_trade"
+    assert idea["grade"] == "C"
+    assert idea["score"] == 54
+    assert idea["lifecycle_status"] == "candidate"


### PR DESCRIPTION
### Motivation
- Нужно учитывать высокоимпактные экономические события при публикации идей и блокировать торговлю вокруг них, чтобы избежать исполнения сигналов в моменты новостей.
- Для этого идеи должны получать набор полей календаря новостей и применять политику «no-trade» при активной блокировке.

### Description
- Добавлена интеграция с `nearest_news_for_symbol` и реализованы `enrich_idea_with_news_calendar` и `enrich_ideas_with_news_calendar` в `app/services/idea_lifecycle.py`, которые добавляют поля `news_event`, `news_currency`, `news_impact`, `news_time_utc`, `minutes_to_event`, `news_lock_active`, `news_source` и при `news_lock_active=true` принудительно выставляют `trade_permission=false`, `advisor_allowed=false`, `mode="NO TRADE"`, `prop_mode="no_trade"`, `grade="C"` и ограничивают score до максимум `54` (с сохранением MT4-совместимых полей).
- Enrichment применён в ключевых местах pipeline: внутри `apply_idea_lifecycle` для активных и candidate идей, а также после `prop_desk` фильтров в `app/main.py` и в `/api/ideas/market` роутере (`app/api/ideas_routes.py`) чтобы downstream-фильтры не перезаписывали блокировку.
- Сохранены существующие поля и имена (включая MT4-совместимые), изменения минимальны и изолированы в отдельных функциях; добавлен регрессионный тест в `tests/test_idea_lifecycle_api.py`.
- Изменённые файлы: `app/services/idea_lifecycle.py`, `app/main.py`, `app/api/ideas_routes.py`, `tests/test_idea_lifecycle_api.py`.

### Testing
- Выполнена компиляция изменённых модулей командой `python3 -m py_compile app/services/idea_lifecycle.py app/api/ideas_routes.py app/main.py` и компиляция прошла успешно.
- Запущены юнит-тесты `pytest -q tests/test_idea_lifecycle_api.py tests/test_market_ideas_timeout.py`, все тесты прошли успешно (`9 passed` in local run with warnings only).
- Проверка целостности диффа выполнена (`git diff --check`) и ошибок форматирования/синтаксиса не выявлено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34070303ac833187794897df68897b)