### PR TITLE
Добавить поддержку MT4 DOM/Heatmap в backend

### DIFF
--- a/app/core/fast_mt4_runtime_patch.py
+++ b/app/core/fast_mt4_runtime_patch.py
@@ -9,6 +9,14 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 FAST_CANDLES: dict[str, dict[str, Any]] = {}
+FAST_HEATMAP_FIELDS = (
+    "heatmap_available",
+    "heatmap_wall_above",
+    "heatmap_wall_below",
+    "heatmap_wall_above_size",
+    "heatmap_wall_below_size",
+    "heatmap_bias",
+)
 FAST_OPTIONS: dict[str, dict[str, Any]] = {}
 
 
@@ -55,7 +63,8 @@ def _signal(symbol: str, tf: str) -> dict[str, Any]:
             action = "SELL"; sl = last + span * 0.45; tp = last - span * 0.55
         else:
             action = "WAIT"; sl = 0; tp = 0
-        return {"symbol": symbol, "timeframe": tf, "signal": action, "action": action, "confidence": 55 if action != "WAIT" else 35, "entry": round(last, 5), "stop_loss": round(sl, 5) if sl else 0, "take_profit": round(tp, 5) if tp else 0, "source": "fast_mt4", "updated_at": datetime.now(timezone.utc).isoformat()}
+        extra_fields = {key: row.get(key) for key in FAST_HEATMAP_FIELDS if row.get(key) is not None}
+        return {"symbol": symbol, "timeframe": tf, "signal": action, "action": action, "confidence": 55 if action != "WAIT" else 35, "entry": round(last, 5), "stop_loss": round(sl, 5) if sl else 0, "take_profit": round(tp, 5) if tp else 0, **extra_fields, "source": "fast_mt4", "updated_at": datetime.now(timezone.utc).isoformat()}
     except Exception:
         return {"symbol": symbol, "timeframe": tf, "signal": "WAIT", "action": "WAIT", "confidence": 35, "entry": 0, "stop_loss": 0, "take_profit": 0, "source": "fast_mt4"}
 
@@ -72,7 +81,8 @@ async def push_candles(request) -> dict[str, Any]:
         candles = payload.get("bars") if isinstance(payload, dict) else []
     if not isinstance(candles, list):
         candles = []
-    FAST_CANDLES[f"{symbol}:{tf}"] = {"symbol": symbol, "timeframe": tf, "candles": candles[-600:], "updated_at": datetime.now(timezone.utc).isoformat()}
+    extra_fields = {key: payload.get(key) for key in FAST_HEATMAP_FIELDS if isinstance(payload, dict) and payload.get(key) is not None}
+    FAST_CANDLES[f"{symbol}:{tf}"] = {"symbol": symbol, "timeframe": tf, "candles": candles[-600:], **extra_fields, "updated_at": datetime.now(timezone.utc).isoformat()}
     return {"ok": True, "status": "stored", "symbol": symbol, "tf": tf, "count": len(candles)}
 
 

--- a/app/core/prop_score_recovery_patch.py
+++ b/app/core/prop_score_recovery_patch.py
@@ -379,6 +379,62 @@ def _margin_zone_context(idea: dict[str, Any], symbol: str, timeframe: str, cand
     return build_margin_zone_context(None, symbol, current_price, entry_price)
 
 
+
+def _heatmap_context(idea: dict[str, Any], symbol: str, direction: str, entry: float | None, tp: float | None) -> dict[str, Any]:
+    market_context = idea.get("market_context") if isinstance(idea.get("market_context"), dict) else {}
+    mt4_context = None
+    try:
+        module = sys.modules.get("app.main")
+        resolver = getattr(module, "resolve_mt4_candle_item", None) if module else None
+        if callable(resolver):
+            _, mt4_context = resolver(symbol, str(idea.get("timeframe") or idea.get("tf") or "M15"))
+    except Exception:
+        mt4_context = None
+
+    def pick(key: str) -> Any:
+        for payload in (idea, market_context, mt4_context):
+            if isinstance(payload, dict) and payload.get(key) not in (None, "", "—"):
+                return payload.get(key)
+        return None
+
+    raw_available = pick("heatmap_available")
+    available = raw_available if isinstance(raw_available, bool) else str(raw_available).strip().lower() in {"1", "true", "yes", "available"}
+    wall_above = _num(pick("heatmap_wall_above"))
+    wall_below = _num(pick("heatmap_wall_below"))
+    wall_above_size = _num(pick("heatmap_wall_above_size"))
+    wall_below_size = _num(pick("heatmap_wall_below_size"))
+    bias = str(pick("heatmap_bias") or "").strip().lower()
+    if not available and not any(value is not None for value in (wall_above, wall_below)) and not bias:
+        return {"available": False, "heatmap_available": False, "heatmap_score": 0, "score_adjustment": 0, "heatmap_reason_ru": "DOM/Heatmap слой от MT4 bridge недоступен.", "heatmap_bias": bias or None, "heatmap_wall_above": wall_above, "heatmap_wall_below": wall_below, "heatmap_wall_above_size": wall_above_size, "heatmap_wall_below_size": wall_below_size}
+
+    pip = _pip(symbol, entry or tp or 1.0)
+    sizes = [value for value in (wall_above_size, wall_below_size) if value is not None and value > 0]
+    large_threshold = max(sizes) * 0.65 if sizes else None
+    adjustment = 0
+    reasons: list[str] = []
+    if direction == "BUY" and bias in {"bullish", "buy", "long"}:
+        adjustment += 6; reasons.append("heatmap bias совпадает с BUY: +6")
+    elif direction == "SELL" and bias in {"bearish", "sell", "short"}:
+        adjustment += 6; reasons.append("heatmap bias совпадает с SELL: +6")
+    elif direction == "BUY" and bias in {"bearish", "sell", "short"}:
+        adjustment -= 8; reasons.append("heatmap bias против BUY: -8")
+    elif direction == "SELL" and bias in {"bullish", "buy", "long"}:
+        adjustment -= 8; reasons.append("heatmap bias против SELL: -8")
+
+    if direction == "BUY":
+        if tp is not None and wall_above is not None and (large_threshold is None or (wall_above_size or 0) >= large_threshold) and entry is not None and entry <= wall_above <= tp and abs(tp - wall_above) <= pip * 12:
+            adjustment -= 6; reasons.append("крупная wall сверху прямо перед/около TP: -6")
+        if entry is not None and wall_below is not None and (large_threshold is None or (wall_below_size or 0) >= large_threshold) and 0 <= entry - wall_below <= pip * 18:
+            adjustment += 6; reasons.append("крупная wall ниже entry как поддержка: +6")
+    elif direction == "SELL":
+        if tp is not None and wall_below is not None and (large_threshold is None or (wall_below_size or 0) >= large_threshold) and entry is not None and tp <= wall_below <= entry and abs(wall_below - tp) <= pip * 12:
+            adjustment -= 6; reasons.append("крупная wall снизу прямо перед/около TP: -6")
+        if entry is not None and wall_above is not None and (large_threshold is None or (wall_above_size or 0) >= large_threshold) and 0 <= wall_above - entry <= pip * 18:
+            adjustment += 6; reasons.append("крупная wall выше entry как сопротивление: +6")
+    if not reasons:
+        reasons.append("DOM/Heatmap получен, но без значимого влияния на сделку.")
+    return {"available": True, "heatmap_available": True, "heatmap_score": adjustment, "score_adjustment": adjustment, "heatmap_reason_ru": "; ".join(reasons), "heatmap_bias": bias or None, "heatmap_wall_above": wall_above, "heatmap_wall_below": wall_below, "heatmap_wall_above_size": wall_above_size, "heatmap_wall_below_size": wall_below_size}
+
 def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     candles = _candles(idea)
@@ -394,6 +450,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     dpoc = _dpoc_context(idea, symbol, timeframe, direction, candles)
     margin_zone = _margin_zone_context(idea, symbol, timeframe, candles)
     max_pain = _max_pain_context(idea, direction, external_options)
+    heatmap = _heatmap_context(idea, symbol, direction, entry, tp)
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     has_structure = any(_text_has_data(idea.get(k)) for k in ("reason_ru", "summary_ru", "market_structure", "htf_context", "entry_source"))
@@ -414,7 +471,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
         _row("sentiment", "Sentiment / новости", 5, int(sentiment.get("score") or 0), str(sentiment.get("text_ru") or "нет sentiment")),
     ]
     base_score = round(sum(r["score"] for r in rows) / max(sum(r["weight"] for r in rows), 1) * 100)
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0)))
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0) + int(heatmap.get("score_adjustment") or 0)))
     allowed = bool(direction in {"BUY", "SELL"} and valid and rr is not None and rr >= 1.1 and score >= 55 and not sentiment_conflict)
     grade = "A" if score >= 70 else "B" if score >= 55 else "C" if score >= 40 else "D"
     mode = "prop_entry" if allowed and score >= 70 else "watchlist" if allowed else "research_only" if score >= 40 else "no_trade"
@@ -430,7 +487,7 @@ def _score_payload(idea: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     if volume_delta.get("delta_divergence"):
         blockers.append("Delta divergence: цена и CumDelta расходятся")
     score_payload = {"score": score, "grade": grade, "mode": mode, "decision_ru": "Рабочая prop-идея." if allowed else "Только наблюдение: условий для автоторговли недостаточно.", "direction": direction, "criteria": rows, "blockers": blockers, "missing_inputs": [r["label_ru"] for r in rows if r["status"] == "missing"], "trade_geometry": {"symbol": symbol, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "has_levels": valid, "valid_geometry": valid, "level_source": level_source, "candles_count": len(candles), "fallback_used": level_source == "atr_fallback"}, "sentiment_filter": sentiment, "sentiment_used": sentiment.get("alignment") != "missing", "external_options_filter": external_options, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "volume_delta": volume_delta, "volume_delta_source": volume_delta.get("source"), "delta_divergence": bool(volume_delta.get("delta_divergence")), "dpoc": dpoc, "dpoc_price": dpoc.get("dpoc_price"), "distance_to_dpoc_pips": dpoc.get("distance_to_dpoc_pips")}
-    score_payload.update({"margin_lower": margin_zone.get("margin_lower"), "margin_upper": margin_zone.get("margin_upper"), "margin_zone_lower": margin_zone.get("margin_zone_lower"), "margin_zone_upper": margin_zone.get("margin_zone_upper"), "margin_source": margin_zone.get("margin_source"), "margin_zone_confluence": margin_zone, "max_pain_context": max_pain, "max_pain_price": max_pain.get("max_pain_price"), "distance_to_max_pain_pips": max_pain.get("distance_to_max_pain_pips"), "max_pain_alignment": max_pain.get("max_pain_alignment"), "max_pain_text_ru": max_pain.get("max_pain_text_ru")})
+    score_payload.update({"margin_lower": margin_zone.get("margin_lower"), "margin_upper": margin_zone.get("margin_upper"), "margin_zone_lower": margin_zone.get("margin_zone_lower"), "margin_zone_upper": margin_zone.get("margin_zone_upper"), "margin_source": margin_zone.get("margin_source"), "margin_zone_confluence": margin_zone, "max_pain_context": max_pain, "max_pain_price": max_pain.get("max_pain_price"), "distance_to_max_pain_pips": max_pain.get("distance_to_max_pain_pips"), "max_pain_alignment": max_pain.get("max_pain_alignment"), "max_pain_text_ru": max_pain.get("max_pain_text_ru"), "heatmap": heatmap, "heatmap_score": heatmap.get("heatmap_score"), "heatmap_reason_ru": heatmap.get("heatmap_reason_ru"), "heatmap_available": heatmap.get("heatmap_available"), "heatmap_wall_above": heatmap.get("heatmap_wall_above"), "heatmap_wall_below": heatmap.get("heatmap_wall_below"), "heatmap_wall_above_size": heatmap.get("heatmap_wall_above_size"), "heatmap_wall_below_size": heatmap.get("heatmap_wall_below_size"), "heatmap_bias": heatmap.get("heatmap_bias")})
     score_payload["external_options_note"] = str(external_options.get("text_ru") or "") if external_options_high_conflict else ""
     advisor = {"allowed": allowed, "reason": "allowed: BUY/SELL + valid levels + RR>=1.10 + sentiment not against" if allowed else "; ".join(blockers) or "score below autotrade threshold", "symbol": symbol, "action": direction, "entry": entry, "sl": sl, "tp": tp, "rr": rr, "score": score, "grade": grade, "mode": mode, "sentiment_filter": sentiment, "external_options_used": bool(external_options.get("used")), "external_options_alignment": external_options.get("alignment") or "neutral", "external_options_source": "CME_OptionsFX", "external_options_filter": external_options, "level_source": level_source}
     return score_payload, advisor
@@ -508,6 +565,15 @@ def install_prop_score_recovery_patch() -> None:
                     enriched["distance_to_max_pain_pips"] = score.get("distance_to_max_pain_pips")
                     enriched["max_pain_alignment"] = score.get("max_pain_alignment")
                     enriched["max_pain_text_ru"] = score.get("max_pain_text_ru")
+                    enriched["heatmap"] = score.get("heatmap")
+                    enriched["heatmap_score"] = score.get("heatmap_score")
+                    enriched["heatmap_reason_ru"] = score.get("heatmap_reason_ru")
+                    enriched["heatmap_available"] = score.get("heatmap_available")
+                    enriched["heatmap_wall_above"] = score.get("heatmap_wall_above")
+                    enriched["heatmap_wall_below"] = score.get("heatmap_wall_below")
+                    enriched["heatmap_wall_above_size"] = score.get("heatmap_wall_above_size")
+                    enriched["heatmap_wall_below_size"] = score.get("heatmap_wall_below_size")
+                    enriched["heatmap_bias"] = score.get("heatmap_bias")
                     market_structure = dict(enriched.get("market_structure") or {})
                     market_structure["dpoc_price"] = score.get("dpoc_price")
                     market_structure["distance_to_dpoc_pips"] = score.get("distance_to_dpoc_pips")

--- a/app/main.py
+++ b/app/main.py
@@ -194,14 +194,56 @@ def _extract_ai_json_payload(ai_text: str) -> dict[str, Any]:
     return {}
 
 
+MT4_HEATMAP_FIELDS = (
+    "heatmap_available",
+    "heatmap_wall_above",
+    "heatmap_wall_below",
+    "heatmap_wall_above_size",
+    "heatmap_wall_below_size",
+    "heatmap_bias",
+)
+
+
+def _mt4_bool_or_none(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value in (None, "", "—"):
+        return None
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on", "available"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", "unavailable"}:
+        return False
+    return None
+
+
+def _extract_mt4_heatmap_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    heatmap: dict[str, Any] = {}
+    available = _mt4_bool_or_none(payload.get("heatmap_available"))
+    if available is not None:
+        heatmap["heatmap_available"] = available
+    for key in ("heatmap_wall_above", "heatmap_wall_below", "heatmap_wall_above_size", "heatmap_wall_below_size"):
+        value = _first_mt4_float(payload, (key,), positive_only=key.endswith(("above", "below")))
+        if value is not None:
+            heatmap[key] = value
+    bias = str(payload.get("heatmap_bias") or "").strip().lower()
+    if bias:
+        heatmap["heatmap_bias"] = bias
+    return heatmap
+
+
 def _compact_candle(candle: dict[str, Any]) -> dict[str, Any]:
-    return {
+    row = {
         "time": int(candle.get("time") or 0),
         "open": float(candle.get("open") or 0.0),
         "high": float(candle.get("high") or 0.0),
         "low": float(candle.get("low") or 0.0),
         "close": float(candle.get("close") or 0.0),
     }
+    row.update(_extract_mt4_heatmap_fields(candle))
+    return row
 
 
 
@@ -274,6 +316,8 @@ def _extract_mt4_rich_fields(payload: dict[str, Any]) -> dict[str, Any]:
     if margin_source:
         rich["margin_source"] = margin_source
 
+    rich.update(_extract_mt4_heatmap_fields(payload))
+
     return rich
 
 
@@ -320,6 +364,7 @@ def _mt4_debug_rich_fields(item: dict[str, Any]) -> dict[str, Any]:
             "cumulative_delta",
             "hft_signal",
             "margin_source",
+            *MT4_HEATMAP_FIELDS,
         )
         if isinstance(item, dict) and item.get(field) is not None
     }
@@ -1309,6 +1354,12 @@ def api_mt4_ingest_get(
     margin_zone_lower: float = 0.0,
     margin_zone_upper: float = 0.0,
     margin_source: str = "",
+    heatmap_available: bool | None = None,
+    heatmap_wall_above: float = 0.0,
+    heatmap_wall_below: float = 0.0,
+    heatmap_wall_above_size: float = 0.0,
+    heatmap_wall_below_size: float = 0.0,
+    heatmap_bias: str = "",
     hft_signal: str = "",
     bars: str = "",
     broker: str = "",
@@ -1326,7 +1377,19 @@ def api_mt4_ingest_get(
 
     store_key = f"{normalized_symbol}:{timeframe}"
     candle_time = int(time or 0)
-    candle_row = _compact_candle({"time": candle_time, "open": open, "high": high, "low": low, "close": close})
+    candle_row = _compact_candle({
+        "time": candle_time,
+        "open": open,
+        "high": high,
+        "low": low,
+        "close": close,
+        "heatmap_available": heatmap_available,
+        "heatmap_wall_above": heatmap_wall_above,
+        "heatmap_wall_below": heatmap_wall_below,
+        "heatmap_wall_above_size": heatmap_wall_above_size,
+        "heatmap_wall_below_size": heatmap_wall_below_size,
+        "heatmap_bias": heatmap_bias,
+    })
     existing = (MT4_CANDLE_STORE.get(store_key) or {}).get("candles") or []
     merged = {int(c.get("time") or 0): c for c in existing if isinstance(c, dict) and int(c.get("time") or 0) > 0}
     if candle_time > 0:
@@ -1350,6 +1413,12 @@ def api_mt4_ingest_get(
         "cumulative_delta": cumulative_delta,
         "hft_signal": hft_signal,
         "margin_source": margin_source,
+        "heatmap_available": heatmap_available,
+        "heatmap_wall_above": heatmap_wall_above,
+        "heatmap_wall_below": heatmap_wall_below,
+        "heatmap_wall_above_size": heatmap_wall_above_size,
+        "heatmap_wall_below_size": heatmap_wall_below_size,
+        "heatmap_bias": heatmap_bias,
     })
     _prune_stale_mt4_store()
     _merge_mt4_store_item(
@@ -1394,6 +1463,7 @@ def api_mt4_ingest_get(
         "margin_zone_upper": rich_fields.get("margin_zone_upper"),
         "margin_source": margin_source or "Future_Volume_v5.00",
         "hft_signal": hft_signal,
+        **rich_fields,
         "bars": bars,
         "broker": broker,
         "account": account,
@@ -2832,6 +2902,12 @@ def build_signal_from_candles(symbol: str, tf: str = "M15") -> dict[str, Any]:
         "last_candle_time": last_candle_time, "available_timeframes": available_timeframes, "source": "mt4_ingest" if available_timeframes else "market_provider",
         "prop_signal_score": {"score": inst.get("confidence", 0), "grade": "A" if inst.get("confidence", 0) >= 74 else "B" if inst.get("confidence", 0) >= 62 else "C", "mode": inst.get("mode", "watchlist")},
     }
+    _, mt4_item = resolve_mt4_candle_item(symbol_norm, tf_norm)
+    heatmap_fields = _mt4_debug_rich_fields(mt4_item or {})
+    for field in MT4_HEATMAP_FIELDS:
+        if field in heatmap_fields:
+            result[field] = heatmap_fields[field]
+            result["prop_signal_score"][field] = heatmap_fields[field]
     return result
 
 

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -1054,6 +1054,93 @@ def _criterion_rows(idea: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+
+def _heatmap_context(idea: dict[str, Any], direction: str, geo: dict[str, Any]) -> dict[str, Any]:
+    source: dict[str, Any] = idea if isinstance(idea, dict) else {}
+    market_context = source.get("market_context") if isinstance(source.get("market_context"), dict) else {}
+    mt4_context = _mt4_store_context(source.get("symbol") or source.get("pair") or source.get("instrument"), source.get("timeframe") or source.get("tf")) or {}
+
+    def pick(key: str) -> Any:
+        for payload in (source, market_context, mt4_context):
+            if isinstance(payload, dict) and payload.get(key) not in (None, "", "—"):
+                return payload.get(key)
+        return None
+
+    raw_available = pick("heatmap_available")
+    available = raw_available if isinstance(raw_available, bool) else str(raw_available).strip().lower() in {"1", "true", "yes", "available"}
+    wall_above = _to_float(pick("heatmap_wall_above"))
+    wall_below = _to_float(pick("heatmap_wall_below"))
+    wall_above_size = _to_float(pick("heatmap_wall_above_size"))
+    wall_below_size = _to_float(pick("heatmap_wall_below_size"))
+    bias = str(pick("heatmap_bias") or "").strip().lower()
+    entry = _to_float(geo.get("entry"))
+    tp = _to_float(geo.get("tp"))
+    symbol = str(geo.get("symbol") or source.get("symbol") or "")
+    pip = _pip_size(symbol, entry)
+    sizes = [value for value in (wall_above_size, wall_below_size) if value is not None and value > 0]
+    large_threshold = max(sizes) * 0.65 if sizes else None
+
+    score_adjustment = 0
+    reasons: list[str] = []
+    if not available and not any(value is not None for value in (wall_above, wall_below)) and not bias:
+        return {
+            "available": False,
+            "heatmap_available": False,
+            "heatmap_score": 0,
+            "score_adjustment": 0,
+            "heatmap_reason_ru": "DOM/Heatmap слой от MT4 bridge недоступен.",
+            "heatmap_bias": bias or None,
+            "heatmap_wall_above": wall_above,
+            "heatmap_wall_below": wall_below,
+            "heatmap_wall_above_size": wall_above_size,
+            "heatmap_wall_below_size": wall_below_size,
+        }
+
+    if direction == "BUY" and bias in {"bullish", "buy", "long"}:
+        score_adjustment += 6
+        reasons.append("heatmap bias совпадает с BUY: +6")
+    elif direction == "SELL" and bias in {"bearish", "sell", "short"}:
+        score_adjustment += 6
+        reasons.append("heatmap bias совпадает с SELL: +6")
+    elif direction == "BUY" and bias in {"bearish", "sell", "short"}:
+        score_adjustment -= 8
+        reasons.append("heatmap bias против BUY: -8")
+    elif direction == "SELL" and bias in {"bullish", "buy", "long"}:
+        score_adjustment -= 8
+        reasons.append("heatmap bias против SELL: -8")
+
+    near_tp_limit = pip * 12
+    support_limit = pip * 18
+    if direction == "BUY":
+        if tp is not None and wall_above is not None and (large_threshold is None or (wall_above_size or 0) >= large_threshold) and entry is not None and entry <= wall_above <= tp and abs(tp - wall_above) <= near_tp_limit:
+            score_adjustment -= 6
+            reasons.append("крупная wall сверху прямо перед/около TP: -6")
+        if entry is not None and wall_below is not None and (large_threshold is None or (wall_below_size or 0) >= large_threshold) and 0 <= entry - wall_below <= support_limit:
+            score_adjustment += 6
+            reasons.append("крупная wall ниже entry как поддержка: +6")
+    elif direction == "SELL":
+        if tp is not None and wall_below is not None and (large_threshold is None or (wall_below_size or 0) >= large_threshold) and entry is not None and tp <= wall_below <= entry and abs(wall_below - tp) <= near_tp_limit:
+            score_adjustment -= 6
+            reasons.append("крупная wall снизу прямо перед/около TP: -6")
+        if entry is not None and wall_above is not None and (large_threshold is None or (wall_above_size or 0) >= large_threshold) and 0 <= wall_above - entry <= support_limit:
+            score_adjustment += 6
+            reasons.append("крупная wall выше entry как сопротивление: +6")
+
+    if not reasons:
+        reasons.append("DOM/Heatmap получен, но без значимого влияния на сделку.")
+    return {
+        "available": True,
+        "heatmap_available": True,
+        "heatmap_score": score_adjustment,
+        "score_adjustment": score_adjustment,
+        "heatmap_reason_ru": "; ".join(reasons),
+        "heatmap_bias": bias or None,
+        "heatmap_wall_above": wall_above,
+        "heatmap_wall_below": wall_below,
+        "heatmap_wall_above_size": wall_above_size,
+        "heatmap_wall_below_size": wall_below_size,
+    }
+
 def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     safe_idea = idea if isinstance(idea, dict) else {}
     rows = _criterion_rows(safe_idea)
@@ -1068,9 +1155,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     dpoc = _dpoc_context(safe_idea, direction)
     margin_zone = _margin_zone_context(safe_idea)
     max_pain = _max_pain_context(safe_idea, direction, external_options)
+    heatmap = _heatmap_context(safe_idea, direction, geo)
     volume_delta_source = volume_delta.get("source")
     hft_signal = volume_delta.get("hft_signal") or _hft_signal_context(safe_idea).get("hft_signal")
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0)))
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0) + int(heatmap.get("score_adjustment") or 0)))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     external_options_note = ""
@@ -1144,6 +1232,8 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
             "fallback_used": bool(geo.get("fallback_used")),
             "volume_delta_source": volume_delta_source,
             "hft_signal": hft_signal,
+            "heatmap_score": heatmap.get("heatmap_score"),
+            "heatmap_reason_ru": heatmap.get("heatmap_reason_ru"),
         },
         "criteria": rows,
         "blockers": blockers,
@@ -1171,6 +1261,15 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "distance_to_max_pain_pips": max_pain.get("distance_to_max_pain_pips"),
         "max_pain_alignment": max_pain.get("max_pain_alignment"),
         "max_pain_text_ru": max_pain.get("max_pain_text_ru"),
+        "heatmap": heatmap,
+        "heatmap_score": heatmap.get("heatmap_score"),
+        "heatmap_reason_ru": heatmap.get("heatmap_reason_ru"),
+        "heatmap_available": heatmap.get("heatmap_available"),
+        "heatmap_wall_above": heatmap.get("heatmap_wall_above"),
+        "heatmap_wall_below": heatmap.get("heatmap_wall_below"),
+        "heatmap_wall_above_size": heatmap.get("heatmap_wall_above_size"),
+        "heatmap_wall_below_size": heatmap.get("heatmap_wall_below_size"),
+        "heatmap_bias": heatmap.get("heatmap_bias"),
         "real_candle_diagnostics": candle_diag,
         "volume_delta_source": volume_delta_source,
         "hft_signal": hft_signal,
@@ -1327,6 +1426,15 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "distance_to_max_pain_pips": score.get("distance_to_max_pain_pips"),
             "max_pain_alignment": score.get("max_pain_alignment"),
             "max_pain_text_ru": score.get("max_pain_text_ru"),
+            "heatmap": score.get("heatmap"),
+            "heatmap_score": score.get("heatmap_score"),
+            "heatmap_reason_ru": score.get("heatmap_reason_ru"),
+            "heatmap_available": score.get("heatmap_available"),
+            "heatmap_wall_above": score.get("heatmap_wall_above"),
+            "heatmap_wall_below": score.get("heatmap_wall_below"),
+            "heatmap_wall_above_size": score.get("heatmap_wall_above_size"),
+            "heatmap_wall_below_size": score.get("heatmap_wall_below_size"),
+            "heatmap_bias": score.get("heatmap_bias"),
         }
     )
     market_structure = dict(enriched.get("market_structure") or {})

--- a/tests/test_mt4_heatmap_bridge.py
+++ b/tests/test_mt4_heatmap_bridge.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+
+from app import main
+from app.main import api_debug_mt4_bridge_pair, api_mt4_ingest_get
+from app.services.prop_signal_engine import build_prop_signal_score, enrich_idea_with_prop_score
+
+
+def _idea(action: str = "BUY", close: float = 1.1000, symbol: str = "AUDUSD") -> dict:
+    return {
+        "symbol": symbol,
+        "timeframe": "M15",
+        "action": action,
+        "entry": close,
+        "sl": close - 0.0020 if action == "BUY" else close + 0.0020,
+        "tp": close + 0.0030 if action == "BUY" else close - 0.0030,
+        "candles": [
+            {"time": i + 1, "open": close - 0.0002, "high": close + 0.0003, "low": close - 0.0003, "close": close}
+            for i in range(30)
+        ],
+        "reason_ru": "Подтверждённая структура",
+    }
+
+
+def test_mt4_ingest_get_stores_and_debug_exposes_heatmap_fields():
+    stamp = int(datetime.now(timezone.utc).timestamp())
+    response = api_mt4_ingest_get(
+        symbol="EURUSD",
+        tf="M15",
+        time=stamp,
+        open=1.1000,
+        high=1.1010,
+        low=1.0990,
+        close=1.1005,
+        heatmap_available=True,
+        heatmap_wall_above=1.1030,
+        heatmap_wall_below=1.0985,
+        heatmap_wall_above_size=120.0,
+        heatmap_wall_below_size=80.0,
+        heatmap_bias="bullish",
+    )
+    debug = api_debug_mt4_bridge_pair("EURUSD", "M15", limit=5)
+
+    assert response["ok"] is True
+    assert debug["heatmap_available"] is True
+    assert debug["heatmap_wall_above"] == 1.1030
+    assert debug["heatmap_wall_below"] == 1.0985
+    assert debug["heatmap_wall_above_size"] == 120.0
+    assert debug["heatmap_wall_below_size"] == 80.0
+    assert debug["heatmap_bias"] == "bullish"
+    assert debug["candles"][-1]["heatmap_bias"] == "bullish"
+
+
+def test_build_signal_from_candles_adds_heatmap_fields(monkeypatch):
+    rows = [
+        {"time": i + 1, "open": 1.1000, "high": 1.1010, "low": 1.0990, "close": 1.1000 + i * 0.00001}
+        for i in range(80)
+    ]
+    main.MT4_CANDLE_STORE["GBPUSD:M15"] = {
+        "symbol": "GBPUSD",
+        "timeframe": "M15",
+        "candles": rows,
+        "updated_at": datetime.now(timezone.utc),
+        "heatmap_available": True,
+        "heatmap_wall_above": 1.1050,
+        "heatmap_wall_below": 1.0970,
+        "heatmap_wall_above_size": 200.0,
+        "heatmap_wall_below_size": 140.0,
+        "heatmap_bias": "bullish",
+    }
+    monkeypatch.setattr(main, "fetch_candles", lambda symbol, tf, limit=160: {"candles": rows, "provider": "mt4_bridge"})
+
+    signal = main.build_signal_from_candles("GBPUSD", "M15")
+
+    assert signal["heatmap_available"] is True
+    assert signal["heatmap_bias"] == "bullish"
+    assert signal["prop_signal_score"]["heatmap_wall_above"] == 1.1050
+
+
+def test_prop_engine_scores_heatmap_bias_and_walls():
+    base = build_prop_signal_score(_idea("BUY", 1.1000))
+    aligned_support = build_prop_signal_score(
+        {
+            **_idea("BUY", 1.1000),
+            "heatmap_available": True,
+            "heatmap_bias": "bullish",
+            "heatmap_wall_below": 1.0990,
+            "heatmap_wall_below_size": 150.0,
+        }
+    )
+    conflict_tp_wall = build_prop_signal_score(
+        {
+            **_idea("BUY", 1.1000),
+            "heatmap_available": True,
+            "heatmap_bias": "bearish",
+            "heatmap_wall_above": 1.1025,
+            "heatmap_wall_above_size": 150.0,
+        }
+    )
+    enriched = enrich_idea_with_prop_score({**_idea("BUY", 1.1000), "heatmap_available": True, "heatmap_bias": "bullish"})
+
+    assert aligned_support["heatmap_score"] == 12
+    assert aligned_support["score"] == min(100, base["score"] + 12)
+    assert conflict_tp_wall["heatmap_score"] == -14
+    assert conflict_tp_wall["score"] == max(0, base["score"] - 14)
+    assert enriched["heatmap_available"] is True
+    assert enriched["heatmap_reason_ru"]


### PR DESCRIPTION
### Motivation
- Подключить DOM/Heatmap данные из MT4 bridge (поля `heatmap_available`, `heatmap_wall_above`, `heatmap_wall_below`, `heatmap_wall_above_size`, `heatmap_wall_below_size`, `heatmap_bias`) в backend и сделать их доступными в store/ответах/prop-логике.
- Сохранить совместимость MT4/существующих контрактов и не переименовывать текущие поля `score`, `grade`, `mode`, `trade_permission`, `advisor_allowed`.
- Использовать heatmap как дополнительный подтверждающий/блокирующий слой в Prop Engine для улучшения скоринга идей.

### Description
- Собираются и сохраняются heatmap-поля из payload в MT4 candle store и в rich fields через `api_mt4_ingest_get`/`api/mt4/push-candles` и `_extract_mt4_rich_fields`. (`app/main.py`)
- Поля добавлены в debug-эндпоинт `GET /api/debug/mt4-bridge/{symbol}/{timeframe}` и проброшены в `build_signal_from_candles` в топ-уровневый сигнал и во вложенный `prop_signal_score`. (`app/main.py`)
- В Prop Engine добавлен расчёт `heatmap` контекста и скоринг: совпадение bias с направлением `+6`, конфликт bias `-8`, крупная wall перед TP `-6`, крупная wall под/над entry как поддержка/сопротивление `+6`, и результат экспортируется как `heatmap_score` и `heatmap_reason_ru` (поля также попадают в `prop_signal_score` и в обогащённую идею). (`app/services/prop_signal_engine.py`, `app/core/prop_score_recovery_patch.py`)
- Fast MT4 runtime patch обновлён для сохранения/возврата heatmap-полей в быстром режиме и тесты добавлены для регрессии. Основные изменённые файлы: `app/main.py`, `app/services/prop_signal_engine.py`, `app/core/prop_score_recovery_patch.py`, `app/core/fast_mt4_runtime_patch.py`, `tests/test_mt4_heatmap_bridge.py`.

### Testing
- Выполнена предварительная компиляция: `python -m compileall app/main.py app/services/prop_signal_engine.py app/core/prop_score_recovery_patch.py app/core/fast_mt4_runtime_patch.py` и компиляция прошла успешно.
- Запущены регрессионные тесты: `pytest -q tests/test_mt4_heatmap_bridge.py tests/test_mt4_dpoc.py tests/test_mt4_margin_zones.py` и все тесты прошли успешно (в сумме `13 passed`, предупреждения присутствуют).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3424729f8083319ab825b73d29ef29)