### PR TITLE
Сохранение HFT-полей MT4 для генерации идей

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -244,6 +244,9 @@ def _compact_candle(candle: dict[str, Any]) -> dict[str, Any]:
         "close": float(candle.get("close") or 0.0),
     }
     row.update(_extract_mt4_heatmap_fields(candle))
+    for field, value in _extract_mt4_rich_fields(candle).items():
+        if field.startswith("hft_") and value not in (None, ""):
+            row[field] = value
     return row
 
 
@@ -313,6 +316,22 @@ def _extract_mt4_rich_fields(payload: dict[str, Any]) -> dict[str, Any]:
     if hft_signal:
         rich["hft_signal"] = hft_signal
 
+    hft_available = _mt4_bool_or_none(payload.get("hft_object_available"))
+    if hft_available is not None:
+        rich["hft_object_available"] = hft_available
+    hft_point_price = _first_mt4_float(payload, ("hft_point_price",), positive_only=True)
+    if hft_point_price is not None:
+        rich["hft_point_price"] = hft_point_price
+    hft_point_type = str(payload.get("hft_point_type") or "").strip()
+    if hft_point_type:
+        rich["hft_point_type"] = hft_point_type
+    hft_point_side = str(payload.get("hft_point_side") or "").strip()
+    if hft_point_side:
+        rich["hft_point_side"] = hft_point_side
+    hft_point_strength = _first_mt4_float(payload, ("hft_point_strength",))
+    if hft_point_strength is not None:
+        rich["hft_point_strength"] = hft_point_strength
+
     margin_source = str(payload.get("margin_source") or "").strip()
     if margin_source:
         rich["margin_source"] = margin_source
@@ -364,6 +383,11 @@ def _mt4_debug_rich_fields(item: dict[str, Any]) -> dict[str, Any]:
             "future_delta",
             "cumulative_delta",
             "hft_signal",
+            "hft_object_available",
+            "hft_point_price",
+            "hft_point_type",
+            "hft_point_side",
+            "hft_point_strength",
             "margin_source",
             *MT4_HEATMAP_FIELDS,
         )
@@ -1380,6 +1404,11 @@ def api_mt4_ingest_get(
     heatmap_wall_below_size: float = 0.0,
     heatmap_bias: str = "",
     hft_signal: str = "",
+    hft_object_available: bool | None = None,
+    hft_point_price: float = 0.0,
+    hft_point_type: str = "",
+    hft_point_side: str = "",
+    hft_point_strength: float = 0.0,
     bars: str = "",
     broker: str = "",
     account: str = "",
@@ -1408,6 +1437,11 @@ def api_mt4_ingest_get(
         "heatmap_wall_above_size": heatmap_wall_above_size,
         "heatmap_wall_below_size": heatmap_wall_below_size,
         "heatmap_bias": heatmap_bias,
+        "hft_object_available": hft_object_available,
+        "hft_point_price": hft_point_price,
+        "hft_point_type": hft_point_type,
+        "hft_point_side": hft_point_side,
+        "hft_point_strength": hft_point_strength,
     })
     existing = (MT4_CANDLE_STORE.get(store_key) or {}).get("candles") or []
     merged = {int(c.get("time") or 0): c for c in existing if isinstance(c, dict) and int(c.get("time") or 0) > 0}
@@ -1431,6 +1465,11 @@ def api_mt4_ingest_get(
         "future_delta": future_delta,
         "cumulative_delta": cumulative_delta,
         "hft_signal": hft_signal,
+        "hft_object_available": hft_object_available,
+        "hft_point_price": hft_point_price,
+        "hft_point_type": hft_point_type,
+        "hft_point_side": hft_point_side,
+        "hft_point_strength": hft_point_strength,
         "margin_source": margin_source,
         "heatmap_available": heatmap_available,
         "heatmap_wall_above": heatmap_wall_above,
@@ -1482,6 +1521,11 @@ def api_mt4_ingest_get(
         "margin_zone_upper": rich_fields.get("margin_zone_upper"),
         "margin_source": margin_source or "Future_Volume_v5.00",
         "hft_signal": hft_signal,
+        "hft_object_available": rich_fields.get("hft_object_available"),
+        "hft_point_price": rich_fields.get("hft_point_price"),
+        "hft_point_type": rich_fields.get("hft_point_type"),
+        "hft_point_side": rich_fields.get("hft_point_side"),
+        "hft_point_strength": rich_fields.get("hft_point_strength"),
         **rich_fields,
         "bars": bars,
         "broker": broker,

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -659,6 +659,11 @@ def _current_price_for_hft(idea: dict[str, Any], candles: list[dict[str, Any]] |
 def _hft_layer_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     timeframe = str(idea.get("timeframe") or idea.get("tf") or "").upper().strip() or None
+    mt4_store_payload = _mt4_store_context(symbol, timeframe) if symbol else None
+    latest_mt4_candle = None
+    if isinstance(mt4_store_payload, dict):
+        mt4_candles = [row for row in mt4_store_payload.get("candles") or [] if isinstance(row, dict)]
+        latest_mt4_candle = mt4_candles[-1] if mt4_candles else None
     sources: list[tuple[str, dict[str, Any] | None]] = [
         ("idea", idea),
         ("analysis", idea.get("analysis") if isinstance(idea.get("analysis"), dict) else None),
@@ -666,21 +671,36 @@ def _hft_layer_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
         ("market_structure", idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else None),
     ]
     if symbol:
-        sources.append(("mt4_candle_store", _mt4_store_context(symbol, timeframe)))
+        sources.append(("mt4_candle_store", mt4_store_payload))
+        sources.append(("mt4_latest_candle", latest_mt4_candle))
         sources.append(("mt4_volume_cluster", get_latest_volume_cluster(symbol, timeframe)))
 
     raw: dict[str, Any] | None = None
     source = "unavailable"
+    received_from_ingest = False
+    stored_in_mt4_store = False
     for source_name, payload in sources:
         if not isinstance(payload, dict):
             continue
         nested = payload.get("hft_layer") if isinstance(payload.get("hft_layer"), dict) else payload
         available = _bool_value(nested.get("hft_object_available") if "hft_object_available" in nested else nested.get("available"))
         point_price = _to_float(nested.get("hft_point_price") if "hft_point_price" in nested else nested.get("price"))
-        if available and point_price is not None:
+        if available is not None or point_price is not None:
+            received_from_ingest = received_from_ingest or source_name in {"mt4_candle_store", "mt4_latest_candle", "mt4_volume_cluster"}
+            stored_in_mt4_store = stored_in_mt4_store or source_name in {"mt4_candle_store", "mt4_latest_candle"}
+        if available and point_price is not None and point_price > 0:
             raw = nested
             source = source_name
             break
+
+    debug = {
+        "received_from_ingest": received_from_ingest,
+        "stored_in_mt4_store": stored_in_mt4_store,
+        "attached_to_idea": raw is not None,
+        "hft_point_price": _to_float(raw.get("hft_point_price") if "hft_point_price" in raw else raw.get("price")) if isinstance(raw, dict) else None,
+        "hft_point_type": (raw.get("hft_point_type") or raw.get("type")) if isinstance(raw, dict) else None,
+        "hft_point_side": (raw.get("hft_point_side") or raw.get("side")) if isinstance(raw, dict) else None,
+    }
 
     unavailable = {
         "available": False,
@@ -692,6 +712,7 @@ def _hft_layer_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
         "strength": 0,
         "score_adjustment": 0,
         "source": source,
+        "hft_debug": debug,
         "summary_ru": "HFT Stop Hunt недоступен; слой не создаёт сигнал и не влияет на score.",
     }
     if raw is None:
@@ -699,7 +720,11 @@ def _hft_layer_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
 
     current_price = _current_price_for_hft(idea)
     point_price = _to_float(raw.get("hft_point_price") if "hft_point_price" in raw else raw.get("price"))
-    side = str(raw.get("hft_point_side") or raw.get("side") or "").lower().strip()
+    side = str(raw.get("hft_point_side") or raw.get("side") or "").lower().strip().replace("-", "_")
+    if side in {"above_price", "aboveprice", "above_market"}:
+        side = "above"
+    elif side in {"below_price", "belowprice", "below_market"}:
+        side = "below"
     point_type = str(raw.get("hft_point_type") or raw.get("type") or "hft").lower().strip() or "hft"
     if point_price is None:
         return unavailable
@@ -719,6 +744,9 @@ def _hft_layer_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
     else:
         strength = 3
         adjustment = 3
+    explicit_strength = _to_float(raw.get("hft_point_strength") or raw.get("strength"))
+    if explicit_strength is not None and explicit_strength > 0:
+        strength = max(0, min(10, int(round(explicit_strength))))
 
     aligned = (direction == "SELL" and bias == "bearish") or (direction == "BUY" and bias == "bullish")
     if direction not in {"BUY", "SELL"} or adjustment == 0:
@@ -740,6 +768,13 @@ def _hft_layer_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
         "strength": strength,
         "score_adjustment": max(-8, min(8, int(score_adjustment))),
         "source": source,
+        "hft_debug": {
+            **debug,
+            "attached_to_idea": True,
+            "hft_point_price": point_price,
+            "hft_point_type": point_type,
+            "hft_point_side": side,
+        },
         "summary_ru": f"Ликвидность находится {location_ru} рынка. Сценарий {support_ru}.",
     }
 
@@ -1388,6 +1423,7 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
         "hft_distance_points": hft_layer.get("distance_points"),
         "hft_bias": hft_layer.get("bias"),
         "hft_score_adjustment": hft_layer.get("score_adjustment"),
+        "hft_debug": hft_layer.get("hft_debug"),
         "real_candle_diagnostics": candle_diag,
         "volume_delta_source": volume_delta_source,
         "hft_signal": hft_signal,
@@ -1486,6 +1522,7 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
         score["hft_distance_points"] = hft_layer.get("distance_points")
         score["hft_bias"] = hft_layer.get("bias")
         score["hft_score_adjustment"] = hft_layer.get("score_adjustment")
+        score["hft_debug"] = hft_layer.get("hft_debug")
     advisor_signal = _advisor_signal_from_idea(idea, score)
     enriched = dict(idea)
     action = str(advisor_signal.get("action") or score.get("direction") or "WAIT").upper()
@@ -1552,6 +1589,7 @@ def enrich_idea_with_prop_score(idea: dict[str, Any]) -> dict[str, Any]:
             "hft_distance_points": score.get("hft_distance_points"),
             "hft_bias": score.get("hft_bias"),
             "hft_score_adjustment": score.get("hft_score_adjustment"),
+            "hft_debug": score.get("hft_debug") or ((score.get("hft_layer") or {}).get("hft_debug") if isinstance(score.get("hft_layer"), dict) else None),
             "delta_divergence": score.get("delta_divergence"),
             "dpoc": score.get("dpoc"),
             "dpoc_price": score.get("dpoc_price"),

--- a/tests/test_hft_layer.py
+++ b/tests/test_hft_layer.py
@@ -48,6 +48,35 @@ def test_hft_layer_does_not_adjust_score_when_far_away():
     assert with_hft["hft_layer"]["score_adjustment"] == 0
 
 
+def test_hft_layer_reads_rich_fields_from_mt4_store(monkeypatch):
+    from datetime import datetime, timezone
+
+    from app import main
+
+    main.MT4_CANDLE_STORE["XAUUSD:M15"] = {
+        "symbol": "XAUUSD",
+        "timeframe": "M15",
+        "updated_at": datetime.now(timezone.utc),
+        "candles": [{"time": i + 1, "open": 4190.0, "high": 4205.0, "low": 4188.0, "close": 4199.6} for i in range(30)],
+        "hft_object_available": True,
+        "hft_point_type": "hft",
+        "hft_point_side": "above_price",
+        "hft_point_price": 4213.8,
+        "hft_point_strength": 8.0,
+    }
+    monkeypatch.setattr(main, "fetch_candles", lambda symbol, tf, limit=160: {"candles": main.MT4_CANDLE_STORE["XAUUSD:M15"]["candles"], "provider": "mt4_bridge"})
+
+    enriched = enrich_idea_with_prop_score(_idea())
+
+    assert enriched["hft_layer"]["available"] is True
+    assert enriched["hft_layer"]["source"] == "mt4_candle_store"
+    assert enriched["hft_layer"]["side"] == "above"
+    assert enriched["hft_layer"]["strength"] == 8
+    assert enriched["hft_debug"]["received_from_ingest"] is True
+    assert enriched["hft_debug"]["stored_in_mt4_store"] is True
+    assert enriched["hft_debug"]["attached_to_idea"] is True
+
+
 def test_learning_snapshot_contains_hft_fields(tmp_path, monkeypatch):
     import app.services.idea_lifecycle as lifecycle
 

--- a/tests/test_mt4_heatmap_bridge.py
+++ b/tests/test_mt4_heatmap_bridge.py
@@ -50,6 +50,34 @@ def test_mt4_ingest_get_stores_and_debug_exposes_heatmap_fields():
     assert debug["candles"][-1]["heatmap_bias"] == "bullish"
 
 
+def test_mt4_ingest_get_stores_hft_rich_fields():
+    stamp = int(datetime.now(timezone.utc).timestamp())
+    response = api_mt4_ingest_get(
+        symbol="XAUUSD",
+        tf="M15",
+        time=stamp,
+        open=4200.0,
+        high=4205.0,
+        low=4190.0,
+        close=4199.6,
+        hft_object_available=True,
+        hft_point_price=4213.8,
+        hft_point_type="hft",
+        hft_point_side="above_price",
+        hft_point_strength=8.0,
+    )
+
+    item = main.MT4_CANDLE_STORE["XAUUSD:M15"]
+
+    assert response["ok"] is True
+    assert item["hft_object_available"] is True
+    assert item["hft_point_price"] == 4213.8
+    assert item["hft_point_type"] == "hft"
+    assert item["hft_point_side"] == "above_price"
+    assert item["hft_point_strength"] == 8.0
+    assert item["candles"][-1]["hft_point_price"] == 4213.8
+
+
 def test_build_signal_from_candles_adds_heatmap_fields(monkeypatch):
     rows = [
         {"time": i + 1, "open": 1.1000, "high": 1.1010, "low": 1.0990, "close": 1.1000 + i * 0.00001}


### PR DESCRIPTION
### Motivation
- Исправить потерю HFT-полей между `/api/mt4/ingest-get` и генерацией `/ideas`, чтобы HFT-слой был доступен в созданных идеях. 

### Description
- Добавлены параметры в `GET /api/mt4/ingest-get`: `hft_object_available`, `hft_point_price`, `hft_point_type`, `hft_point_side`, `hft_point_strength`, и они включены в сохраняемый payload и в формирование строки свечи. 
- Расширена функция `_extract_mt4_rich_fields` для извлечения и сохранения HFT-полей (`hft_object_available`, `hft_point_price`, `hft_point_type`, `hft_point_side`, `hft_point_strength`) без изменения существующих MZ / Heatmap / DPOC / CumDelta / FutureVol логик. 
- При сохранении в `MT4_CANDLE_STORE` HFT-поля теперь попадают в объект store и также в поля последней свечи (через `_compact_candle`), чтобы генераторы могли читать данные и с уровня store, и из последней свечи. 
- Обновлён генератор HFT-слоя в `prop_signal_engine` чтобы брать HFT из `mt4_candle_store`, `mt4_latest_candle` и `mt4_volume_cluster`, учитывать `hft_object_available && hft_point_price > 0`, нормализовать алиасы стороны (`above_price`/`below_price`), применять явный `hft_point_strength` при расчётах и не менять советник. 
- Добавлен диагностический объект `hft_debug` с флагами `received_from_ingest`, `stored_in_mt4_store`, `attached_to_idea` и полями точки (`hft_point_price`, `hft_point_type`, `hft_point_side`) и прокинут в score/enriched idea. 
- Добавлены регрессионные тесты: проверка сохранения HFT-полей в `MT4_CANDLE_STORE` и проверка, что enrichment читает HFT из MT4 store и присваивает `hft_layer` и `hft_debug`.

### Testing
- Скомпилированы модули: `python -m py_compile app/main.py app/services/prop_signal_engine.py` (успешно). 
- Запущены тесты: `pytest tests/test_hft_layer.py tests/test_mt4_heatmap_bridge.py`, все тесты прошли: `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38143e0d0c8331bd89b5a87e44a2d0)