### PR TITLE
Добавить proxy‑режим OrderFlow для MT4 Live и масштабируемый скоринг

### DIFF
--- a/app/services/orderflow_client.py
+++ b/app/services/orderflow_client.py
@@ -16,6 +16,9 @@ ORDERFLOW_METADATA_FIELDS = (
     "data_source_status",
     "data_source_age_seconds",
     "data_source_reason",
+    "orderflow_mode",
+    "orderflow_mode_label",
+    "orderflow_mode_explanation",
 )
 
 ORDERFLOW_COMPATIBILITY_FIELDS = (
@@ -31,6 +34,9 @@ ORDERFLOW_MARKET_IDEA_FALLBACK: dict[str, Any] = {
     "data_source_quality": 0,
     "data_source_status": "unavailable",
     "data_source_reason": "orderflow_snapshot_missing",
+    "orderflow_mode": "unavailable",
+    "orderflow_mode_label": "Unavailable",
+    "orderflow_mode_explanation": "OrderFlow недоступен: подтверждающий слой не участвует в оценке.",
 }
 
 ORDERFLOW_FIELDS = (
@@ -62,9 +68,43 @@ UNAVAILABLE_SNAPSHOT: dict[str, Any] = {
     "data_source_status": "unavailable",
     "data_source_age_seconds": None,
     "data_source_reason": "OrderFlow Engine unavailable",
+    "orderflow_mode": "unavailable",
+    "orderflow_mode_label": "Unavailable",
+    "orderflow_mode_explanation": "OrderFlow недоступен: подтверждающий слой не участвует в оценке.",
     **{field: None for field in ORDERFLOW_FIELDS},
 }
 
+
+
+def resolve_orderflow_mode(data_source: Any) -> str:
+    source = str(data_source or "").strip().lower()
+    if source == "databento":
+        return "institutional"
+    if source == "mt4_live":
+        return "proxy"
+    if source == "cache":
+        return "cache"
+    return "unavailable"
+
+
+def orderflow_mode_label(mode: Any) -> str:
+    return {
+        "institutional": "Institutional",
+        "proxy": "Proxy",
+        "cache": "Cache",
+        "unavailable": "Unavailable",
+    }.get(str(mode or "").strip().lower(), "Unavailable")
+
+
+def orderflow_mode_explanation(mode: Any) -> str:
+    normalized = str(mode or "").strip().lower()
+    if normalized == "institutional":
+        return "OrderFlow работает в institutional-режиме: доступен полноценный Databento/CME поток."
+    if normalized == "proxy":
+        return "OrderFlow работает в MT4 proxy-режиме: используются live ticks брокера, без полноценного CME DOM."
+    if normalized == "cache":
+        return "OrderFlow работает из cache: используется только контекстный слой без свежего подтверждающего буста."
+    return "OrderFlow недоступен: подтверждающий слой не участвует в оценке."
 
 def is_orderflow_engine_enabled() -> bool:
     value = str(get_env("ORDERFLOW_ENABLED", get_env("ORDERFLOW_ENGINE_ENABLED", "false")) or "false").strip().lower()
@@ -103,6 +143,10 @@ def _normalize_snapshot(payload: Any) -> dict[str, Any]:
         normalized["data_source_label"] = "Unknown Source"
     if not normalized.get("data_source_status"):
         normalized["data_source_status"] = "ok" if available else "unavailable"
+    mode = resolve_orderflow_mode(normalized.get("data_source"))
+    normalized["orderflow_mode"] = mode
+    normalized["orderflow_mode_label"] = orderflow_mode_label(mode)
+    normalized["orderflow_mode_explanation"] = orderflow_mode_explanation(mode)
     for field in ORDERFLOW_FIELDS:
         normalized[field] = source.get(field)
     return normalized

--- a/app/services/prop_signal_engine.py
+++ b/app/services/prop_signal_engine.py
@@ -825,19 +825,48 @@ def _margin_zone_context(idea: dict[str, Any]) -> dict[str, Any]:
     return build_margin_zone_context(None, symbol, current_price, entry_price)
 
 
+def _orderflow_mode_from_idea(idea: dict[str, Any]) -> str:
+    source = str(idea.get("data_source") or idea.get("orderflow_data_source") or "").strip().lower()
+    if source == "databento":
+        return "institutional"
+    if source == "mt4_live":
+        return "proxy"
+    if source == "cache":
+        return "cache"
+    return "unavailable"
+
+
+def _orderflow_mode_explanation(mode: str) -> str:
+    if mode == "institutional":
+        return "OrderFlow работает в institutional-режиме: Databento/CME даёт полноценное подтверждение."
+    if mode == "proxy":
+        return "OrderFlow работает в MT4 proxy-режиме: используются live ticks брокера, без полноценного CME DOM."
+    if mode == "cache":
+        return "OrderFlow работает из cache: это контекст, а не свежий сигнал входа."
+    return "OrderFlow недоступен: подтверждающий слой не участвует в оценке."
+
+
 def _volume_delta_context(idea: dict[str, Any], direction: str) -> dict[str, Any]:
     candles = _candles(idea)
     symbol = _normalize_symbol(idea.get("symbol") or idea.get("pair") or idea.get("instrument"))
     timeframe = str(idea.get("timeframe") or idea.get("tf") or "").upper().strip() or None
+    orderflow_mode = _orderflow_mode_from_idea(idea)
     volume_delta = _extract_volume_delta_from_payload(idea)
     if volume_delta is None:
         volume_delta = _extract_volume_delta_from_payload(idea.get("analysis") if isinstance(idea.get("analysis"), dict) else None)
     if volume_delta is None and symbol:
         volume_delta = _extract_volume_delta_from_payload(get_latest_volume_cluster(symbol, timeframe))
+    if volume_delta is not None and orderflow_mode == "unavailable":
+        source_name = str(volume_delta.get("source") or "").strip().lower()
+        if source_name == "futuredelta":
+            orderflow_mode = "institutional"
+        elif source_name in {"futurevolume", "tickvolume", "mt4", "mt4_live", "broker_ticks"}:
+            orderflow_mode = "proxy"
     if volume_delta is None:
         return {
             "available": False,
             "source": "unavailable",
+            "orderflow_mode": orderflow_mode,
             "delta": None,
             "cumdelta": None,
             "is_proxy": True,
@@ -872,6 +901,11 @@ def _volume_delta_context(idea: dict[str, Any], direction: str) -> dict[str, Any
         elif direction == "SELL" and price_trend == "rising" and cumdelta_trend == "rising":
             adjustment = -3
 
+    if confirmed:
+        adjustment = {"institutional": 5, "proxy": 3, "cache": 1}.get(orderflow_mode, 0)
+    elif divergence and orderflow_mode in {"proxy", "cache"}:
+        adjustment = max(adjustment, -2 if orderflow_mode == "proxy" else 0)
+
     source_label = volume_delta.get("source") or "unavailable"
     proxy_label = "proxy" if volume_delta.get("is_proxy") else "real"
     text = (
@@ -879,12 +913,17 @@ def _volume_delta_context(idea: dict[str, Any], direction: str) -> dict[str, Any
         f"delta={volume_delta.get('delta')}, cumdelta={volume_delta.get('cumdelta')}, "
         f"price={price_trend}, cumdelta_trend={cumdelta_trend}"
     )
+    text += f"; orderflow_mode={orderflow_mode}"
+    if orderflow_mode == "proxy":
+        text += "; MT4 proxy: DOM pressure/absorption/imbalance/iceberg footprint не дают institutional boost"
     if divergence:
         text += "; delta_divergence=true"
     elif confirmed:
         text += "; delta подтверждает направление"
     return {
         **volume_delta,
+        "orderflow_mode": orderflow_mode,
+        "orderflow_mode_explanation": _orderflow_mode_explanation(orderflow_mode),
         "price_delta": price_delta,
         "price_trend": price_trend,
         "cumdelta_trend": cumdelta_trend,
@@ -1302,10 +1341,11 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
     hft_layer = _hft_layer_context(safe_idea, direction)
     volume_delta_source = volume_delta.get("source")
     hft_signal = volume_delta.get("hft_signal") or _hft_signal_context(safe_idea).get("hft_signal")
-    orderflow_available = bool(volume_delta.get("available"))
+    orderflow_mode = str(volume_delta.get("orderflow_mode") or _orderflow_mode_from_idea(safe_idea))
+    orderflow_available = bool(volume_delta.get("available")) and orderflow_mode != "unavailable"
     orderflow_adjustment = int(volume_delta.get("score_adjustment") or 0) if orderflow_available else 0
     score = max(0, min(100, base_score + int(external_options.get("score_adjustment") or 0) + orderflow_adjustment + int(dpoc.get("score_adjustment") or 0) + int(margin_zone.get("score_adjustment") or 0) + int(max_pain.get("score_adjustment") or 0) + int(heatmap.get("score_adjustment") or 0) + int(hft_layer.get("score_adjustment") or 0)))
-    score_weights = {"market_structure": 25, "liquidity": 20, "options": 20, "heatmap": 15, "news": 10, "hft": 10, "orderflow": 0 if not orderflow_available else 5}
+    score_weights = {"market_structure": 25, "liquidity": 20, "options": 20, "heatmap": 15, "news": 10, "hft": 10, "orderflow": {"institutional": 5, "proxy": 3, "cache": 1}.get(orderflow_mode, 0) if orderflow_available else 0}
     sentiment_conflict = sentiment.get("alignment") == "conflict"
     external_options_high_conflict = bool(external_options.get("alignment") == "conflict" and external_options.get("high_confidence_conflict"))
     external_options_note = ""
@@ -1384,12 +1424,16 @@ def build_prop_signal_score(idea: dict[str, Any]) -> dict[str, Any]:
             "hft_score_adjustment": hft_layer.get("score_adjustment"),
             "score_weights": score_weights,
             "orderflow_available": orderflow_available,
+            "orderflow_mode": orderflow_mode,
+            "orderflow_mode_explanation": volume_delta.get("orderflow_mode_explanation") or _orderflow_mode_explanation(orderflow_mode),
             "options_weight": score_weights["options"],
             "ai_view_mode": "frontend_localStorage",
         },
         "criteria": rows,
         "score_weights": score_weights,
         "orderflow_available": orderflow_available,
+        "orderflow_mode": orderflow_mode,
+        "orderflow_mode_explanation": volume_delta.get("orderflow_mode_explanation") or _orderflow_mode_explanation(orderflow_mode),
         "options_weight": score_weights["options"],
         "ai_view_mode": "frontend_localStorage",
         "blockers": blockers,

--- a/app/static/ideas.js
+++ b/app/static/ideas.js
@@ -922,7 +922,7 @@ function getAiSourceMeta(idea) {
 
 
 function hasOrderflowSourceMetadata(idea) {
-  return ["data_source", "data_source_label", "data_source_status", "data_source_quality", "data_source_reason", "data_source_age_seconds", "orderflow_available"].some((key) => Object.prototype.hasOwnProperty.call(idea || {}, key));
+  return ["data_source", "data_source_label", "data_source_status", "data_source_quality", "data_source_reason", "data_source_age_seconds", "orderflow_available", "orderflow_mode"].some((key) => Object.prototype.hasOwnProperty.call(idea || {}, key));
 }
 
 function normalizeOrderflowReason(value) {
@@ -958,6 +958,9 @@ function normalizeOrderflowSource(idea) {
     unavailable: { icon: "🔴", label: label === "Unknown Source" ? "Unavailable" : label, compact: "Unavailable", descriptor: "Unavailable" },
     unknown: { icon: ok ? "🟢" : unavailable ? "🔴" : "⚪", label, compact: ok ? "OrderFlow" : "Unknown", descriptor: label },
   }[kind];
+  const explicitMode = String(idea?.orderflow_mode || "").toLowerCase();
+  const mode = explicitMode || (kind === "databento" ? "institutional" : kind === "mt4" ? "proxy" : kind === "cache" ? "cache" : "unavailable");
+  const modeLabel = mode === "institutional" ? "Institutional" : mode === "proxy" ? "Proxy" : mode === "cache" ? "Cache" : "Unavailable";
   const q = Number(idea?.data_source_quality ?? idea?.orderflow_source_quality);
   const qualityPercent = Number.isFinite(q) ? Math.max(0, Math.min(100, Math.round(q))) : null;
   const ageValue = idea?.data_source_age_seconds ?? idea?.orderflow_source_age_seconds;
@@ -970,6 +973,8 @@ function normalizeOrderflowSource(idea) {
     available: ok && !unavailable,
     status,
     source: raw,
+    mode,
+    modeLabel,
     qualityPercent,
     qualityText: qualityPercent === null ? "Quality —" : `Quality ${qualityPercent}%`,
     age: ageSeconds,
@@ -984,19 +989,19 @@ function renderOrderflowSourceBadge(idea) {
 
 function renderOrderflowSourceHybrid(idea) {
   const src = normalizeOrderflowSource(idea);
-  return `OrderFlow / ${src.label} / ${src.qualityText}`;
+  return `OrderFlow / ${src.label} / ${src.qualityText} / mode: ${src.modeLabel}`;
 }
 
 function renderOrderflowSourceHybridBlock(idea) {
   const src = normalizeOrderflowSource(idea);
-  return `<section class="institutional-section orderflow-source-compact"><h4>OrderFlow</h4><p>${escapeHtml(src.label)}<br>${escapeHtml(src.qualityText)}<br>Reason: ${escapeHtml(src.reason)}<br>Age: ${escapeHtml(src.ageText)}</p></section>`;
+  return `<section class="institutional-section orderflow-source-compact"><h4>OrderFlow</h4><p>${escapeHtml(src.label)}<br>OrderFlow mode: ${escapeHtml(src.modeLabel)}<br>${escapeHtml(src.qualityText)}<br>Reason: ${escapeHtml(src.reason)}<br>Age: ${escapeHtml(src.ageText)}</p></section>`;
 }
 
 function renderOrderflowSourceBlock(idea) {
   const src = normalizeOrderflowSource(idea);
   return `<section class="institutional-section orderflow-source-block" title="Source: ${escapeHtml(src.label)}
 Reason: ${escapeHtml(src.reason)}
-Age: ${escapeHtml(src.ageText)}"><h4>OrderFlow Source</h4><p><strong>${escapeHtml(`${src.icon} ${src.label}`)}</strong><br>Source: ${escapeHtml(src.label)}<br>${escapeHtml(src.qualityText)}<br>Reason: ${escapeHtml(src.reason)}<br>Age: ${escapeHtml(src.ageText)}</p></section>`;
+Age: ${escapeHtml(src.ageText)}"><h4>OrderFlow Source</h4><p><strong>${escapeHtml(`${src.icon} ${src.label}`)}</strong><br>Source: ${escapeHtml(src.label)}<br>OrderFlow mode: ${escapeHtml(src.modeLabel)}<br>${escapeHtml(src.qualityText)}<br>Reason: ${escapeHtml(src.reason)}<br>Age: ${escapeHtml(src.ageText)}</p></section>`;
 }
 
 function isOrderflowAvailable(idea) {
@@ -1021,6 +1026,7 @@ function renderOrderflowEngineBlock(idea) {
   const rows = [
     ["Source", normalizeOrderflowSource(idea).label],
     ["Quality", normalizeOrderflowSource(idea).qualityText],
+    ["Mode", normalizeOrderflowSource(idea).modeLabel],
     ["Reason", normalizeOrderflowSource(idea).reason],
     ["Age", normalizeOrderflowSource(idea).ageText],
     ["Delta", idea.delta],
@@ -1031,9 +1037,10 @@ function renderOrderflowEngineBlock(idea) {
     ["POC", idea.poc],
     ["VAH", idea.vah],
     ["VAL", idea.val],
-    ["DOM Pressure", idea.dom_pressure],
-    ["Imbalance", idea.imbalance],
-    ["Absorption", idea.absorption],
+    ["Proxy note", normalizeOrderflowSource(idea).mode === "proxy" ? "OrderFlow работает в MT4 proxy-режиме: используются live ticks брокера, без полноценного CME DOM." : "—"],
+    ["DOM Pressure", normalizeOrderflowSource(idea).mode === "proxy" ? "proxy-only / neutralized" : idea.dom_pressure],
+    ["Imbalance", normalizeOrderflowSource(idea).mode === "proxy" ? "proxy-only / neutralized" : idea.imbalance],
+    ["Absorption", normalizeOrderflowSource(idea).mode === "proxy" ? "proxy-only / neutralized" : idea.absorption],
     ["Exhaustion", idea.exhaustion],
     ["Market State", idea.market_state],
     ["Bias", idea.orderflow_bias],

--- a/tests/test_orderflow_client.py
+++ b/tests/test_orderflow_client.py
@@ -72,6 +72,8 @@ def test_get_orderflow_snapshot_uses_engine_url_symbol_and_timeout(monkeypatch) 
     assert snapshot["data_source_label"] == "Databento CME"
     assert snapshot["data_source_quality"] == 5
     assert snapshot["data_source_age_seconds"] == 3
+    assert snapshot["orderflow_mode"] == "institutional"
+    assert snapshot["orderflow_mode_label"] == "Institutional"
 
 
 def test_get_orderflow_snapshot_returns_unavailable_on_error(monkeypatch) -> None:
@@ -88,3 +90,33 @@ def test_get_orderflow_snapshot_returns_unavailable_on_error(monkeypatch) -> Non
     assert snapshot["data_source_label"] == "Unknown Source"
     assert snapshot["data_source_status"] == "unavailable"
     assert snapshot["delta"] is None
+
+
+def test_mt4_live_snapshot_is_proxy_mode(monkeypatch) -> None:
+    def fake_get(*args, **kwargs):
+        return _Response({
+            "available": True,
+            "data_source": "mt4_live",
+            "data_source_label": "MT4 Live",
+            "data_source_quality": 75,
+            "delta": 10,
+            "cumdelta": 20,
+        })
+
+    monkeypatch.setattr(orderflow_client.requests, "get", fake_get)
+
+    snapshot = orderflow_client.get_orderflow_snapshot("EURUSD")
+
+    assert snapshot["orderflow_available"] is True
+    assert snapshot["orderflow_mode"] == "proxy"
+    assert snapshot["orderflow_mode_label"] == "Proxy"
+    assert "MT4 proxy-режиме" in snapshot["orderflow_mode_explanation"]
+
+
+def test_cache_snapshot_is_cache_mode(monkeypatch) -> None:
+    def fake_get(*args, **kwargs):
+        return _Response({"available": True, "data_source": "cache", "delta": 1, "cumdelta": 2})
+
+    monkeypatch.setattr(orderflow_client.requests, "get", fake_get)
+
+    assert orderflow_client.get_orderflow_snapshot("EURUSD")["orderflow_mode"] == "cache"

--- a/tests/test_volume_delta_priority.py
+++ b/tests/test_volume_delta_priority.py
@@ -106,3 +106,28 @@ def test_prop_engine_marks_delta_divergence_and_reduces_score():
     assert with_divergence["delta_divergence"] is True
     assert with_divergence["prop_signal_score"]["score"] <= without_divergence["prop_signal_score"]["score"] - 5
     assert with_divergence["volume_delta"]["source"] == "FutureDelta"
+
+
+def test_orderflow_scoring_modes_scale_confirmation_boost():
+    base = {
+        "symbol": "EURUSD",
+        "signal": "BUY",
+        "entry": 1.1028,
+        "sl": 1.0980,
+        "tp": 1.1100,
+        "candles": _candles(up=True),
+        "volume_delta": {"source": "FutureDelta", "delta": 180, "cumdelta": 1200, "is_proxy": False, "priority_used": 1},
+    }
+
+    institutional = build_prop_signal_score({**base, "data_source": "databento"})
+    proxy = build_prop_signal_score({**base, "data_source": "mt4_live"})
+    cache = build_prop_signal_score({**base, "data_source": "cache"})
+
+    assert institutional["orderflow_mode"] == "institutional"
+    assert proxy["orderflow_mode"] == "proxy"
+    assert cache["orderflow_mode"] == "cache"
+    assert institutional["volume_delta"]["score_adjustment"] == 5
+    assert proxy["volume_delta"]["score_adjustment"] == 3
+    assert cache["volume_delta"]["score_adjustment"] == 1
+    assert proxy["score_weights"]["orderflow"] == 3
+    assert "MT4 proxy-режиме" in proxy["orderflow_mode_explanation"]


### PR DESCRIPTION
### Motivation
- MT4 Live предоставляет брокерские тик‑данные, но это proxy‑источник без полноценного CME DOM, поэтому скоринг должен учитывать это отдельно.
- Нужно позволить системе безопасно использовать MT4 proxy‑метрики (VWAP, объём, rvol, delta/cumdelta, market_state, bias) и одновременно ослабить влияние DOM/absorption/imbalance/footprint‑сигналов.
- При отсутствии institutional DOM нельзя делать идею недействительной; данные proxy должны давать умеренное подтверждение, cache — лишь контекст.

### Description
- Добавлена явная модель режима OrderFlow: `orderflow_mode` (`institutional`/`proxy`/`cache`/`unavailable`) вместе с метаданными `orderflow_mode_label` и `orderflow_mode_explanation` в `app/services/orderflow_client.py` и в контракте идей через `market_idea_orderflow_metadata`.
- Реализовано определение режима по `data_source` и по источнику `volume_delta` в `app/services/prop_signal_engine.py` через ` _orderflow_mode_from_idea` / `resolve_orderflow_mode` и примечание‑объяснение для proxy (на русском).
- Масштаб подтверждающего буста: при подтверждении delta установка `score_adjustment` = 5 для `institutional`, = 3 для `proxy`, = 1 для `cache`; divergence для proxy/cache даёт меньший штраф (нейтрализация разницы). В `build_prop_signal_score` вес слоя `orderflow` теперь зависит от `orderflow_mode` (institutional=5, proxy=3, cache=1, unavailable=0).
- Для proxy в UI добавлен бейдж/строка режима (`OrderFlow mode: Proxy`) и в блоке OrderFlow DOM/Imbalance/Absorption маркируются как «proxy‑only / neutralized» с поясняющей строкой: `"OrderFlow работает в MT4 proxy-режиме: используются live ticks брокера, без полноценного CME DOM."` в `app/static/ideas.js`.
- Тесты: добавлены проверки нормализации snapshot в `tests/test_orderflow_client.py` и тест шкалирования confirmation boost в `tests/test_volume_delta_priority.py`.
- Не затрагивались модули Options, приоритет Databento и исполнение трейдов (соблюдены ограничения).

### Testing
- Проверены компиляция Python файлов: `python -m py_compile app/services/orderflow_client.py app/services/prop_signal_engine.py` (успешно).
- JS static проверка: `node --check app/static/ideas.js` (успешно).
- Запущены автоматические тесты: `pytest tests/test_orderflow_client.py tests/test_volume_delta_priority.py` и `pytest tests/signals/test_prop_signal_fallback.py` (наборы тестов на изменённой ветке прошли — все целевые тесты зелёные).
- Итог: добавленные и изменённые тесты проходят; в процессе разработки была отловлена и устранена причина порядка выполнения тестов (intermittent order dependency), в финальном прогоне все перечисленные тесты прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a5adebc5c83319ac99c66c645ce22)