### PR TITLE
Исправить отображение OrderFlow в UI

### DIFF
--- a/app/static/ai-status.js
+++ b/app/static/ai-status.js
@@ -27,15 +27,16 @@
   function normalizeOrderflowSource(payload) {
     const idea = Array.isArray(payload?.ideas) ? payload.ideas.find((item) => item && typeof item === "object") : (Array.isArray(payload) ? payload.find((item) => item && typeof item === "object") : payload);
     const hasNewMetadata = ["data_source", "data_source_label", "data_source_status", "data_source_quality", "data_source_reason", "data_source_age_seconds", "orderflow_available"].some((key) => Object.prototype.hasOwnProperty.call(idea || {}, key));
-    const raw = String(idea?.data_source ?? (!hasNewMetadata ? idea?.orderflow_provider : "") ?? "").toLowerCase();
+    const useLiveMetadata = idea?.orderflow_available === true;
+    const raw = String((useLiveMetadata ? idea?.data_source : (idea?.data_source ?? (!hasNewMetadata ? (idea?.orderflow_provider ?? idea?.provider) : ""))) ?? "").toLowerCase();
     const fallbackLabel = raw === "databento" ? "Databento" : raw === "mt4_live" ? "MT4 Live" : raw === "cache" ? "Cache" : raw === "unavailable" ? "Unavailable" : "Unknown Source";
-    const label = idea?.data_source_label || idea?.orderflow_source_label || (!hasNewMetadata ? idea?.orderflow_provider : "") || fallbackLabel;
-    const status = String(idea?.data_source_status ?? (!hasNewMetadata ? idea?.orderflow_status : "") ?? "").toLowerCase();
+    const label = useLiveMetadata ? (idea?.data_source_label || fallbackLabel) : (idea?.data_source_label || idea?.orderflow_source_label || (!hasNewMetadata ? (idea?.orderflow_provider || idea?.provider) : "") || fallbackLabel);
+    const status = String((useLiveMetadata ? idea?.data_source_status : (idea?.data_source_status ?? (!hasNewMetadata ? (idea?.orderflow_status ?? idea?.provider_status) : ""))) ?? "").toLowerCase();
     const available = idea?.orderflow_available === true || status === "ok";
-    const unavailable = idea?.orderflow_available === false || status === "unavailable" || raw === "unavailable" || status.includes("offline");
+    const unavailable = idea?.orderflow_available === false || (idea?.orderflow_available !== true && (status === "unavailable" || raw === "unavailable" || status.includes("offline")));
     let icon = available ? "🟢" : unavailable ? "🔴" : "⚪";
     if (raw === "cache" || /cache|histor/i.test(label)) icon = "🟡";
-    if (raw === "unavailable") icon = "🔴";
+    if (raw === "unavailable" && idea?.orderflow_available !== true) icon = "🔴";
     const q = Number(idea?.data_source_quality ?? idea?.orderflow_source_quality);
     const quality = Number.isFinite(q) ? `Quality ${Math.max(0, Math.min(100, Math.round(q)))}%` : "Quality —";
     const ageRaw = idea?.data_source_age_seconds ?? idea?.orderflow_source_age_seconds;

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -932,13 +932,19 @@ function normalizeOrderflowReason(value) {
 }
 
 function normalizeOrderflowSource(idea) {
-  const hasNewMetadata = hasOrderflowSourceMetadata(idea);
-  const raw = String(idea?.data_source ?? idea?.orderflow_data_source ?? (!hasNewMetadata ? idea?.orderflow_provider : "") ?? "").toLowerCase();
-  const fallbackLabel = raw === "databento" ? "Databento" : raw === "mt4_live" ? "MT4 Live" : raw === "cache" ? "Cache" : raw === "unavailable" ? "Unavailable" : "Unknown Source";
-  const label = firstText(idea?.data_source_label, idea?.orderflow_source_label, !hasNewMetadata ? idea?.orderflow_provider : null) || fallbackLabel;
-  const status = String(idea?.data_source_status ?? (!hasNewMetadata ? idea?.orderflow_status : "") ?? "").toLowerCase();
   const explicitAvailable = idea?.orderflow_available;
-  const unavailable = explicitAvailable === false || status === "unavailable" || status.includes("offline") || raw === "unavailable" || raw === "offline";
+  const useLiveMetadata = explicitAvailable === true;
+  const hasNewMetadata = hasOrderflowSourceMetadata(idea);
+  const rawValue = useLiveMetadata
+    ? idea?.data_source
+    : (idea?.data_source ?? idea?.orderflow_data_source ?? (!hasNewMetadata ? (idea?.orderflow_provider ?? idea?.provider) : ""));
+  const raw = String(rawValue ?? "").toLowerCase();
+  const fallbackLabel = raw === "databento" ? "Databento" : raw === "mt4_live" ? "MT4 Live" : raw === "cache" ? "Cache" : raw === "unavailable" ? "Unavailable" : "Unknown Source";
+  const label = useLiveMetadata
+    ? (firstText(idea?.data_source_label) || fallbackLabel)
+    : (firstText(idea?.data_source_label, idea?.orderflow_source_label, !hasNewMetadata ? idea?.orderflow_provider : null, !hasNewMetadata ? idea?.provider : null) || fallbackLabel);
+  const status = String(useLiveMetadata ? idea?.data_source_status : (idea?.data_source_status ?? (!hasNewMetadata ? (idea?.orderflow_status ?? idea?.provider_status) : "")) ?? "").toLowerCase();
+  const unavailable = explicitAvailable === false || (explicitAvailable !== true && (status === "unavailable" || status.includes("offline") || raw === "unavailable" || raw === "offline"));
   const ok = explicitAvailable === true || status === "ok";
   let kind = "unknown";
   if (raw === "databento" || /databento|cme/.test(raw) || /databento|cme/i.test(label)) kind = "databento";


### PR DESCRIPTION
### Motivation
- Исправить баг, когда актуальные поля OrderFlow (`data_source_*` и `orderflow_available`) игнорировались и UI показывал «Unavailable» из legacy полей `provider`/`provider_status`.
- Обеспечить приоритет новых метаданных OrderFlow (label, quality, status) при наличии `orderflow_available === true` без изменения логики AI/оценки.

### Description
- Обновлена нормализация источника OrderFlow в `app/static/ideas.js` так, чтобы при `orderflow_available === true` в первовую очередь использовались `data_source`, `data_source_label`, `data_source_status` и `data_source_quality`, а legacy `provider`/`provider_status` применялись только как fallback.
- Аналогичные изменения внесены в `app/static/ai-status.js`, чтобы карточка AI-статуса также приоритизировала live metadata и не перезаписывалась недоступными legacy-значениями.
- Исправлена логика определения «unavailable» и иконки, чтобы значения `unavailable` из старых полей не затирали корректный live статус и качество.
- Изменения закоммичены в одно изменение (файлы: `app/static/ideas.js`, `app/static/ai-status.js`).

### Testing
- Выполнены статические проверки синтаксиса: `node --check app/static/ideas.js` и `node --check app/static/ai-status.js`, обе проверки прошли успешно.
- Выполнен unit-like smoke test нормализации через `node` с примером ответа (`data_source_label = "MT4 Live", data_source_quality = 75, data_source_status = "ok", orderflow_available = true`), тест завершился успешно и вернул ожидаемые значения.
- Запущена проверка `git diff --check`, конфликтов и предупреждений не обнаружено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49f344fe3c83318ac06f9cdfb003f8)