### PR TITLE
Добавить переключатель уровня анализа (Segmented Control) на страницу /ideas

### DIFF
--- a/app/static/ideas.css
+++ b/app/static/ideas.css
@@ -397,16 +397,20 @@ h1 {
 .ai-source-chip--fallback { background: linear-gradient(180deg, #ffd166, #fbbf24); border-color: rgba(251,191,36,.82); }
 .ai-source-chip--rule { background: linear-gradient(180deg, #ff8a8a, #ef4444); border-color: rgba(239,68,68,.82); color:#fff; }
 .ai-generated-line { color:#cfe7ff; border-radius: 14px; font-size:12px; }
+.controls {
+  margin: 0 0 18px;
+}
 .analysis-mode-row,
 .view-mode-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 16px;
-  border: 1px solid rgba(95,156,230,.30);
+  padding: 12px;
+  border: 1px solid rgba(95, 156, 230, 0.24);
   border-radius: 20px;
-  background: rgba(3,14,28,.72);
+  background: rgba(3, 14, 28, 0.62);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
 }
 .view-mode-title {
   color: #e8f3ff;
@@ -415,12 +419,14 @@ h1 {
   letter-spacing: .12em;
   text-transform: uppercase;
 }
-.view-mode-toggle { display: flex; flex-wrap: wrap; gap: 8px; }
+.view-mode-toggle { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; min-width: min(100%, 390px); }
 .view-mode-btn {
   border: 1px solid rgba(95,156,230,.42);
   background: rgba(8,25,48,.86);
   color: #dbeeff;
   border-radius: 999px;
+  min-height: 38px;
+  width: 100%;
   padding: 9px 14px;
   font-size: 13px;
   font-weight: 900;
@@ -452,4 +458,4 @@ h1 {
 }
 .analysis-details summary { cursor: pointer; color:#e8f3ff; font-weight:900; }
 .risk-list { display:grid; gap:8px; margin-top:10px; }
-@media(max-width:720px){ .analysis-mode-row,.view-mode-row{align-items:stretch;flex-direction:column;} }
+@media(max-width:720px){ .analysis-mode-row,.view-mode-row{align-items:stretch;flex-direction:column;} .view-mode-toggle{min-width:0;width:100%;} }

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FXPilot v1.5 · Идеи</title>
-  <link rel="stylesheet" href="/static/ideas.css?v=prop-score-ui-5" />
+  <link rel="stylesheet" href="/static/ideas.css?v=analysis-mode-1" />
   <script src="https://unpkg.com/lightweight-charts@4.2.0/dist/lightweight-charts.standalone.production.js"></script>
-  <script src="/static/ideas.js?v=prop-score-ui-5" defer></script>
+  <script src="/static/ideas.js?v=analysis-mode-1" defer></script>
   <script src="/static/ideas-status-fix.js?v=status-fix-1" defer></script>
   <script src="/static/ideas-chart-fix.js?v=chart-hotfix-6" defer></script>
   <script src="/static/ideas-archive-fix.js?v=archive-ui-2" defer></script>
@@ -129,7 +129,7 @@
       <div class="ai-status-card__head"><span class="ai-status-card__dot">⚪</span><div><p class="ai-status-card__kicker">AI Status</p><strong>Проверка статуса...</strong></div></div>
     </section>
 
-    <section class="controls" aria-label="Фильтры идей"></section>
+    <section class="controls" aria-label="Уровень анализа"></section>
 
     <div id="ideasUpdatedAt" class="subtitle" aria-live="polite"></div>
 

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -1,5 +1,6 @@
 const ideasContainer = document.getElementById("ideasContainer");
 const ideasUpdatedAt = document.getElementById("ideasUpdatedAt");
+const ideasControls = document.querySelector(".controls");
 
 const VOICE_STORAGE_KEY = "voice_notifications_enabled";
 const VOICE_REPEAT_WINDOW_MS = 60000;
@@ -743,16 +744,20 @@ function injectUiStyles() {
     .criterion.partial { border-color:rgba(250,204,21,.32); }
     .criterion.missing { border-color:rgba(248,113,113,.28); opacity:.82; }
     .blocker { padding:10px; border-radius:12px; border:1px solid rgba(248,113,113,.25); background:rgba(127,29,29,.22); color:#fecdd3; }
+.controls {
+  margin: 0 0 18px;
+}
 .analysis-mode-row,
 .view-mode-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 16px;
-  border: 1px solid rgba(95,156,230,.30);
+  padding: 12px;
+  border: 1px solid rgba(95, 156, 230, 0.24);
   border-radius: 20px;
-  background: rgba(3,14,28,.72);
+  background: rgba(3, 14, 28, 0.62);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
 }
 .view-mode-title {
   color: #e8f3ff;
@@ -761,12 +766,14 @@ function injectUiStyles() {
   letter-spacing: .12em;
   text-transform: uppercase;
 }
-.view-mode-toggle { display: flex; flex-wrap: wrap; gap: 8px; }
+.view-mode-toggle { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; min-width: min(100%, 390px); }
 .view-mode-btn {
   border: 1px solid rgba(95,156,230,.42);
   background: rgba(8,25,48,.86);
   color: #dbeeff;
   border-radius: 999px;
+  min-height: 38px;
+  width: 100%;
   padding: 9px 14px;
   font-size: 13px;
   font-weight: 900;
@@ -798,7 +805,7 @@ function injectUiStyles() {
 }
 .analysis-details summary { cursor: pointer; color:#e8f3ff; font-weight:900; }
 .risk-list { display:grid; gap:8px; margin-top:10px; }
-@media(max-width:720px){ .analysis-mode-row,.view-mode-row{align-items:stretch;flex-direction:column;} }
+@media(max-width:720px){ .analysis-mode-row,.view-mode-row{align-items:stretch;flex-direction:column;} .view-mode-toggle{min-width:0;width:100%;} }
 
     @media(max-width:1100px){ .ideas-grid{grid-template-columns:repeat(2,minmax(0,1fr));} .modal-grid{grid-template-columns:1fr;} .modal-meta{grid-template-columns:repeat(2,minmax(0,1fr));} }
     @media(max-width:720px){ .page{padding:16px 12px 42px;} .ideas-page-header{padding:20px;} .ideas-grid{grid-template-columns:1fr;} .compact-levels,.criteria-grid,.modal-meta,.institutional-sections{grid-template-columns:1fr;} .idea-card-top{flex-direction:column;} .badge{white-space:normal;} .chart-area,#ideaModalChart{height:390px;min-height:390px;} }
@@ -953,7 +960,26 @@ function renderAiInterpretation(idea) {
 
 function renderModeToggle() {
   const modes = [["brief", "Кратко"], ["hybrid", "Гибрид"], ["expert", "Эксперт"]];
-  return `<div class="analysis-mode-row" aria-label="Уровень анализа"><div><div class="view-mode-title">УРОВЕНЬ АНАЛИЗА</div><div class="idea-news-line">Выбор меняет отображение карточек без повторного запроса API.</div></div><div class="view-mode-toggle">${modes.map(([key, label]) => `<button class="view-mode-btn ${currentIdeaViewMode === key ? "active" : ""}" data-view-mode="${key}">${label}</button>`).join("")}</div></div>`;
+  return `<div class="analysis-mode-row" aria-label="Уровень анализа"><div class="view-mode-title">УРОВЕНЬ АНАЛИЗА</div><div class="view-mode-toggle" role="group" aria-label="Уровень анализа">${modes.map(([key, label]) => `<button type="button" class="view-mode-btn ${currentIdeaViewMode === key ? "active" : ""}" data-view-mode="${key}" aria-pressed="${currentIdeaViewMode === key ? "true" : "false"}">${label}</button>`).join("")}</div></div>`;
+}
+
+function bindModeToggle(root) {
+  if (!root) return;
+  root.querySelectorAll("[data-view-mode]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const nextMode = btn.getAttribute("data-view-mode") || "hybrid";
+      currentIdeaViewMode = ANALYSIS_MODES.has(nextMode) ? nextMode : "hybrid";
+      localStorage.setItem(IDEAS_VIEW_MODE_KEY, currentIdeaViewMode);
+      renderAnalysisModeControl();
+      if (lastPayload) renderIdeas(lastPayload);
+    });
+  });
+}
+
+function renderAnalysisModeControl() {
+  if (!ideasControls) return;
+  ideasControls.innerHTML = renderModeToggle();
+  bindModeToggle(ideasControls);
 }
 
 function renderBriefCardBody(idea) {
@@ -1384,15 +1410,8 @@ function renderIdeas(payload) {
     ideasContainer.innerHTML = `<div class="ideas-loading">Идеи пока недоступны.</div>`;
     return;
   }
-  ideasContainer.innerHTML = renderModeToggle() + renderPropFilters() + (ideas.length ? `<div class="ideas-grid">${ideas.map(renderIdeaCard).join("")}</div>` : `<div class="ideas-loading">Нет идей под выбранный фильтр.</div>`);
-  ideasContainer.querySelectorAll("[data-view-mode]").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const nextMode = btn.getAttribute("data-view-mode") || "hybrid";
-      currentIdeaViewMode = ANALYSIS_MODES.has(nextMode) ? nextMode : "hybrid";
-      localStorage.setItem(IDEAS_VIEW_MODE_KEY, currentIdeaViewMode);
-      renderIdeas(lastPayload);
-    });
-  });
+  renderAnalysisModeControl();
+  ideasContainer.innerHTML = renderPropFilters() + (ideas.length ? `<div class="ideas-grid">${ideas.map(renderIdeaCard).join("")}</div>` : `<div class="ideas-loading">Нет идей под выбранный фильтр.</div>`);
   ideasContainer.querySelectorAll("[data-prop-filter]").forEach((btn) => {
     btn.addEventListener("click", () => {
       currentPropFilter = btn.getAttribute("data-prop-filter") || "all";
@@ -1431,6 +1450,7 @@ function startIdeasPage() {
   injectUiStyles();
   initVoiceToggle();
   createIdeasModal();
+  renderAnalysisModeControl();
   loadIdeas();
   if (ideasPollTimer) clearInterval(ideasPollTimer);
   ideasPollTimer = setInterval(loadIdeas, 60000);


### PR DESCRIPTION
### Motivation
- Реализовать отсутствующий на странице `/ideas` элемент — переключатель «УРОВЕНЬ АНАЛИЗА», чтобы пользователь мог менять детализацию отображения карточек (Кратко / Гибрид / Эксперт) без нового запроса к API.
- Переключатель должен быть видим всегда (включая отсутствие идей) и сохранять выбор между сессиями.

### Description
- Вставлен блок управления сразу после `AI STATUS` и перед строкой обновления в `app/static/ideas.html` и переименованы URL-версии статики для cache-busting (`?v=analysis-mode-1`).
- Добавлены в `app/static/ideas.js`: ссылка на контейнер `.controls`, функция `renderModeToggle()` для генерации Segmented Control, `bindModeToggle()` для привязки обработчиков и `renderAnalysisModeControl()` для рендера контролла независимо от наличия идей; переключение использует `lastPayload` и перерисовывает карточки без дополнительного запроса к API.
- Сохранение выбора реализовано через `localStorage` с ключом `fxpilot-analysis-mode` и значением по умолчанию `hybrid`.
- Обновлён CSS (`app/static/ideas.css`) для тёмного закруглённого Segmented Control: три равных колонки-кнопки, адаптивность, активная кнопка подсвечивается бирюзовым градиентом и стиль соответствует верхнему меню.

### Testing
- Успешно скомпилирована статика и Python-модули с `python3 -m compileall app` и `python3 -m py_compile app/main.py main.py`.
- Запуск приложения и простая проверка страницы прошли (`curl http://127.0.0.1:8765/ideas` и `curl` статики показывают вставку контролла и наличие `fxpilot-analysis-mode` в скомпонованном JS).
- Запущены автоматизированные тесты `pytest tests/api/test_ideas_api.py`, компоновка тестов прошла частично и зафиксирован 1 существующий backend-тестный регресс: `test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback` завершился неудачей (ожидался `narrative_source == "model"`, фактически вернулся `"fallback"`), что не связано с изменением UI на `/ideas`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4780dbb6e08331b5cdf7c30e13d070)