### PR TITLE
Исправление сканера HFT/ICE объектов (MT4 bridge)

### DIFF
--- a/AI_Ideas_Trader.mq4
+++ b/AI_Ideas_Trader.mq4
@@ -36,6 +36,14 @@ string g_lastBlockedSymbol = "";
 int g_lastFoundCount = 0;
 int g_lastAllowedCount = 0;
 int g_lastBlockedCount = 0;
+bool g_hftObjectFound = false;
+string g_hftObjectName = "";
+string g_hftObjectKind = "none";
+int g_hftObjectMt4Type = -1;
+double g_hftObjectPrice = 0.0;
+double g_hftObjectDistance = 0.0;
+double g_hftObjectStrength = 0.0;
+int g_hftObjectsTotal = 0;
 
 int OnInit()
 {
@@ -45,6 +53,7 @@ int OnInit()
 
 void OnTick()
 {
+   ScanHftObjects();
    if(TimeCurrent() - g_lastPoll < RefreshSeconds) return;
    g_lastPoll = TimeCurrent();
    PollSignalsAndTrade();
@@ -339,6 +348,7 @@ string BoolToText(bool value)
 
 void DrawStatusPanel()
 {
+   ScanHftObjects();
    string reason = g_lastBlockedReason;
    if(StringLen(reason) == 0) reason = "none";
    Comment(
@@ -346,8 +356,83 @@ void DrawStatusPanel()
       "Found: ", g_lastFoundCount, "\n",
       "Allowed: ", g_lastAllowedCount, "\n",
       "Blocked: ", g_lastBlockedCount, "\n",
-      "Last blocked: ", g_lastBlockedSymbol, " ", reason
+      "Last blocked: ", g_lastBlockedSymbol, " ", reason, "\n",
+      "HFT object: ", (g_hftObjectFound ? "yes" : "no"), "\n",
+      "type=", g_hftObjectKind, "\n",
+      "price=", DoubleToString(g_hftObjectPrice, Digits), "\n",
+      "distance=", DoubleToString(g_hftObjectDistance, Digits), "\n",
+      "strength=", DoubleToString(g_hftObjectStrength, 1)
    );
+}
+
+void ScanHftObjects()
+{
+   int total = ObjectsTotal();
+   g_hftObjectsTotal = total;
+   g_hftObjectFound = false;
+   g_hftObjectName = "";
+   g_hftObjectKind = "none";
+   g_hftObjectMt4Type = -1;
+   g_hftObjectPrice = 0.0;
+   g_hftObjectDistance = 0.0;
+   g_hftObjectStrength = 0.0;
+
+   double currentPrice = (Bid > 0 && Ask > 0) ? ((Bid + Ask) / 2.0) : Close[0];
+   double bestDistance = 0.0;
+   Print("HFT scanner: ObjectsTotal()=", total);
+
+   for(int i = total - 1; i >= 0; i--)
+   {
+      string name = ObjectName(i);
+      string kind = "";
+      if(StringFind(name, "fut_hft_point_") >= 0) kind = "hft";
+      if(StringFind(name, "fut_ice_point_") >= 0) kind = "ice";
+      if(StringLen(kind) == 0) continue;
+
+      int mt4Type = ObjectType(name);
+      double price = ObjectGet(name, OBJPROP_PRICE1);
+      if(price <= 0.0) price = ObjectGet(name, OBJPROP_PRICE2);
+      if(price <= 0.0)
+      {
+         Print("HFT scanner: found name=", name, " type=", mt4Type, " price=0 skipped");
+         continue;
+      }
+
+      double distance = MathAbs(currentPrice - price);
+      double strength = ObjectGet(name, OBJPROP_WIDTH);
+      if(strength <= 0.0) strength = 1.0;
+      Print("HFT scanner: found name=", name, " type=", mt4Type, " kind=", kind, " price=", DoubleToString(price, Digits), " distance=", DoubleToString(distance, Digits), " strength=", DoubleToString(strength, 1));
+
+      if(!g_hftObjectFound || distance < bestDistance)
+      {
+         g_hftObjectFound = true;
+         g_hftObjectName = name;
+         g_hftObjectKind = kind;
+         g_hftObjectMt4Type = mt4Type;
+         g_hftObjectPrice = NormalizeDouble(price, Digits);
+         g_hftObjectDistance = NormalizeDouble(distance, Digits);
+         g_hftObjectStrength = strength;
+         bestDistance = distance;
+      }
+   }
+
+   if(g_hftObjectFound)
+   {
+      Print("HFT scanner: nearest name=", g_hftObjectName, " type=", g_hftObjectMt4Type, " kind=", g_hftObjectKind, " price=", DoubleToString(g_hftObjectPrice, Digits), " distance=", DoubleToString(g_hftObjectDistance, Digits), " strength=", DoubleToString(g_hftObjectStrength, 1));
+   }
+   else
+   {
+      Print("HFT scanner: nearest not found type=none price=0");
+   }
+}
+
+string BuildHftObjectJson()
+{
+   if(!g_hftObjectFound)
+   {
+      return("{\"available\":false,\"type\":\"none\",\"price\":0,\"distance\":0,\"strength\":0}");
+   }
+   return("{\"available\":true,\"name\":\"" + g_hftObjectName + "\",\"type\":\"" + g_hftObjectKind + "\",\"mt4_type\":" + IntegerToString(g_hftObjectMt4Type) + ",\"price\":" + DoubleToString(g_hftObjectPrice, Digits) + ",\"distance\":" + DoubleToString(g_hftObjectDistance, Digits) + ",\"strength\":" + DoubleToString(g_hftObjectStrength, 1) + "}");
 }
 
 string ResolveBlockedReason(string obj, string action, double entry, double sl, double tp, bool tradePermission, int score, string grade, string mode)

--- a/app/main.py
+++ b/app/main.py
@@ -313,6 +313,33 @@ def _extract_mt4_rich_fields(payload: dict[str, Any]) -> dict[str, Any]:
     if hft_signal:
         rich["hft_signal"] = hft_signal
 
+    hft_object = payload.get("hft_object") if isinstance(payload.get("hft_object"), dict) else {}
+    hft_object_type = str(
+        payload.get("hft_object_type")
+        or payload.get("hftObjectType")
+        or hft_object.get("type")
+        or ""
+    ).strip().lower()
+    if hft_object_type in {"hft", "ice"}:
+        rich["hft_object_found"] = True
+        rich["hft_object_type"] = hft_object_type
+        name = str(payload.get("hft_object_name") or payload.get("hftObjectName") or hft_object.get("name") or "").strip()
+        if name:
+            rich["hft_object_name"] = name
+        for source_key, out_key in (
+            ("hft_object_price", "hft_object_price"),
+            ("hft_object_distance", "hft_object_distance"),
+            ("hft_object_strength", "hft_object_strength"),
+        ):
+            value = _first_mt4_float(payload, (source_key,))
+            if value is None:
+                value = _mt4_float_or_none(hft_object.get(source_key.replace("hft_object_", "")))
+            if value is not None:
+                rich[out_key] = value
+    elif payload.get("hft_object_found") is not None or hft_object:
+        rich["hft_object_found"] = False
+        rich["hft_object_type"] = "none"
+
     margin_source = str(payload.get("margin_source") or "").strip()
     if margin_source:
         rich["margin_source"] = margin_source
@@ -364,6 +391,12 @@ def _mt4_debug_rich_fields(item: dict[str, Any]) -> dict[str, Any]:
             "future_delta",
             "cumulative_delta",
             "hft_signal",
+            "hft_object_found",
+            "hft_object_name",
+            "hft_object_type",
+            "hft_object_price",
+            "hft_object_distance",
+            "hft_object_strength",
             "margin_source",
             *MT4_HEATMAP_FIELDS,
         )
@@ -1380,6 +1413,12 @@ def api_mt4_ingest_get(
     heatmap_wall_below_size: float = 0.0,
     heatmap_bias: str = "",
     hft_signal: str = "",
+    hft_object_found: bool | None = None,
+    hft_object_name: str = "",
+    hft_object_type: str = "",
+    hft_object_price: float = 0.0,
+    hft_object_distance: float = 0.0,
+    hft_object_strength: float = 0.0,
     bars: str = "",
     broker: str = "",
     account: str = "",
@@ -1431,6 +1470,12 @@ def api_mt4_ingest_get(
         "future_delta": future_delta,
         "cumulative_delta": cumulative_delta,
         "hft_signal": hft_signal,
+        "hft_object_found": hft_object_found,
+        "hft_object_name": hft_object_name,
+        "hft_object_type": hft_object_type,
+        "hft_object_price": hft_object_price,
+        "hft_object_distance": hft_object_distance,
+        "hft_object_strength": hft_object_strength,
         "margin_source": margin_source,
         "heatmap_available": heatmap_available,
         "heatmap_wall_above": heatmap_wall_above,
@@ -1482,6 +1527,12 @@ def api_mt4_ingest_get(
         "margin_zone_upper": rich_fields.get("margin_zone_upper"),
         "margin_source": margin_source or "Future_Volume_v5.00",
         "hft_signal": hft_signal,
+        "hft_object_found": rich_fields.get("hft_object_found"),
+        "hft_object_name": rich_fields.get("hft_object_name"),
+        "hft_object_type": rich_fields.get("hft_object_type"),
+        "hft_object_price": rich_fields.get("hft_object_price"),
+        "hft_object_distance": rich_fields.get("hft_object_distance"),
+        "hft_object_strength": rich_fields.get("hft_object_strength"),
         **rich_fields,
         "bars": bars,
         "broker": broker,

--- a/tests/test_mt4_hft_object_bridge.py
+++ b/tests/test_mt4_hft_object_bridge.py
@@ -1,0 +1,37 @@
+from app.main import _extract_mt4_rich_fields, _mt4_debug_rich_fields
+
+
+def test_mt4_rich_fields_keep_nearest_hft_object_contract():
+    payload = {
+        "hft_object": {
+            "name": "prefix_fut_hft_point_123",
+            "type": "hft",
+            "price": 1.1012,
+            "distance": 0.0003,
+            "strength": 4,
+        }
+    }
+
+    rich = _extract_mt4_rich_fields(payload)
+
+    assert rich["hft_object_found"] is True
+    assert rich["hft_object_name"] == "prefix_fut_hft_point_123"
+    assert rich["hft_object_type"] == "hft"
+    assert rich["hft_object_price"] == 1.1012
+    assert rich["hft_object_distance"] == 0.0003
+    assert rich["hft_object_strength"] == 4
+    assert _mt4_debug_rich_fields(rich)["hft_object_type"] == "hft"
+
+
+def test_mt4_rich_fields_accept_flat_ice_object_contract():
+    rich = _extract_mt4_rich_fields({
+        "hft_object_name": "fut_ice_point_999",
+        "hft_object_type": "ice",
+        "hft_object_price": "1.0990",
+        "hft_object_distance": "0.0001",
+        "hft_object_strength": "2",
+    })
+
+    assert rich["hft_object_found"] is True
+    assert rich["hft_object_type"] == "ice"
+    assert rich["hft_object_price"] == 1.099


### PR DESCRIPTION
### Motivation
- Панель MT4 не видела существующие на графике объекты `fut_hft_point_*` / `fut_ice_point_*`, поэтому нужно обеспечить поиск по подстроке среди всех объектов и вернуть ближайший к текущей цене объект.\n
### Description
- Добавлен `ScanHftObjects()` в `AI_Ideas_Trader.mq4`, который перебирает все объекты через `ObjectsTotal()`/`ObjectName(i)`, ищет по подстрокам `fut_hft_point_` и `fut_ice_point_`, логирует `ObjectsTotal()`, имя, MT4-тип, цену, `distance` и `strength`, и выбирает ближайший к текущей цене объект.\n
- Расширена панель статуса `DrawStatusPanel()` в `AI_Ideas_Trader.mq4` для вывода: `HFT object: yes/no`, `type`, `price`, `distance`, `strength`.\n
- Добавлена функция `BuildHftObjectJson()` в MQL для формирования JSON ближайшего объекта (или `available:false`), чтобы MT4 bridge мог отдавать выбранный объект в единый контракт.\n
- Расширена серверная обработка в `app/main.py`: `_extract_mt4_rich_fields()` умеет принимать ближайший объект как вложенный `hft_object` или как плоские поля `hft_object_*`, сохраняет `hft_object_found`, `hft_object_name`, `hft_object_type`, `hft_object_price`, `hft_object_distance`, `hft_object_strength`, и включает эти поля в отладочный вывод `_mt4_debug_rich_fields()` и в payload для `save_volume_cluster_payload`.\n
- Добавлен модульный тест `tests/test_mt4_hft_object_bridge.py`, покрывающий и nested, и flat контракты для HFT/ICE объектов.\n
- Изменённые файлы: `AI_Ideas_Trader.mq4`, `app/main.py`, добавлен `tests/test_mt4_hft_object_bridge.py`.\n
### Testing
- Собрана проверка синтаксиса `python3 -m compileall app/main.py`, сборка прошла успешно.\n
- Прогон тестов `pytest -q tests/test_mt4_hft_object_bridge.py tests/test_mt4_volume_cluster.py tests/test_mt4_margin_zones.py` завершился успешно (все тесты прошли).\n
- Автоматические тесты: `12 passed` (есть предупреждения времени выполнения, не влияющие на логику).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37fc6f2e3c83318e381728fd3f387b)