### PR TITLE
Интеграция OrderFlow SourceManager (data_source metadata) в UI

### DIFF
--- a/app/static/ai-status.js
+++ b/app/static/ai-status.js
@@ -19,17 +19,28 @@
     return `${Math.floor(hours / 24)} дн назад`;
   }
 
+  function normalizeReason(value) {
+    const text = String(value || "").trim();
+    return text ? text.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "—";
+  }
+
   function normalizeOrderflowSource(payload) {
     const idea = Array.isArray(payload?.ideas) ? payload.ideas.find((item) => item && typeof item === "object") : (Array.isArray(payload) ? payload.find((item) => item && typeof item === "object") : payload);
-    const label = idea?.data_source_label || idea?.orderflow_source_label || "Unknown Source";
-    const raw = String(idea?.data_source || idea?.orderflow_provider || label || "").toLowerCase();
-    const status = String(idea?.data_source_status || idea?.orderflow_status || "").toLowerCase();
-    const unavailable = status.includes("unavailable") || status.includes("offline") || raw === "unavailable";
-    if (/databento|cme/.test(raw) || /databento|cme/i.test(label)) return { icon: "🟢", label: label === "Unknown Source" ? "Databento CME" : label };
-    if (/mt4|bridge|broker/.test(raw) || /mt4|bridge/i.test(label)) return { icon: "🟡", label: label === "Unknown Source" ? "MT4 Bridge" : label };
-    if (/cache|histor/.test(raw) || /cache|histor/i.test(label)) return { icon: "🟠", label: label === "Unknown Source" ? "Cache" : label };
-    if (unavailable) return { icon: "🔴", label: label === "Unknown Source" ? "Offline" : label };
-    return { icon: "⚪", label };
+    const hasNewMetadata = ["data_source", "data_source_label", "data_source_status", "data_source_quality", "data_source_reason", "data_source_age_seconds", "orderflow_available"].some((key) => Object.prototype.hasOwnProperty.call(idea || {}, key));
+    const raw = String(idea?.data_source ?? (!hasNewMetadata ? idea?.orderflow_provider : "") ?? "").toLowerCase();
+    const fallbackLabel = raw === "databento" ? "Databento" : raw === "mt4_live" ? "MT4 Live" : raw === "cache" ? "Cache" : raw === "unavailable" ? "Unavailable" : "Unknown Source";
+    const label = idea?.data_source_label || idea?.orderflow_source_label || (!hasNewMetadata ? idea?.orderflow_provider : "") || fallbackLabel;
+    const status = String(idea?.data_source_status ?? (!hasNewMetadata ? idea?.orderflow_status : "") ?? "").toLowerCase();
+    const available = idea?.orderflow_available === true || status === "ok";
+    const unavailable = idea?.orderflow_available === false || status === "unavailable" || raw === "unavailable" || status.includes("offline");
+    let icon = available ? "🟢" : unavailable ? "🔴" : "⚪";
+    if (raw === "cache" || /cache|histor/i.test(label)) icon = "🟡";
+    if (raw === "unavailable") icon = "🔴";
+    const q = Number(idea?.data_source_quality ?? idea?.orderflow_source_quality);
+    const quality = Number.isFinite(q) ? `Quality ${Math.max(0, Math.min(100, Math.round(q)))}%` : "Quality —";
+    const ageRaw = idea?.data_source_age_seconds ?? idea?.orderflow_source_age_seconds;
+    const age = ageRaw === null || ageRaw === undefined || ageRaw === "" ? "—" : `${Math.max(0, Math.round(Number(ageRaw) || 0))} sec`;
+    return { icon, label, available: Boolean(idea?.orderflow_available), quality, reason: normalizeReason(idea?.data_source_reason ?? idea?.orderflow_source_reason), age };
   }
 
   function renderAiStatus(root, status, orderflowSource) {
@@ -49,7 +60,8 @@
         <span>Provider: <b>${escapeHtml(status?.provider || PROVIDER_LABEL)}</b></span>
         <span>Model: <b>${escapeHtml(MODEL_LABEL)}</b></span>
         <span>${active ? "Last Success" : "Last Error"}: <b>${active ? escapeHtml(timeAgo(status?.last_success_time)) : escapeHtml(error)}</b></span>
-        <span>OrderFlow: <b>${escapeHtml(orderflowSource ? `${orderflowSource.icon} ${orderflowSource.label}` : "Unknown Source")}</b></span>
+        <span title="${escapeHtml(orderflowSource ? `Source: ${orderflowSource.label}\nReason: ${orderflowSource.reason}\nAge: ${orderflowSource.age}` : "Source: Unknown Source")}">OrderFlow: <b>${escapeHtml(orderflowSource ? `${orderflowSource.icon} ${orderflowSource.label}` : "Unknown Source")}</b></span>
+        <span>OrderFlow quality: <b>${escapeHtml(orderflowSource ? orderflowSource.quality : "Quality —")}</b></span>
       </div>
     `;
   }

--- a/app/static/ideas-institutional-polish.js
+++ b/app/static/ideas-institutional-polish.js
@@ -136,12 +136,14 @@
     const absorption = dash(idea.absorption, idea.absorption_signal, idea.orderflow?.absorption);
     const domBias = dash(idea.dom_bias, idea.orderflow?.dom_bias);
     const reason = dash(idea.orderflow_reason_ru, idea.heatmap_reason_ru, idea.dom_reason_ru, "—");
-    const src = typeof normalizeOrderflowSource === "function" ? normalizeOrderflowSource(idea) : { icon: "⚪", label: "Unknown Source", compact: "Unknown", descriptor: "Unknown Source", qualityStars: "☆☆☆☆☆" };
+    const src = typeof normalizeOrderflowSource === "function" ? normalizeOrderflowSource(idea) : { icon: "⚪", label: "Unknown Source", compact: "Unknown", descriptor: "Unknown Source", qualityText: "Quality —", reason: "—", ageText: "—" };
     return `<section class="institutional-section pro-layer pro-layer--orderflow">
       <div class="pro-layer-head"><h4>⚡ Orderflow</h4><div class="mini-chip-row">${renderChip(`${src.icon} ${src.compact}`, src.kind === "unavailable" ? "bad" : src.kind === "cache" ? "warn" : "good")}${renderChip(`DOM ${domBias}`, asLower(domBias).includes("bear") ? "bad" : asLower(domBias).includes("bull") ? "good" : "neutral")}${renderChip(`CVD ${cvd}`, String(cvd) === "false" ? "neutral" : "warn")}</div></div>
       <div class="pro-layer-grid compact">
         ${renderMetric("Source", `${src.label} · ${src.descriptor}`)}
-        ${renderMetric("Quality", src.qualityStars)}
+        ${renderMetric("Quality", src.qualityText)}
+        ${renderMetric("Reason", src.reason)}
+        ${renderMetric("Age", src.ageText)}
         ${renderMetric("Delta", dash(idea.delta, vd.delta))}
         ${renderMetric("CumDelta", dash(idea.cum_delta, idea.cumulative_delta, vd.cumdelta))}
         ${renderMetric("Absorption", absorption)}

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -921,28 +921,56 @@ function getAiSourceMeta(idea) {
 }
 
 
-function normalizeOrderflowSource(idea) {
-  const raw = String(idea?.data_source || idea?.orderflow_data_source || idea?.orderflow_provider || "").toLowerCase();
-  const label = firstText(idea?.data_source_label, idea?.orderflow_source_label) || "Unknown Source";
-  const status = String(idea?.data_source_status || idea?.orderflow_status || "").toLowerCase();
-  const unavailable = status.includes("unavailable") || status.includes("offline") || raw === "unavailable" || raw === "offline";
-  let kind = "unknown";
-  if (/databento|cme/.test(raw) || /databento|cme/i.test(label)) kind = "databento";
-  else if (/mt4|bridge|broker/.test(raw) || /mt4|bridge/i.test(label)) kind = "mt4";
-  else if (/cache|histor/.test(raw) || /cache|histor/i.test(label)) kind = "cache";
-  else if (unavailable) kind = "unavailable";
-  const meta = {
-    databento: { icon: "🟢", label: label === "Unknown Source" ? "Databento CME" : label, compact: "Databento", descriptor: "CME Order Flow" },
-    mt4: { icon: "🟡", label: label === "Unknown Source" ? "MT4 Bridge" : label, compact: "MT4", descriptor: "Live broker ticks" },
-    cache: { icon: "🟠", label: label === "Unknown Source" ? "Historical Cache" : label, compact: "Cache", descriptor: "Historical snapshot" },
-    unavailable: { icon: "🔴", label: label === "Unknown Source" ? "Unavailable" : label, compact: "Offline", descriptor: "Unknown Source" },
-    unknown: { icon: "⚪", label, compact: "Unknown", descriptor: "Unknown Source" },
-  }[kind];
-  const q = Number(idea?.data_source_quality ?? idea?.orderflow_source_quality);
-  const quality = Number.isFinite(q) ? Math.max(1, Math.min(5, Math.round(q))) : 0;
-  return { kind, ...meta, qualityStars: quality ? `${"★".repeat(quality)}${"☆".repeat(5 - quality)}` : "☆☆☆☆☆", age: idea?.data_source_age_seconds ?? idea?.orderflow_source_age_seconds, reason: firstText(idea?.data_source_reason, idea?.orderflow_source_reason) };
+function hasOrderflowSourceMetadata(idea) {
+  return ["data_source", "data_source_label", "data_source_status", "data_source_quality", "data_source_reason", "data_source_age_seconds", "orderflow_available"].some((key) => Object.prototype.hasOwnProperty.call(idea || {}, key));
 }
 
+function normalizeOrderflowReason(value) {
+  const text = firstText(value);
+  if (!text) return "—";
+  return String(text).replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function normalizeOrderflowSource(idea) {
+  const hasNewMetadata = hasOrderflowSourceMetadata(idea);
+  const raw = String(idea?.data_source ?? idea?.orderflow_data_source ?? (!hasNewMetadata ? idea?.orderflow_provider : "") ?? "").toLowerCase();
+  const fallbackLabel = raw === "databento" ? "Databento" : raw === "mt4_live" ? "MT4 Live" : raw === "cache" ? "Cache" : raw === "unavailable" ? "Unavailable" : "Unknown Source";
+  const label = firstText(idea?.data_source_label, idea?.orderflow_source_label, !hasNewMetadata ? idea?.orderflow_provider : null) || fallbackLabel;
+  const status = String(idea?.data_source_status ?? (!hasNewMetadata ? idea?.orderflow_status : "") ?? "").toLowerCase();
+  const explicitAvailable = idea?.orderflow_available;
+  const unavailable = explicitAvailable === false || status === "unavailable" || status.includes("offline") || raw === "unavailable" || raw === "offline";
+  const ok = explicitAvailable === true || status === "ok";
+  let kind = "unknown";
+  if (raw === "databento" || /databento|cme/.test(raw) || /databento|cme/i.test(label)) kind = "databento";
+  else if (raw === "mt4_live" || /mt4|bridge|broker/.test(raw) || /mt4|bridge/i.test(label)) kind = "mt4";
+  else if (raw === "cache" || /cache|histor/.test(raw) || /cache|histor/i.test(label)) kind = "cache";
+  else if (unavailable) kind = "unavailable";
+  const meta = {
+    databento: { icon: "🟢", label: label === "Unknown Source" ? "Databento" : label, compact: "OrderFlow", descriptor: "Databento" },
+    mt4: { icon: "🟢", label: label === "Unknown Source" ? "MT4 Live" : label, compact: "OrderFlow", descriptor: "MT4 Live" },
+    cache: { icon: "🟡", label: label === "Unknown Source" ? "Cache" : label, compact: "Cache", descriptor: "Cache" },
+    unavailable: { icon: "🔴", label: label === "Unknown Source" ? "Unavailable" : label, compact: "Unavailable", descriptor: "Unavailable" },
+    unknown: { icon: ok ? "🟢" : unavailable ? "🔴" : "⚪", label, compact: ok ? "OrderFlow" : "Unknown", descriptor: label },
+  }[kind];
+  const q = Number(idea?.data_source_quality ?? idea?.orderflow_source_quality);
+  const qualityPercent = Number.isFinite(q) ? Math.max(0, Math.min(100, Math.round(q))) : null;
+  const ageValue = idea?.data_source_age_seconds ?? idea?.orderflow_source_age_seconds;
+  const ageSeconds = ageValue === null || ageValue === undefined || ageValue === "" ? null : Math.max(0, Math.round(Number(ageValue) || 0));
+  return {
+    kind,
+    ...meta,
+    ok,
+    unavailable,
+    available: ok && !unavailable,
+    status,
+    source: raw,
+    qualityPercent,
+    qualityText: qualityPercent === null ? "Quality —" : `Quality ${qualityPercent}%`,
+    age: ageSeconds,
+    ageText: ageSeconds === null ? "—" : `${ageSeconds} sec`,
+    reason: normalizeOrderflowReason(idea?.data_source_reason ?? idea?.orderflow_source_reason),
+  };
+}
 function renderOrderflowSourceBadge(idea) {
   const src = normalizeOrderflowSource(idea);
   return `${src.icon} ${src.compact}`;
@@ -950,22 +978,24 @@ function renderOrderflowSourceBadge(idea) {
 
 function renderOrderflowSourceHybrid(idea) {
   const src = normalizeOrderflowSource(idea);
-  return `OrderFlow / ${src.label} / ${src.qualityStars}`;
+  return `OrderFlow / ${src.label} / ${src.qualityText}`;
 }
 
 function renderOrderflowSourceHybridBlock(idea) {
   const src = normalizeOrderflowSource(idea);
-  return `<section class="institutional-section orderflow-source-compact"><h4>OrderFlow</h4><p>${escapeHtml(src.label)}<br>${escapeHtml(src.qualityStars)}</p></section>`;
+  return `<section class="institutional-section orderflow-source-compact"><h4>OrderFlow</h4><p>${escapeHtml(src.label)}<br>${escapeHtml(src.qualityText)}<br>Reason: ${escapeHtml(src.reason)}<br>Age: ${escapeHtml(src.ageText)}</p></section>`;
 }
 
 function renderOrderflowSourceBlock(idea) {
   const src = normalizeOrderflowSource(idea);
-  const age = src.age === null || src.age === undefined || src.age === "" ? "—" : `${Math.max(0, Math.round(Number(src.age) || 0))} seconds ago`;
-  const reason = src.kind === "unavailable" && src.reason ? `<br>Reason: ${escapeHtml(src.reason)}` : "";
-  return `<section class="institutional-section orderflow-source-block"><h4>OrderFlow Source</h4><p><strong>${escapeHtml(`${src.icon} ${src.label}`)}</strong><br>${escapeHtml(src.descriptor)}<br>Quality: ${escapeHtml(src.qualityStars)}<br>Last update: ${escapeHtml(age)}${reason}</p></section>`;
+  return `<section class="institutional-section orderflow-source-block" title="Source: ${escapeHtml(src.label)}
+Reason: ${escapeHtml(src.reason)}
+Age: ${escapeHtml(src.ageText)}"><h4>OrderFlow Source</h4><p><strong>${escapeHtml(`${src.icon} ${src.label}`)}</strong><br>Source: ${escapeHtml(src.label)}<br>${escapeHtml(src.qualityText)}<br>Reason: ${escapeHtml(src.reason)}<br>Age: ${escapeHtml(src.ageText)}</p></section>`;
 }
 
 function isOrderflowAvailable(idea) {
+  const src = normalizeOrderflowSource(idea);
+  if (hasOrderflowSourceMetadata(idea)) return src.available;
   const vd = resolveVolumeDelta(idea);
   return Boolean(idea.orderflow_available ?? idea.prop_signal_score?.orderflow_available ?? (vd.source && vd.source !== "unavailable" && (vd.delta !== undefined || vd.cumdelta !== undefined)));
 }
@@ -983,9 +1013,10 @@ function renderOrderflowEngineBlock(idea) {
     return `${renderOrderflowSourceBlock(idea)}<section class="institutional-section"><h4>2. Order Flow Engine</h4><p>Order Flow Engine недоступен. Слой временно не участвует в оценке.</p></section>`;
   }
   const rows = [
-    ["Provider", idea.orderflow_provider],
-    ["Status", idea.orderflow_status],
-    ["Source Detail", normalizeOrderflowSource(idea).descriptor],
+    ["Source", normalizeOrderflowSource(idea).label],
+    ["Quality", normalizeOrderflowSource(idea).qualityText],
+    ["Reason", normalizeOrderflowSource(idea).reason],
+    ["Age", normalizeOrderflowSource(idea).ageText],
     ["Delta", idea.delta],
     ["CumDelta", idea.cumdelta],
     ["Volume", idea.volume],


### PR DESCRIPTION
### Motivation
- Прекратить использование устаревших полей `provider`/`provider_status` для определения статуса OrderFlow и перейти на авторитетные метаданные SourceManager, возвращаемые бекендом (`data_source`, `data_source_label`, `data_source_status`, `data_source_quality`, `data_source_reason`, `data_source_age_seconds`, `orderflow_available`).
- Показать пользователю явный бейдж источника, качество, причину и возраст данных, сохранив совместимость со старой логикой при отсутствии новой metadata.

### Description
- Добавил проверку наличия новой metadata и новую нормализацию источника в `app/static/ideas.js` (`hasOrderflowSourceMetadata`, `normalizeOrderflowReason`, `normalizeOrderflowSource`) и адаптировал рендеры OrderFlow для бейджа, compact/hybrid и full block (отображение `label`, `qualityText`, `reason`, `ageText`).
- Обновил `app/static/ai-status.js` для показа авторитетного OrderFlow-источника и качества с тултипом, содержащим Source/Reason/Age; логика определения иконки/статуса учитывает `orderflow_available` и `data_source_status`.
- Обновил `app/static/ideas-institutional-polish.js` чтобы в Pro/Hybrid/Expert карточках отображались `Source`, `Quality`, `Reason`, `Age` из backend metadata.
- Обеспечил backward compatibility: при отсутствии новых полей используется прежняя логика на `orderflow_provider`/`orderflow_status` и старый `resolveVolumeDelta`-фоллбек; статус OrderFlow считается GREEN если `orderflow_available === true` или `data_source_status === 'ok'`, RED когда `orderflow_available === false` или `data_source_status === 'unavailable'`.
- Изменения ограничены UI-слоем; OrderFlow Engine и backend не менялись.

### Testing
- Выполнена синтаксическая проверка JS-файлов: `node --check app/static/ideas.js` (успешно).
- Выполнена синтаксическая проверка JS-файлов: `node --check app/static/ai-status.js` (успешно).
- Выполнена синтаксическая проверка JS-файлов: `node --check app/static/ideas-institutional-polish.js` (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49e48099b88331921a38dff078a46e)