### PR TITLE
Интеграция HFT Stop Hunt слоя

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 
 ## Что обновлено в версии 3.9
+- Интегрирован HFT Stop Hunt layer в `/api/ideas` и `/ideas/market`: поля MT4 Bridge v4 `hft_object_available`, `hft_point_type`, `hft_point_side`, `hft_point_price` теперь формируют `hft_layer`, расстояние до точки, bias, strength и ограниченную корректировку Score ±8 без создания самостоятельного сигнала.
+- HFT-диагностика добавлена в `learning_snapshot`, `advisor_filter_debug` и карточку `/ideas`; старые слои MZ, Heatmap, DPOC, CumDelta, Future Volume/Delta, Options, News/Fundamental и Lifecycle сохранены.
 - Добавлен prop-desk execution layer для `/api/ideas/market` и `/api/ideas` без удаления legacy MT4-полей: killzone, ATR(14), RVOL, VWAP, news lock, correlation risk, cooldown after losses, dynamic risk и market regime.
 - Новые поля включают `base_score`, `execution_score`, `final_score`, `killzone_status`, `atr_pips`, `rvol`, `vwap_alignment`, `news_lock_active`, `correlation_block`, `cooldown_active`, `risk_per_trade_pct`, `recommended_lot`, `market_regime`.
 - Старые поля `entry`, `sl`, `tp`, `signal`, `action`, `trade_permission`, `advisor_allowed`, `score`, `grade`, `mode` сохранены; при блокировках исполнения выставляется `mode=NO TRADE`.

--- a/app/services/idea_lifecycle.py
+++ b/app/services/idea_lifecycle.py
@@ -463,6 +463,12 @@ def _with_advisor_compat_fields(idea: dict[str, Any], archive: list[dict[str, An
         "news_impact": idea.get("news_impact"),
         "minutes_to_event": idea.get("minutes_to_event"),
         "fundamental_score_adjustment": score_adjustment,
+        "hft_object_available": idea.get("hft_object_available") or (idea.get("hft_layer") or {}).get("available") if isinstance(idea.get("hft_layer"), dict) else idea.get("hft_object_available"),
+        "hft_point_type": idea.get("hft_point_type") or (idea.get("hft_layer") or {}).get("type") if isinstance(idea.get("hft_layer"), dict) else idea.get("hft_point_type"),
+        "hft_point_side": idea.get("hft_point_side") or (idea.get("hft_layer") or {}).get("side") if isinstance(idea.get("hft_layer"), dict) else idea.get("hft_point_side"),
+        "hft_point_price": idea.get("hft_point_price") or (idea.get("hft_layer") or {}).get("price") if isinstance(idea.get("hft_layer"), dict) else idea.get("hft_point_price"),
+        "distance_points": idea.get("hft_distance_points") or (idea.get("hft_layer") or {}).get("distance_points") if isinstance(idea.get("hft_layer"), dict) else idea.get("hft_distance_points"),
+        "hft_score_adjustment": idea.get("hft_score_adjustment") or (idea.get("hft_layer") or {}).get("score_adjustment") if isinstance(idea.get("hft_layer"), dict) else idea.get("hft_score_adjustment"),
     }
 
     for key, value in idea.items():
@@ -553,6 +559,12 @@ def _learning_snapshot(idea: dict[str, Any], *, created_at_utc: str) -> dict[str
         "mode": idea.get("mode") or idea.get("prop_mode") or advisor.get("mode") or prop.get("mode"),
         "market_structure_bias": idea.get("market_structure_bias") or idea.get("structure_bias") or idea.get("marketStructureBias"),
         "options_bias": idea.get("options_bias") or idea.get("optionsBias") or idea.get("external_options_bias"),
+        "hft_available": idea.get("hft_object_available") or prop.get("hft_object_available") or ((idea.get("hft_layer") or {}).get("available") if isinstance(idea.get("hft_layer"), dict) else None),
+        "hft_type": idea.get("hft_point_type") or prop.get("hft_point_type") or ((idea.get("hft_layer") or {}).get("type") if isinstance(idea.get("hft_layer"), dict) else None),
+        "hft_side": idea.get("hft_point_side") or prop.get("hft_point_side") or ((idea.get("hft_layer") or {}).get("side") if isinstance(idea.get("hft_layer"), dict) else None),
+        "hft_distance": idea.get("hft_distance_points") or prop.get("hft_distance_points") or ((idea.get("hft_layer") or {}).get("distance_points") if isinstance(idea.get("hft_layer"), dict) else None),
+        "hft_bias": idea.get("hft_bias") or prop.get("hft_bias") or ((idea.get("hft_layer") or {}).get("bias") if isinstance(idea.get("hft_layer"), dict) else None),
+        "hft_score_adjustment": idea.get("hft_score_adjustment") or prop.get("hft_score_adjustment") or ((idea.get("hft_layer") or {}).get("score_adjustment") if isinstance(idea.get("hft_layer"), dict) else None),
         "news_risk": idea.get("news_risk"),
         "fundamental_status": idea.get("fundamental_status"),
         "sentiment_alignment": idea.get("sentiment_alignment"),

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -635,6 +635,114 @@ def _hft_signal_context(idea: dict[str, Any]) -> dict[str, Any]:
     return {"hft_signal": "", "hft_signal_source": "unavailable"}
 
 
+
+def _bool_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value or "").lower().strip() in {"1", "true", "yes", "y", "on"}
+
+
+def _current_price_for_hft(idea: dict[str, Any], candles: list[dict[str, Any]] | None = None) -> float | None:
+    current_price = _to_float(idea.get("current_price") or idea.get("price") or idea.get("last") or idea.get("close"))
+    if current_price is not None:
+        return current_price
+    rows = candles if candles is not None else _candles(idea)
+    if rows:
+        current_price = _to_float(rows[-1].get("close"))
+        if current_price is not None:
+            return current_price
+    return _to_float(idea.get("entry") or idea.get("entry_price"))
+
+
+def _hft_layer_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
+    symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
+    timeframe = str(idea.get("timeframe") or idea.get("tf") or "").upper().strip() or None
+    sources: list[tuple[str, dict[str, Any] | None]] = [
+        ("idea", idea),
+        ("analysis", idea.get("analysis") if isinstance(idea.get("analysis"), dict) else None),
+        ("market_context", idea.get("market_context") if isinstance(idea.get("market_context"), dict) else None),
+        ("market_structure", idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None),
+    ]
+    if symbol:
+        sources.append(("mt4_candle_store", _mt4_store_context(symbol, timeframe)))
+        sources.append(("mt4_volume_cluster", get_latest_volume_cluster(symbol, timeframe)))
+
+    raw: dict[str, Any] | None = None
+    source = "unavailable"
+    for source_name, payload in sources:
+        if not isinstance(payload, dict):
+            continue
+        nested = payload.get("hft_layer") if isinstance(payload.get("hft_layer"), dict) else payload
+        available = _bool_value(nested.get("hft_object_available") if "hft_object_available" in nested else nested.get("available"))
+        point_price = _to_float(nested.get("hft_point_price") if "hft_point_price" in nested else nested.get("price"))
+        if available and point_price is not None:
+            raw = nested
+            source = source_name
+            break
+
+    unavailable = {
+        "available": False,
+        "type": None,
+        "side": None,
+        "price": None,
+        "distance_points": None,
+        "bias": "neutral",
+        "strength": 0,
+        "score_adjustment": 0,
+        "source": source,
+        "summary_ru": "HFT Stop Hunt недоступен; слой не создаёт сигнал и не влияет на score.",
+    }
+    if raw is None:
+        return unavailable
+
+    current_price = _current_price_for_hft(idea)
+    point_price = _to_float(raw.get("hft_point_price") if "hft_point_price" in raw else raw.get("price"))
+    side = str(raw.get("hft_point_side") or raw.get("side") or "").lower().strip()
+    point_type = str(raw.get("hft_point_type") or raw.get("type") or "hft").lower().strip() or "hft"
+    if point_price is None:
+        return unavailable
+    if side not in {"above", "below"} and current_price is not None:
+        side = "above" if point_price > current_price else "below" if point_price < current_price else "near"
+    distance = abs(current_price - point_price) if current_price is not None else None
+    bias = "bearish" if side == "above" else "bullish" if side == "below" else "neutral"
+
+    if distance is None or distance > 300:
+        strength, adjustment = 0, 0
+    elif distance <= 50:
+        strength = 7
+        adjustment = 6
+    elif distance <= 150:
+        strength = 5
+        adjustment = 4
+    else:
+        strength = 3
+        adjustment = 3
+
+    aligned = (direction == "SELL" and bias == "bearish") or (direction == "BUY" and bias == "bullish")
+    if direction not in {"BUY", "SELL"} or adjustment == 0:
+        score_adjustment = 0
+    elif aligned:
+        score_adjustment = adjustment
+    else:
+        score_adjustment = -min(8, adjustment + 2)
+
+    location_ru = "выше" if side == "above" else "ниже" if side == "below" else "рядом с"
+    support_ru = "поддерживает текущую продажу" if direction == "SELL" and aligned else "поддерживает текущую покупку" if direction == "BUY" and aligned else "ослабляет текущий сценарий" if direction in {"BUY", "SELL"} and not aligned and score_adjustment < 0 else "не влияет на текущий сценарий"
+    return {
+        "available": True,
+        "type": point_type,
+        "side": side,
+        "price": point_price,
+        "distance_points": round(distance, 1) if distance is not None else None,
+        "bias": bias,
+        "strength": strength,
+        "score_adjustment": max(-8, min(8, int(score_adjustment))),
+        "source": source,
+        "summary_ru": f"Ликвидность находится {location_ru} рынка. Сценарий {support_ru}.",
+    }
+
 def _dpoc_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     timeframe = str(idea.get("timeframe") or idea.get("tf") or "").upper().strip() or None
@@ -1156,9 +1264,10 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     margin_zone = _margin_zone_context(safe_idea)
     max_pain = _max_pain_context(safe_idea, direction, external_options)
     heatmap = _heatmap_context(safe_idea, direction, geo)
+    hft_layer = _hft_layer_context(safe_idea, direction)
     volume_delta_source = volume_delta.get("source")
     hft_signal = volume_delta.get("hft_signal") or _hft_signal_context(safe_idea).get("hft_signal")
-    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0) + int(heatmap.get("score_adjustment") or 0)))
+    score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + int(volume_delta.get("score_adjustment") or 0) + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0) + int(heatmap.get("score_adjustment") or 0) + int(hft_layer.get("score_adjustment") or 0)))
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     external_options_note = ""
@@ -1234,6 +1343,7 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
             "hft_signal": hft_signal,
             "heatmap_score": heatmap.get("heatmap_score"),
             "heatmap_reason_ru": heatmap.get("heatmap_reason_ru"),
+            "hft_score_adjustment": hft_layer.get("score_adjustment"),
         },
         "criteria": rows,
         "blockers": blockers,
@@ -1270,6 +1380,14 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "heatmap_wall_above_size": heatmap.get("heatmap_wall_above_size"),
         "heatmap_wall_below_size": heatmap.get("heatmap_wall_below_size"),
         "heatmap_bias": heatmap.get("heatmap_bias"),
+        "hft_layer": hft_layer,
+        "hft_object_available": hft_layer.get("available"),
+        "hft_point_type": hft_layer.get("type"),
+        "hft_point_side": hft_layer.get("side"),
+        "hft_point_price": hft_layer.get("price"),
+        "hft_distance_points": hft_layer.get("distance_points"),
+        "hft_bias": hft_layer.get("bias"),
+        "hft_score_adjustment": hft_layer.get("score_adjustment"),
         "real_candle_diagnostics": candle_diag,
         "volume_delta_source": volume_delta_source,
         "hft_signal": hft_signal,
@@ -1342,6 +1460,7 @@ def _advisor_signal_from_idea(idea: dict[str, Any], score: dict[str, Any]) -> di
         "diagnostics": score.get("diagnostics"),
         "volume_delta_source": score.get("volume_delta_source"),
         "hft_signal": score.get("hft_signal"),
+        "hft_layer": score.get("hft_layer"),
     }
 
 
@@ -1357,6 +1476,16 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
         market_context.get("margin_upper"),
     )
     score = build_prop_signal_score(idea)
+    if not isinstance(score.get("hft_layer"), dict):
+        hft_layer = _hft_layer_context(idea, str(score.get("direction") or _direction(idea)).upper())
+        score["hft_layer"] = hft_layer
+        score["hft_object_available"] = hft_layer.get("available")
+        score["hft_point_type"] = hft_layer.get("type")
+        score["hft_point_side"] = hft_layer.get("side")
+        score["hft_point_price"] = hft_layer.get("price")
+        score["hft_distance_points"] = hft_layer.get("distance_points")
+        score["hft_bias"] = hft_layer.get("bias")
+        score["hft_score_adjustment"] = hft_layer.get("score_adjustment")
     advisor_signal = _advisor_signal_from_idea(idea, score)
     enriched = dict(idea)
     action = str(advisor_signal.get("action") or score.get("direction") or "WAIT").upper()
@@ -1390,6 +1519,10 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
         {
             "prop_signal_score": score,
             "prop_score": score["score"],
+            "propScore": score["score"],
+            "confidence": score["score"],
+            "propConfidence": score["score"],
+            "score": score["score"],
             "prop_grade": score["grade"],
             "prop_mode": score["mode"],
             "prop_decision_ru": score["decision_ru"],
@@ -1411,6 +1544,14 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "volume_delta": score.get("volume_delta"),
             "volume_delta_source": score.get("volume_delta_source"),
             "hft_signal": score.get("hft_signal"),
+            "hft_layer": score.get("hft_layer"),
+            "hft_object_available": score.get("hft_object_available"),
+            "hft_point_type": score.get("hft_point_type"),
+            "hft_point_side": score.get("hft_point_side"),
+            "hft_point_price": score.get("hft_point_price"),
+            "hft_distance_points": score.get("hft_distance_points"),
+            "hft_bias": score.get("hft_bias"),
+            "hft_score_adjustment": score.get("hft_score_adjustment"),
             "delta_divergence": score.get("delta_divergence"),
             "dpoc": score.get("dpoc"),
             "dpoc_price": score.get("dpoc_price"),

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -698,6 +698,40 @@ function renderStatusPills(idea) {
   return `<div class="status-pill-row">${pills.map(([label, cls]) => `<span class="status-pill ${cls}">${escapeHtml(label)}</span>`).join("")}</div>`;
 }
 
+function resolveHftLayer(idea) {
+  const layer = idea && typeof idea.hft_layer === "object" && idea.hft_layer ? idea.hft_layer : {};
+  return {
+    available: Boolean(layer.available ?? idea?.hft_object_available),
+    bias: String(layer.bias || idea?.hft_bias || "neutral"),
+    strength: layer.strength ?? idea?.hft_strength ?? 0,
+    side: String(layer.side || idea?.hft_point_side || ""),
+    price: layer.price ?? idea?.hft_point_price,
+    distance: layer.distance_points ?? idea?.hft_distance_points,
+    adjustment: layer.score_adjustment ?? idea?.hft_score_adjustment ?? 0,
+    summary: layer.summary_ru || idea?.hft_summary_ru || "HFT Stop Hunt недоступен; слой не влияет на сигнал.",
+  };
+}
+
+function renderHftLayer(idea, { compact = false } = {}) {
+  const hft = resolveHftLayer(idea);
+  if (!hft.available) return compact ? "" : `<section class="modal-section hft-layer"><h4>HFT Stop Hunt</h4><p class="modal-text">${escapeHtml(hft.summary)}</p></section>`;
+  const biasLabel = hft.bias ? hft.bias.charAt(0).toUpperCase() + hft.bias.slice(1) : "Neutral";
+  const text = `${hft.summary} Цена HFT: ${formatNumber(hft.price)} · дистанция ${formatNumber(hft.distance)} пунктов · влияние score ${Number(hft.adjustment) >= 0 ? "+" : ""}${hft.adjustment}.`;
+  if (compact) {
+    return `<section class="institutional-section hft-layer"><h4>HFT Stop Hunt</h4><p>Bias: ${escapeHtml(biasLabel)} · Strength: ${escapeHtml(hft.strength)}/10<br>${escapeHtml(hft.summary)}</p></section>`;
+  }
+  return `<section class="modal-section hft-layer" style="margin-top:16px;">
+    <h4>HFT Stop Hunt</h4>
+    <div class="modal-meta">
+      <div><span>Bias</span><strong>${escapeHtml(biasLabel)}</strong></div>
+      <div><span>Strength</span><strong>${escapeHtml(hft.strength)}/10</strong></div>
+      <div><span>Side</span><strong>${escapeHtml(hft.side || "—")}</strong></div>
+      <div><span>Score</span><strong>${Number(hft.adjustment) >= 0 ? "+" : ""}${escapeHtml(hft.adjustment)}</strong></div>
+    </div>
+    <p class="modal-text">${escapeHtml(text)}</p>
+  </section>`;
+}
+
 function renderInstitutionalSections(idea) {
   const vd = resolveVolumeDelta(idea);
   const newsEvent = valueOrDash(idea.news_event, resolveNewsContext(idea));
@@ -711,6 +745,7 @@ function renderInstitutionalSections(idea) {
     <section class="institutional-section"><h4>Orderflow</h4><p>⚡ DOM ${escapeHtml(valueOrDash(idea.dom_bias))} · Absorption ${escapeHtml(valueOrDash(idea.absorption))} · CVD div ${escapeHtml(valueOrDash(idea.cvd_divergence, vd.divergence))}<br>${escapeHtml(heatmap)}</p></section>
     <section class="institutional-section"><h4>Options</h4><p>🧩 Bias ${escapeHtml(resolveExternalOptionsBias(idea))} · Max Pain ${escapeHtml(formatListValue(resolveOptionsMaxPain(idea)))} · Strikes ${escapeHtml(formatListValue(resolveOptionsKeyStrikes(idea)))}</p></section>
     <section class="institutional-section"><h4>News/Fundamental</h4><p>📰 ${escapeHtml(newsEvent)} · Impact ${escapeHtml(newsImpact)} · до события ${escapeHtml(minutes)} мин.</p></section>
+    ${renderHftLayer(idea, { compact: true })}
     <section class="institutional-section"><h4>Risk/Execution</h4><p>🛡️ Execution ${escapeHtml(valueOrDash(idea.execution_score))} · Final ${escapeHtml(valueOrDash(idea.final_score, idea.score))} · Risk ${escapeHtml(valueOrDash(idea.risk_per_trade_pct, idea.recommended_risk_percent))}%</p></section>
   </div>`;
 }
@@ -831,6 +866,7 @@ function openIdeaModal(idea) {
       <div>
         ${renderPropDetails(idea)}
         ${renderExecutionAnalysis(idea)}
+        ${renderHftLayer(idea)}
         <section class="modal-section" style="margin-top:16px;">
           <h4>Smart Money Narrative</h4>
           <p class="modal-text"><strong>narrative_source:</strong> ${escapeHtml(idea.narrative_source || aiSource.label)}</p>

--- a/tests/test_hft_layer.py
+++ b/tests/test_hft_layer.py
@@ -1,0 +1,72 @@
+from app.services.idea_lifecycle import apply_idea_lifecycle
+from app.services.prop_signal_engine import enrich_idea_with_prop_score
+
+
+def _idea(**overrides):
+    base = {
+        "symbol": "XAUUSD",
+        "timeframe": "M15",
+        "signal": "SELL",
+        "entry": 4200.0,
+        "sl": 4210.0,
+        "tp": 4180.0,
+        "current_price": 4199.6,
+        "candles": [{"open": 4190.0, "high": 4205.0, "low": 4188.0, "close": 4199.6}] * 30,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_hft_layer_supports_existing_sell_signal_and_updates_score_fields():
+    enriched = enrich_idea_with_prop_score(
+        _idea(
+            hft_object_available=True,
+            hft_point_type="hft",
+            hft_point_side="above",
+            hft_point_price=4213.8,
+        )
+    )
+
+    hft = enriched["hft_layer"]
+    assert hft["available"] is True
+    assert hft["type"] == "hft"
+    assert hft["side"] == "above"
+    assert hft["price"] == 4213.8
+    assert hft["distance_points"] == 14.2
+    assert hft["bias"] == "bearish"
+    assert hft["strength"] == 7
+    assert 3 <= hft["score_adjustment"] <= 8
+    assert enriched["confidence"] == enriched["prop_score"] == enriched["propScore"] == enriched["propConfidence"]
+
+
+def test_hft_layer_does_not_adjust_score_when_far_away():
+    with_hft = enrich_idea_with_prop_score(
+        _idea(hft_object_available=True, hft_point_type="hft", hft_point_side="above", hft_point_price=4605.0)
+    )
+
+    assert with_hft["hft_layer"]["distance_points"] > 300
+    assert with_hft["hft_layer"]["score_adjustment"] == 0
+
+
+def test_learning_snapshot_contains_hft_fields(tmp_path, monkeypatch):
+    import app.services.idea_lifecycle as lifecycle
+
+    monkeypatch.setattr(lifecycle, "ACTIVE_FILE", tmp_path / "active_ideas.json")
+    payload = apply_idea_lifecycle([
+        enrich_idea_with_prop_score(
+            _idea(
+                hft_object_available=True,
+                hft_point_type="hft",
+                hft_point_side="above",
+                hft_point_price=4213.8,
+            )
+        )
+    ])
+
+    snapshot = payload["active"][0]["learning_snapshot"]
+    assert snapshot["hft_available"] is True
+    assert snapshot["hft_type"] == "hft"
+    assert snapshot["hft_side"] == "above"
+    assert snapshot["hft_distance"] == 14.2
+    assert snapshot["hft_bias"] == "bearish"
+    assert snapshot["hft_score_adjustment"] > 0


### PR DESCRIPTION
### Motivation
- Добавить поддержку HFT-индикаторов из MT4 Bridge v4 в пайплайн идей как отдельный необязательный слой, который не создает самостоятельные сигналы, а лишь корректирует существующий `prop`-score с ограничением влияния ±8. 

### Description
- Добавлена функция `_hft_layer_context` и вспомогательные `_bool_value`/`_current_price_for_hft` в `app/services/prop_signal_engine.py` для парсинга полей `hft_object_available`, `hft_point_price`, `hft_point_type`, `hft_point_side` и вычисления `distance_points`, `bias`, `strength` и `score_adjustment`.
- HFT учтён в `build_prop_signal_score` и `enrich_idea_with_prop_score` как негенерирующий слой с пробросом полей в итоговый payload (`hft_layer`, `hft_object_available`, `hft_point_type`, `hft_point_side`, `hft_point_price`, `hft_distance_points`, `hft_bias`, `hft_score_adjustment`) и обновлением совместимых полей `prop_score`, `propScore`, `confidence`, `propConfidence` и `score`.
- Расширены debug/learning контракты в `app/services/idea_lifecycle.py`: добавлены поля в `advisor_filter_debug` и `learning_snapshot` (`hft_available`, `hft_type`, `hft_side`, `hft_distance`, `hft_bias`, `hft_score_adjustment`) для обучения и отладки.
- Frontend: добавлены `resolveHftLayer` и `renderHftLayer` в `app/static/ideas.js` и HFT-блокы вставлены в карточку и modal detail-view (`/ideas`) с русской подсказкой и краткой/полной версией отображения.
- Документация: обновлён `README.md` с описанием интеграции HFT и сохранения legacy-слоёв (MZ, Heatmap, DPOC, CumDelta, Future Volume/Delta, Options, News/Fundamental, Lifecycle).
- Тесты: добавлен `tests/test_hft_layer.py`, покрывающий сценарии aligned SELL, отсутствие влияния при большой дистанции и наличие полей в `learning_snapshot`.

### Testing
- Запущены юнит-тесты: `pytest -q tests/test_hft_layer.py tests/test_mt4_heatmap_bridge.py tests/test_mt4_dpoc.py tests/test_idea_lifecycle_api.py`, все тесты прошли успешно (`17 passed`).
- Проверена корректность синтаксиса модулей через `python3 -m py_compile app/services/prop_signal_engine.py app/services/idea_lifecycle.py` и `node --check app/static/ideas.js`, оба прогона прошли без ошибок.
- Добавлен и выполнен набор новых автоматизированных тестов `tests/test_hft_layer.py`, которые подтверждают поведение слоя и прокидку полей в `learning_snapshot`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a380ceca87c8331822222a12f7bcd57)