### PR TITLE
Передача метаданных OrderFlow в /api/ideas/market

### DIFF
--- a/app/api/ideas_routes.py
+++ b/app/api/ideas_routes.py
@@ -17,6 +17,7 @@ from app.services.orderflow_client import (
     UNAVAILABLE_SNAPSHOT,
     get_orderflow_snapshot,
     is_orderflow_engine_enabled,
+    market_idea_orderflow_metadata,
 )
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.prop_desk_filters import PropDeskFilterService
@@ -180,7 +181,7 @@ def _attach_orderflow_snapshot_to_idea(idea: dict) -> dict:
         **UNAVAILABLE_SNAPSHOT,
         "orderflow_status": "engine_disabled",
     }
-    enriched.update(snapshot)
+    enriched.update(market_idea_orderflow_metadata(snapshot))
     return enriched
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,12 @@ from app.services.news_service import fetch_public_news
 from app.services.twelvedata_ws_service import twelvedata_ws_service
 from app.services.mt4_volume_cluster_bridge import save_volume_cluster_payload
 from app.services.mt4_options_bridge import get_latest_options_levels, save_options_levels
-from app.services.orderflow_client import UNAVAILABLE_SNAPSHOT, get_orderflow_snapshot, is_orderflow_engine_enabled
+from app.services.orderflow_client import (
+    UNAVAILABLE_SNAPSHOT,
+    get_orderflow_snapshot,
+    is_orderflow_engine_enabled,
+    market_idea_orderflow_metadata,
+)
 from app.services.prop_signal_engine import enrich_ideas_with_prop_scores
 from app.services.prop_desk_filters import PropDeskFilterService
 from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_stats, enrich_ideas_with_news_calendar
@@ -1074,7 +1079,7 @@ def _attach_orderflow_snapshot(signal: dict[str, Any]) -> dict[str, Any]:
         if is_orderflow_engine_enabled()
         else {**UNAVAILABLE_SNAPSHOT, "orderflow_status": "engine_disabled"}
     )
-    normalized.update({**UNAVAILABLE_SNAPSHOT, **snapshot})
+    normalized.update(market_idea_orderflow_metadata(snapshot))
     return normalized
 
 

--- a/app/services/orderflow_client.py
+++ b/app/services/orderflow_client.py
@@ -18,6 +18,21 @@ ORDERFLOW_METADATA_FIELDS = (
     "data_source_reason",
 )
 
+ORDERFLOW_COMPATIBILITY_FIELDS = (
+    "orderflow_provider",
+    "provider_status",
+    "provider_debug",
+)
+
+ORDERFLOW_MARKET_IDEA_FALLBACK: dict[str, Any] = {
+    "orderflow_available": False,
+    "data_source": "unavailable",
+    "data_source_label": "Unavailable",
+    "data_source_quality": 0,
+    "data_source_status": "unavailable",
+    "data_source_reason": "orderflow_snapshot_missing",
+}
+
 ORDERFLOW_FIELDS = (
     "delta",
     "cumdelta",
@@ -91,6 +106,33 @@ def _normalize_snapshot(payload: Any) -> dict[str, Any]:
     for field in ORDERFLOW_FIELDS:
         normalized[field] = source.get(field)
     return normalized
+
+
+def market_idea_orderflow_metadata(snapshot: Any) -> dict[str, Any]:
+    """Return the OrderFlow metadata contract exposed on every market idea."""
+    if not isinstance(snapshot, dict) or not snapshot:
+        return dict(ORDERFLOW_MARKET_IDEA_FALLBACK)
+
+    metadata = dict(snapshot)
+    for field, value in ORDERFLOW_MARKET_IDEA_FALLBACK.items():
+        if metadata.get(field) is None or (
+            field == "data_source_label"
+            and not snapshot.get("data_source")
+            and metadata.get(field) == UNAVAILABLE_SNAPSHOT["data_source_label"]
+        ) or (
+            field == "data_source_quality"
+            and not snapshot.get("data_source")
+        ) or (
+            field == "data_source_reason"
+            and not snapshot.get("data_source")
+        ):
+            metadata[field] = value
+    for field in ("orderflow_available", *ORDERFLOW_METADATA_FIELDS, *ORDERFLOW_COMPATIBILITY_FIELDS):
+        if field in ORDERFLOW_MARKET_IDEA_FALLBACK and not snapshot.get("data_source"):
+            continue
+        if snapshot.get(field) is not None:
+            metadata[field] = snapshot[field]
+    return metadata
 
 
 def get_orderflow_snapshot(symbol: str) -> dict[str, Any]:

--- a/tests/test_market_ideas_timeout.py
+++ b/tests/test_market_ideas_timeout.py
@@ -64,14 +64,68 @@ def test_build_market_attaches_orderflow_when_enabled(monkeypatch) -> None:
     monkeypatch.setattr(main, "apply_idea_lifecycle", lambda ideas: {"ideas": ideas, "archive": [], "statistics": {"total": len(ideas)}})
     monkeypatch.setattr(main, "_apply_prop_desk_execution", lambda ideas, archive=None: ideas)
     monkeypatch.setattr(main, "enrich_ideas_with_news_calendar", lambda ideas: ideas)
-    monkeypatch.setattr(main, "get_orderflow_snapshot", lambda symbol: {"orderflow_available": True, "orderflow_provider": "fxpilot", "delta": 11})
+    monkeypatch.setattr(
+        main,
+        "get_orderflow_snapshot",
+        lambda symbol: {
+            "orderflow_available": True,
+            "orderflow_provider": "fxpilot",
+            "provider_status": "ok",
+            "provider_debug": {"source": "test"},
+            "data_source": "mt4_live",
+            "data_source_label": "MT4 Live",
+            "data_source_quality": 75,
+            "data_source_status": "ok",
+            "data_source_reason": "databento_unusable_mt4_live_fresh",
+            "data_source_age_seconds": 4,
+            "delta": 11,
+        },
+    )
 
     payload = main.build_market()
 
     assert payload["ideas"][0]["orderflow_available"] is True
     assert payload["ideas"][0]["orderflow_provider"] == "fxpilot"
+    assert payload["ideas"][0]["provider_status"] == "ok"
+    assert payload["ideas"][0]["provider_debug"] == {"source": "test"}
+    assert payload["ideas"][0]["data_source"] == "mt4_live"
+    assert payload["ideas"][0]["data_source_label"] == "MT4 Live"
+    assert payload["ideas"][0]["data_source_quality"] == 75
+    assert payload["ideas"][0]["data_source_status"] == "ok"
+    assert payload["ideas"][0]["data_source_reason"] == "databento_unusable_mt4_live_fresh"
+    assert payload["ideas"][0]["data_source_age_seconds"] == 4
     assert payload["ideas"][0]["delta"] == 11
     assert payload["ideas"][0]["signal"] == "WAIT"
+
+
+def test_api_ideas_market_returns_orderflow_source_metadata_from_cache(monkeypatch) -> None:
+    payload = {
+        "ideas": [
+            {
+                "symbol": "EURUSD",
+                "signal": "WAIT",
+                "orderflow_available": True,
+                "data_source": "mt4_live",
+                "data_source_label": "MT4 Live",
+                "data_source_quality": 75,
+                "data_source_status": "ok",
+            }
+        ],
+        "archive": [],
+    }
+    monkeypatch.setattr(main, "_queue_market_ideas_refresh", lambda: True)
+    monkeypatch.setitem(main.MARKET_IDEAS_CACHE, "payload", payload)
+    monkeypatch.setitem(main.MARKET_IDEAS_CACHE, "updated_at_epoch", main.time.time())
+
+    response = TestClient(main.app).get("/api/ideas/market")
+
+    assert response.status_code == 200
+    idea = response.json()["ideas"][0]
+    assert idea["orderflow_available"] is True
+    assert idea["data_source"] == "mt4_live"
+    assert idea["data_source_label"] == "MT4 Live"
+    assert idea["data_source_quality"] == 75
+    assert idea["data_source_status"] == "ok"
 
 
 def test_build_market_marks_orderflow_disabled_without_engine_call(monkeypatch) -> None:
@@ -89,4 +143,9 @@ def test_build_market_marks_orderflow_disabled_without_engine_call(monkeypatch) 
     assert payload["ideas"][0]["orderflow_available"] is False
     assert payload["ideas"][0]["orderflow_provider"] == "unavailable"
     assert payload["ideas"][0]["orderflow_status"] == "engine_disabled"
+    assert payload["ideas"][0]["data_source"] == "unavailable"
+    assert payload["ideas"][0]["data_source_label"] == "Unavailable"
+    assert payload["ideas"][0]["data_source_quality"] == 0
+    assert payload["ideas"][0]["data_source_status"] == "unavailable"
+    assert payload["ideas"][0]["data_source_reason"] == "orderflow_snapshot_missing"
     assert payload["ideas"][0]["signal"] == "BUY"


### PR DESCRIPTION
### Motivation
- Интерфейс не получал поля source/quality из OrderFlow snapshot, из‑за чего UI отображал «OrderFlow: Unknown Source» и пустую Quality; задача — пробросить существующие метаданные OrderFlow в каждый объект идеи без изменения scoring или AI-логики.

### Description
- Добавлен нормализатор `market_idea_orderflow_metadata` в `app/services/orderflow_client.py`, который формирует контракт метаданных для каждой идеи и содержит безопасный fallback при отсутствии snapshot (например `data_source: "unavailable"`, `data_source_label: "Unavailable"`, `data_source_quality: 0`).
- Применён этот нормализатор при прикреплении snapshot к идеям в `build_market()` (`app/main.py`) и в роутере `/api/ideas/market` (`app/api/ideas_routes.py`) так, чтобы поля OrderFlow и совместимые поля (`orderflow_provider`, `provider_status`, `provider_debug`) копировались в объект идеи.
- Сохранена существующая логика `UNAVAILABLE_SNAPSHOT`, не изменены веса/score, AI-логика и модуль Options.
- Добавлены/обновлены тесты в `tests/test_market_ideas_timeout.py` чтобы проверять проброс `mt4_live`/`MT4 Live`/`75`/`ok`, совместимые поля и fallback‑значения при отключённом движке.

### Testing
- Запущены автоматические тесты: `pytest tests/test_market_ideas_timeout.py tests/test_orderflow_client.py -q`.
- Результат: все запущенные тесты прошли успешно (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49ecd0bf38833191fd12f29b0690d3)