### PR TITLE
Исправление строки «Новости/фундаментал» в карточках /ideas

### DIFF
--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -376,14 +376,27 @@ function resolveNarrative(idea) {
 }
 
 function resolveNewsContext(idea) {
-  return firstText(
-    idea.news_title,
-    idea.fundamental_context_ru,
-    idea.fundamental_ru,
-    idea.news_context_ru,
-    idea.why_moves_ru,
-    idea.market_impact_ru,
-  ) || "нет данных";
+  const fundamentalSummary = firstText(
+    idea.fundamental_summary_ru,
+    idea.fundamentalSummaryRu,
+  );
+  if (fundamentalSummary) return fundamentalSummary;
+
+  const newsFundamental = firstText(
+    idea.news_fundamental_ru,
+    idea.newsFundamentalRu,
+  );
+  if (newsFundamental) return newsFundamental;
+
+  const newsEvent = firstText(idea.news_event, idea.newsEvent);
+  if (newsEvent) {
+    const newsCurrency = firstText(idea.news_currency, idea.newsCurrency) || "—";
+    const newsImpact = firstText(idea.news_impact, idea.newsImpact) || "—";
+    const minutesToEvent = idea.minutes_to_event ?? idea.minutesToEvent ?? "—";
+    return `${newsCurrency} ${newsEvent}, impact ${newsImpact}, до события ${minutesToEvent} мин`;
+  }
+
+  return "свежих релевантных событий не найдено";
 }
 
 function normalizeChartImageUrl(url) {


### PR DESCRIPTION
### Motivation
- Убрать жёсткий fallback «нет данных» и корректно приоритетизировать поля для строки «Новости/фундаментал» в карточках `/ideas`: сначала `fundamental_summary_ru` / `fundamentalSummaryRu`, затем `news_fundamental_ru` / `newsFundamentalRu`, и в последнюю очередь структурированные поля события (`news_event`, `news_currency`, `news_impact`, `minutes_to_event`).

### Description
- Обновлён `resolveNewsContext` в `app/static/ideas.js`, добавлен приоритетный поиск по новым полям, логика сборки строки из `news_event` в формате `Новости/фундаментал: {currency} {event}, impact {impact}, до события {minutes} мин`, и заменён финальный fallback на `свежих релевантных событий не найдено` без изменений дизайна или backend-маршрутов.

### Testing
- Автоматические проверки: `node --check app/static/ideas.js` и `git diff --check` выполнены успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3774f8f03c8331875bc869ab964e70)