### PR TITLE
Опциональная интеграция FXPilot OrderFlow Engine в /api/ideas/market

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
+from app.services.orderflow_client import UNAVAILABLE_SNAPSHOT, get_orderflow_snapshot, is_orderflow_engine_enabled
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.prop_desk_filters import PropDeskFilterService
 from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_stats, enrich_ideas_with_news_calendar
@@ -1062,6 +1063,24 @@ def generate_trade_ideas() -> tuple[list[dict[str, Any]], list[str]]:
 
 
 
+
+def _attach_orderflow_snapshot(signal: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(signal, dict):
+        return signal
+    normalized = dict(signal)
+    symbol = normalize_symbol(str(normalized.get("symbol") or normalized.get("pair") or normalized.get("instrument") or ""))
+    snapshot = (
+        get_orderflow_snapshot(symbol)
+        if is_orderflow_engine_enabled()
+        else {**UNAVAILABLE_SNAPSHOT, "orderflow_status": "engine_disabled"}
+    )
+    normalized.update(snapshot)
+    return normalized
+
+
+def _attach_orderflow_snapshots(signals: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [_attach_orderflow_snapshot(signal) for signal in signals if isinstance(signal, dict)]
+
 def _apply_prop_desk_execution(ideas: list[dict[str, Any]], archive: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     try:
         return PropDeskFilterService(trade_idea_service.chart_data_service).enrich(ideas, archived_ideas=archive or [], news_events=[])
@@ -1078,6 +1097,7 @@ def build_market() -> dict[str, Any]:
             lifecycle = apply_idea_lifecycle(enriched_signals)
             lifecycle["ideas"] = _apply_prop_desk_execution(lifecycle["ideas"], lifecycle.get("archive") or [])
             lifecycle["ideas"] = enrich_ideas_with_news_calendar(lifecycle["ideas"])
+            lifecycle["ideas"] = _attach_orderflow_snapshots(lifecycle["ideas"])
             return {
                 "signals": lifecycle["ideas"],
                 "ideas": lifecycle["ideas"],

--- a/tests/test_market_ideas_timeout.py
+++ b/tests/test_market_ideas_timeout.py
@@ -54,3 +54,39 @@ def test_json_render_enrichment_never_calls_external_llm(monkeypatch) -> None:
 
     assert enriched["narrative_source"] == "local_safe"
     assert enriched["unified_narrative"]
+
+
+def test_build_market_attaches_orderflow_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("ORDERFLOW_ENGINE_ENABLED", "true")
+    monkeypatch.setattr(main, "generate_trade_ideas", lambda: ([{"symbol": "EURUSD", "signal": "WAIT", "confidence": 50}], []))
+    monkeypatch.setattr(main, "enrich_ideas_with_prop_scores", lambda ideas: ideas)
+    monkeypatch.setattr(main, "_attach_mt4_optionsfx_display_many", lambda ideas: ideas)
+    monkeypatch.setattr(main, "apply_idea_lifecycle", lambda ideas: {"ideas": ideas, "archive": [], "statistics": {"total": len(ideas)}})
+    monkeypatch.setattr(main, "_apply_prop_desk_execution", lambda ideas, archive=None: ideas)
+    monkeypatch.setattr(main, "enrich_ideas_with_news_calendar", lambda ideas: ideas)
+    monkeypatch.setattr(main, "get_orderflow_snapshot", lambda symbol: {"orderflow_available": True, "orderflow_provider": "fxpilot", "delta": 11})
+
+    payload = main.build_market()
+
+    assert payload["ideas"][0]["orderflow_available"] is True
+    assert payload["ideas"][0]["orderflow_provider"] == "fxpilot"
+    assert payload["ideas"][0]["delta"] == 11
+    assert payload["ideas"][0]["signal"] == "WAIT"
+
+
+def test_build_market_marks_orderflow_disabled_without_engine_call(monkeypatch) -> None:
+    monkeypatch.setenv("ORDERFLOW_ENGINE_ENABLED", "false")
+    monkeypatch.setattr(main, "generate_trade_ideas", lambda: ([{"symbol": "EURUSD", "signal": "BUY", "confidence": 60}], []))
+    monkeypatch.setattr(main, "enrich_ideas_with_prop_scores", lambda ideas: ideas)
+    monkeypatch.setattr(main, "_attach_mt4_optionsfx_display_many", lambda ideas: ideas)
+    monkeypatch.setattr(main, "apply_idea_lifecycle", lambda ideas: {"ideas": ideas, "archive": [], "statistics": {"total": len(ideas)}})
+    monkeypatch.setattr(main, "_apply_prop_desk_execution", lambda ideas, archive=None: ideas)
+    monkeypatch.setattr(main, "enrich_ideas_with_news_calendar", lambda ideas: ideas)
+    monkeypatch.setattr(main, "get_orderflow_snapshot", lambda symbol: (_ for _ in ()).throw(AssertionError("engine call")))
+
+    payload = main.build_market()
+
+    assert payload["ideas"][0]["orderflow_available"] is False
+    assert payload["ideas"][0]["orderflow_provider"] == "unavailable"
+    assert payload["ideas"][0]["orderflow_status"] == "engine_disabled"
+    assert payload["ideas"][0]["signal"] == "BUY"

--- a/tests/test_orderflow_client.py
+++ b/tests/test_orderflow_client.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from app.services import orderflow_client
+
+
+class _Response:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_get_orderflow_snapshot_uses_engine_url_symbol_and_timeout(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_get(url: str, *, params: dict, timeout: float):
+        calls.append({"url": url, "params": params, "timeout": timeout})
+        return _Response(
+            {
+                "provider": "fxpilot",
+                "available": True,
+                "delta": 12,
+                "cumdelta": 34,
+                "poc": 1.085,
+                "vah": 1.087,
+                "val": 1.083,
+                "vwap": 1.086,
+                "rvol": 1.4,
+                "dom_pressure": "buy",
+                "absorption": "none",
+                "market_state": "trend",
+                "orderflow_bias": "bullish",
+                "continuation_probability": 62,
+                "reversal_probability": 28,
+            }
+        )
+
+    monkeypatch.setenv("ORDERFLOW_ENGINE_URL", "http://engine.local/")
+    monkeypatch.setattr(orderflow_client.requests, "get", fake_get)
+
+    snapshot = orderflow_client.get_orderflow_snapshot("eurusd")
+
+    assert calls == [
+        {
+            "url": "http://engine.local/api/orderflow/latest",
+            "params": {"symbol": "EURUSD"},
+            "timeout": 2,
+        }
+    ]
+    assert snapshot["orderflow_available"] is True
+    assert snapshot["orderflow_provider"] == "fxpilot"
+    assert snapshot["delta"] == 12
+    assert snapshot["orderflow_bias"] == "bullish"
+
+
+def test_get_orderflow_snapshot_returns_unavailable_on_error(monkeypatch) -> None:
+    def fake_get(*args, **kwargs):
+        raise TimeoutError("offline")
+
+    monkeypatch.setattr(orderflow_client.requests, "get", fake_get)
+
+    snapshot = orderflow_client.get_orderflow_snapshot("EURUSD")
+
+    assert snapshot["orderflow_available"] is False
+    assert snapshot["orderflow_provider"] == "unavailable"
+    assert snapshot["orderflow_status"] == "engine_unavailable"
+    assert snapshot["delta"] is None


### PR DESCRIPTION
### Motivation
- Добавить опциональный внешний provider OrderFlow (FXPilot) для показа метрик объёмного слоя в карточке идеи без изменения scoring и торговой логики. 
- Сделать интеграцию безопасной: если движок недоступен или выключен, поведение сервиса и MT4 bridge остаётся прежним. 
- Обеспечить явный контракт клиента и короткий таймаут для protection от долгих блокировок API. 

### Description
- Подключён клиент `orderflow_client` и добавлены вспомогательные функции `def _attach_orderflow_snapshot(...)` и `def _attach_orderflow_snapshots(...)` для обогащения идей полями orderflow. 
- В pipeline сборки market (`build_market`) выполнено добавление снапшотов orderflow после `apply_idea_lifecycle` и `enrich_ideas_with_news_calendar`, чтобы сохранить существующее поведение scoring/MT4/advisor. 
- С предусмотренным флагом `ORDERFLOW_ENGINE_ENABLED` и `ORDERFLOW_ENGINE_URL` используется GET `.../api/orderflow/latest?symbol=...` с `timeout=2s`, а при выключенном/ошибочном вызове возвращается безопасный payload с `orderflow_available=false`, `orderflow_provider='unavailable'` и `orderflow_status='engine_unavailable'` (если отключено — `orderflow_status='engine_disabled'`). 
- Добавлены тесты: `tests/test_orderflow_client.py` (контракт URL/timeout/fallback) и расширены проверки в `tests/test_market_ideas_timeout.py` для поведения при включённом/выключенном движке. 

### Testing
- Выполнена проверка синтаксиса с `python -m py_compile app/main.py app/services/orderflow_client.py` и она прошла успешно. 
- Запущены модульные тесты `pytest -q tests/test_orderflow_client.py tests/test_market_ideas_timeout.py` и они прошли успешно. 
- Полный запуск `pytest -q tests/api/test_ideas_api.py -x` показал 1 существующую, не связную с этим изменением, ошибку в ожидании `narrative_source == 'model'`; это поведение не затронуто интеграцией orderflow (фейл относится к уже существующему тесту).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4889ed37408331b8a46fa2c501c8a7)