### PR TITLE
Интеграция метаданных источника OrderFlow в UI

### DIFF
--- a/app/services/orderflow_client.py
+++ b/app/services/orderflow_client.py
@@ -9,6 +9,15 @@ from app.core.env import get_env
 
 logger = logging.getLogger(__name__)
 
+ORDERFLOW_METADATA_FIELDS = (
+    "data_source",
+    "data_source_label",
+    "data_source_quality",
+    "data_source_status",
+    "data_source_age_seconds",
+    "data_source_reason",
+)
+
 ORDERFLOW_FIELDS = (
     "delta",
     "cumdelta",
@@ -32,6 +41,12 @@ UNAVAILABLE_SNAPSHOT: dict[str, Any] = {
     "orderflow_available": False,
     "orderflow_provider": "unavailable",
     "orderflow_status": "engine_unavailable",
+    "data_source": None,
+    "data_source_label": "Unknown Source",
+    "data_source_quality": None,
+    "data_source_status": "unavailable",
+    "data_source_age_seconds": None,
+    "data_source_reason": "OrderFlow Engine unavailable",
     **{field: None for field in ORDERFLOW_FIELDS},
 }
 
@@ -67,6 +82,12 @@ def _normalize_snapshot(payload: Any) -> dict[str, Any]:
         "orderflow_provider": source.get("orderflow_provider") or source.get("provider") or "fxpilot_orderflow_engine",
         "orderflow_status": source.get("orderflow_status") or source.get("status") or ("ok" if available else "engine_unavailable"),
     }
+    for field in ORDERFLOW_METADATA_FIELDS:
+        normalized[field] = source.get(field)
+    if not normalized.get("data_source_label"):
+        normalized["data_source_label"] = "Unknown Source"
+    if not normalized.get("data_source_status"):
+        normalized["data_source_status"] = "ok" if available else "unavailable"
     for field in ORDERFLOW_FIELDS:
         normalized[field] = source.get(field)
     return normalized

--- a/app/static/ai-status.js
+++ b/app/static/ai-status.js
@@ -19,7 +19,20 @@
     return `${Math.floor(hours / 24)} дн назад`;
   }
 
-  function renderAiStatus(root, status) {
+  function normalizeOrderflowSource(payload) {
+    const idea = Array.isArray(payload?.ideas) ? payload.ideas.find((item) => item && typeof item === "object") : (Array.isArray(payload) ? payload.find((item) => item && typeof item === "object") : payload);
+    const label = idea?.data_source_label || idea?.orderflow_source_label || "Unknown Source";
+    const raw = String(idea?.data_source || idea?.orderflow_provider || label || "").toLowerCase();
+    const status = String(idea?.data_source_status || idea?.orderflow_status || "").toLowerCase();
+    const unavailable = status.includes("unavailable") || status.includes("offline") || raw === "unavailable";
+    if (/databento|cme/.test(raw) || /databento|cme/i.test(label)) return { icon: "🟢", label: label === "Unknown Source" ? "Databento CME" : label };
+    if (/mt4|bridge|broker/.test(raw) || /mt4|bridge/i.test(label)) return { icon: "🟡", label: label === "Unknown Source" ? "MT4 Bridge" : label };
+    if (/cache|histor/.test(raw) || /cache|histor/i.test(label)) return { icon: "🟠", label: label === "Unknown Source" ? "Cache" : label };
+    if (unavailable) return { icon: "🔴", label: label === "Unknown Source" ? "Offline" : label };
+    return { icon: "⚪", label };
+  }
+
+  function renderAiStatus(root, status, orderflowSource) {
     const active = Boolean(status?.llm_available);
     const error = status?.last_error || (!status?.api_key_configured ? "OPENROUTER_API_KEY не настроен" : "LLM недоступна");
     root.classList.toggle("ai-status-card--active", active);
@@ -36,6 +49,7 @@
         <span>Provider: <b>${escapeHtml(status?.provider || PROVIDER_LABEL)}</b></span>
         <span>Model: <b>${escapeHtml(MODEL_LABEL)}</b></span>
         <span>${active ? "Last Success" : "Last Error"}: <b>${active ? escapeHtml(timeAgo(status?.last_success_time)) : escapeHtml(error)}</b></span>
+        <span>OrderFlow: <b>${escapeHtml(orderflowSource ? `${orderflowSource.icon} ${orderflowSource.label}` : "Unknown Source")}</b></span>
       </div>
     `;
   }
@@ -47,9 +61,14 @@
       const response = await fetch("/api/ai/status", { cache: "no-store" });
       if (!response.ok) throw new Error(`status_${response.status}`);
       const status = await response.json();
-      roots.forEach((root) => renderAiStatus(root, status));
+      let orderflowSource = null;
+      try {
+        const ideasResponse = await fetch("/api/ideas/market", { cache: "no-store" });
+        if (ideasResponse.ok) orderflowSource = normalizeOrderflowSource(await ideasResponse.json());
+      } catch (_) {}
+      roots.forEach((root) => renderAiStatus(root, status, orderflowSource));
     } catch (error) {
-      roots.forEach((root) => renderAiStatus(root, { llm_available: false, provider: PROVIDER_LABEL, last_error: error.message }));
+      roots.forEach((root) => renderAiStatus(root, { llm_available: false, provider: PROVIDER_LABEL, last_error: error.message }, null));
     }
   }
 

--- a/app/static/ideas-institutional-polish.js
+++ b/app/static/ideas-institutional-polish.js
@@ -136,9 +136,12 @@
     const absorption = dash(idea.absorption, idea.absorption_signal, idea.orderflow?.absorption);
     const domBias = dash(idea.dom_bias, idea.orderflow?.dom_bias);
     const reason = dash(idea.orderflow_reason_ru, idea.heatmap_reason_ru, idea.dom_reason_ru, "—");
+    const src = typeof normalizeOrderflowSource === "function" ? normalizeOrderflowSource(idea) : { icon: "⚪", label: "Unknown Source", compact: "Unknown", descriptor: "Unknown Source", qualityStars: "☆☆☆☆☆" };
     return `<section class="institutional-section pro-layer pro-layer--orderflow">
-      <div class="pro-layer-head"><h4>⚡ Orderflow</h4><div class="mini-chip-row">${renderChip(`DOM ${domBias}`, asLower(domBias).includes("bear") ? "bad" : asLower(domBias).includes("bull") ? "good" : "neutral")}${renderChip(`CVD ${cvd}`, String(cvd) === "false" ? "neutral" : "warn")}</div></div>
+      <div class="pro-layer-head"><h4>⚡ Orderflow</h4><div class="mini-chip-row">${renderChip(`${src.icon} ${src.compact}`, src.kind === "unavailable" ? "bad" : src.kind === "cache" ? "warn" : "good")}${renderChip(`DOM ${domBias}`, asLower(domBias).includes("bear") ? "bad" : asLower(domBias).includes("bull") ? "good" : "neutral")}${renderChip(`CVD ${cvd}`, String(cvd) === "false" ? "neutral" : "warn")}</div></div>
       <div class="pro-layer-grid compact">
+        ${renderMetric("Source", `${src.label} · ${src.descriptor}`)}
+        ${renderMetric("Quality", src.qualityStars)}
         ${renderMetric("Delta", dash(idea.delta, vd.delta))}
         ${renderMetric("CumDelta", dash(idea.cum_delta, idea.cumulative_delta, vd.cumdelta))}
         ${renderMetric("Absorption", absorption)}

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -921,13 +921,57 @@ function getAiSourceMeta(idea) {
 }
 
 
+function normalizeOrderflowSource(idea) {
+  const raw = String(idea?.data_source || idea?.orderflow_data_source || idea?.orderflow_provider || "").toLowerCase();
+  const label = firstText(idea?.data_source_label, idea?.orderflow_source_label) || "Unknown Source";
+  const status = String(idea?.data_source_status || idea?.orderflow_status || "").toLowerCase();
+  const unavailable = status.includes("unavailable") || status.includes("offline") || raw === "unavailable" || raw === "offline";
+  let kind = "unknown";
+  if (/databento|cme/.test(raw) || /databento|cme/i.test(label)) kind = "databento";
+  else if (/mt4|bridge|broker/.test(raw) || /mt4|bridge/i.test(label)) kind = "mt4";
+  else if (/cache|histor/.test(raw) || /cache|histor/i.test(label)) kind = "cache";
+  else if (unavailable) kind = "unavailable";
+  const meta = {
+    databento: { icon: "🟢", label: label === "Unknown Source" ? "Databento CME" : label, compact: "Databento", descriptor: "CME Order Flow" },
+    mt4: { icon: "🟡", label: label === "Unknown Source" ? "MT4 Bridge" : label, compact: "MT4", descriptor: "Live broker ticks" },
+    cache: { icon: "🟠", label: label === "Unknown Source" ? "Historical Cache" : label, compact: "Cache", descriptor: "Historical snapshot" },
+    unavailable: { icon: "🔴", label: label === "Unknown Source" ? "Unavailable" : label, compact: "Offline", descriptor: "Unknown Source" },
+    unknown: { icon: "⚪", label, compact: "Unknown", descriptor: "Unknown Source" },
+  }[kind];
+  const q = Number(idea?.data_source_quality ?? idea?.orderflow_source_quality);
+  const quality = Number.isFinite(q) ? Math.max(1, Math.min(5, Math.round(q))) : 0;
+  return { kind, ...meta, qualityStars: quality ? `${"★".repeat(quality)}${"☆".repeat(5 - quality)}` : "☆☆☆☆☆", age: idea?.data_source_age_seconds ?? idea?.orderflow_source_age_seconds, reason: firstText(idea?.data_source_reason, idea?.orderflow_source_reason) };
+}
+
+function renderOrderflowSourceBadge(idea) {
+  const src = normalizeOrderflowSource(idea);
+  return `${src.icon} ${src.compact}`;
+}
+
+function renderOrderflowSourceHybrid(idea) {
+  const src = normalizeOrderflowSource(idea);
+  return `OrderFlow / ${src.label} / ${src.qualityStars}`;
+}
+
+function renderOrderflowSourceHybridBlock(idea) {
+  const src = normalizeOrderflowSource(idea);
+  return `<section class="institutional-section orderflow-source-compact"><h4>OrderFlow</h4><p>${escapeHtml(src.label)}<br>${escapeHtml(src.qualityStars)}</p></section>`;
+}
+
+function renderOrderflowSourceBlock(idea) {
+  const src = normalizeOrderflowSource(idea);
+  const age = src.age === null || src.age === undefined || src.age === "" ? "—" : `${Math.max(0, Math.round(Number(src.age) || 0))} seconds ago`;
+  const reason = src.kind === "unavailable" && src.reason ? `<br>Reason: ${escapeHtml(src.reason)}` : "";
+  return `<section class="institutional-section orderflow-source-block"><h4>OrderFlow Source</h4><p><strong>${escapeHtml(`${src.icon} ${src.label}`)}</strong><br>${escapeHtml(src.descriptor)}<br>Quality: ${escapeHtml(src.qualityStars)}<br>Last update: ${escapeHtml(age)}${reason}</p></section>`;
+}
+
 function isOrderflowAvailable(idea) {
   const vd = resolveVolumeDelta(idea);
   return Boolean(idea.orderflow_available ?? idea.prop_signal_score?.orderflow_available ?? (vd.source && vd.source !== "unavailable" && (vd.delta !== undefined || vd.cumdelta !== undefined)));
 }
 
 function renderOrderflowStatusLine(idea) {
-  return `Order Flow: ${isOrderflowAvailable(idea) ? "доступен" : "недоступен"}`;
+  return `Order Flow: ${isOrderflowAvailable(idea) ? "доступен" : "недоступен"} · ${renderOrderflowSourceBadge(idea)}`;
 }
 
 function renderOrderflowUnavailable(mode) {
@@ -936,11 +980,12 @@ function renderOrderflowUnavailable(mode) {
 
 function renderOrderflowEngineBlock(idea) {
   if (!isOrderflowAvailable(idea)) {
-    return `<section class="institutional-section"><h4>2. Order Flow Engine</h4><p>Order Flow Engine недоступен. Слой временно не участвует в оценке.</p></section>`;
+    return `${renderOrderflowSourceBlock(idea)}<section class="institutional-section"><h4>2. Order Flow Engine</h4><p>Order Flow Engine недоступен. Слой временно не участвует в оценке.</p></section>`;
   }
   const rows = [
     ["Provider", idea.orderflow_provider],
     ["Status", idea.orderflow_status],
+    ["Source Detail", normalizeOrderflowSource(idea).descriptor],
     ["Delta", idea.delta],
     ["CumDelta", idea.cumdelta],
     ["Volume", idea.volume],
@@ -958,7 +1003,7 @@ function renderOrderflowEngineBlock(idea) {
     ["Continuation Probability", idea.continuation_probability],
     ["Reversal Probability", idea.reversal_probability],
   ];
-  return `<section class="institutional-section"><h4>2. Order Flow Engine</h4><p>${rows.map(([label, value]) => `${escapeHtml(label)}: ${escapeHtml(formatListValue(value))}`).join("<br>")}</p></section>`;
+  return `${renderOrderflowSourceBlock(idea)}<section class="institutional-section"><h4>2. Order Flow Engine</h4><p>${rows.map(([label, value]) => `${escapeHtml(label)}: ${escapeHtml(formatListValue(value))}`).join("<br>")}</p></section>`;
 }
 
 function renderScoreDebug(idea) {
@@ -1036,11 +1081,12 @@ function renderHybridCardBody(idea) {
     ["Heatmap", idea.heatmap_available ? firstText(idea.heatmap_bias, idea.heatmap_reason_ru) : "Источник данных недоступен."],
     ["Новости", resolveNewsContext(idea)],
     ["Исполнение", firstText(idea.execution_quality, idea.killzone_status, idea.session) || "Слой временно не участвует в оценке."],
-    ["Order Flow", renderOrderflowStatusLine(idea)],
+    ["Order Flow", renderOrderflowSourceHybrid(idea)],
   ];
   return `<div class="analysis-card-body analysis-card-hybrid">
     <div class="compact-levels"><div><span>Уверенность идеи</span><strong>${escapeHtml(renderIdeaConfidence(idea))}</strong></div>${getTradeLevels(idea).map(([l,v])=>renderField(l, formatNumber(v))).join("")}</div>
     <section class="institutional-section"><h4>Что говорит рынок</h4><p>${escapeHtml(resolveMarketSummary(idea))}</p></section>
+    ${renderOrderflowSourceHybridBlock(idea)}
     <div class="factor-grid">${factors.map(([label,status]) => `<div class="factor-item factor-${status.replaceAll(" ", "-")}"><span>${escapeHtml(label)}</span><strong>${escapeHtml(status)}</strong></div>`).join("")}</div>
     <details class="analysis-details"><summary>Почему ИИ так считает</summary><div class="criteria-grid">${why.map(([l,v])=>`<div class="criterion"><strong>${escapeHtml(l)}</strong><br>${escapeHtml(uiText(v, "Слой временно не участвует в оценке."))}</div>`).join("")}</div></details>
     <details class="analysis-details"><summary>Возможные риски</summary><div class="risk-list">${risks.length ? risks.map((r)=>`<div class="blocker">${escapeHtml(r)}</div>`).join("") : `<p class="modal-text">Критичных рисков не обнаружено.</p>`}</div></details>

--- a/tests/test_orderflow_client.py
+++ b/tests/test_orderflow_client.py
@@ -37,6 +37,12 @@ def test_get_orderflow_snapshot_uses_engine_url_symbol_and_timeout(monkeypatch) 
                 "exhaustion": False,
                 "market_state": "trend",
                 "orderflow_bias": "bullish",
+                "data_source": "databento",
+                "data_source_label": "Databento CME",
+                "data_source_quality": 5,
+                "data_source_status": "ok",
+                "data_source_age_seconds": 3,
+                "data_source_reason": None,
                 "continuation_probability": 62,
                 "reversal_probability": 28,
             }
@@ -62,6 +68,10 @@ def test_get_orderflow_snapshot_uses_engine_url_symbol_and_timeout(monkeypatch) 
     assert snapshot["imbalance"] == "buy"
     assert snapshot["exhaustion"] is False
     assert snapshot["orderflow_bias"] == "bullish"
+    assert snapshot["data_source"] == "databento"
+    assert snapshot["data_source_label"] == "Databento CME"
+    assert snapshot["data_source_quality"] == 5
+    assert snapshot["data_source_age_seconds"] == 3
 
 
 def test_get_orderflow_snapshot_returns_unavailable_on_error(monkeypatch) -> None:
@@ -75,4 +85,6 @@ def test_get_orderflow_snapshot_returns_unavailable_on_error(monkeypatch) -> Non
     assert snapshot["orderflow_available"] is False
     assert snapshot["orderflow_provider"] == "unavailable"
     assert snapshot["orderflow_status"] == "engine_unavailable"
+    assert snapshot["data_source_label"] == "Unknown Source"
+    assert snapshot["data_source_status"] == "unavailable"
     assert snapshot["delta"] is None


### PR DESCRIPTION
### Motivation
- Показать активный источник данных OrderFlow везде, где выводится OrderFlow, используя новую мета-информацию от OrderFlow Engine и сохраняя обратную совместимость при отсутствии метаданных.

### Description
- Добавлена обработка новых полей метаданных (`data_source`, `data_source_label`, `data_source_quality`, `data_source_status`, `data_source_age_seconds`, `data_source_reason`) в нормализацию snapshot в `app/services/orderflow_client.py` с fallback "Unknown Source".
- Реализована клиентская нормализация источника и UI-рендер: компактный бейдж, гибридный блок и подробный блок источника (`renderOrderflowSourceBadge`, `renderOrderflowSourceHybrid`, `renderOrderflowSourceBlock`) в `app/static/ideas.js` и вставка в brief/hybrid/expert режимы без скрытия OrderFlow.
- Обновлён полированный компонент институционального вида (`app/static/ideas-institutional-polish.js`) для отображения бейджа, детали источника и качества рядом с Orderflow, не затрагивая модули опционов и торговую логику.
- Добавлен индикатор источника OrderFlow в карточку AI Status (`app/static/ai-status.js`), который запрашивает `/api/ideas/market` и автоматически обновляется вместе со статусом.
- Тест `tests/test_orderflow_client.py` расширен для проверки propagation метаданных и fallback значений.

### Testing
- Запуск `pytest -q tests/test_orderflow_client.py` прошёл успешно (2 tests passed). 
- Статическая проверка JS через `node --check app/static/ideas.js`, `node --check app/static/ideas-institutional-polish.js` и `node --check app/static/ai-status.js` прошла успешно (без синтаксических ошибок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4921cc18048331b3bb7048801eda98)