### PR TITLE
Добавить лёгкий счётчик посетителей

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.services.idea_lifecycle import apply_idea_lifecycle, build_lifecycle_st
 from app.services.signal_audit_logger import log_signal_audit
 from app.services.timing import timing_log
 from app.services.ai_runtime_status import get_ai_status, record_ai_request_failure, record_ai_request_start, record_ai_request_success, run_ai_test_request, startup_ai_healthcheck
+from app.services.visitor_counter import get_visit_stats, increment_visit
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -491,6 +492,20 @@ def stats_page():
 @app.get("/archive", include_in_schema=False)
 def archive_page():
     return FileResponse(STATIC_DIR / "archive.html")
+
+
+@app.get("/api/visits")
+def api_visits(request: Request, response: Response, increment: bool = False) -> dict[str, Any]:
+    if increment and request.cookies.get("fxpilot_visit_counted") != "1":
+        payload = increment_visit()
+        response.set_cookie(
+            "fxpilot_visit_counted",
+            "1",
+            httponly=False,
+            samesite="lax",
+        )
+        return payload
+    return get_visit_stats()
 
 
 @app.get("/api/ai/status")

--- a/app/services/visitor_counter.py
+++ b/app/services/visitor_counter.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from app.services.storage.json_storage import JsonStorage
+
+VISITS_STORAGE_PATH = Path("signals_data/visitor_counter.json")
+_VISITS_LOCK = Lock()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _today_key(now: datetime | None = None) -> str:
+    return (now or _now()).date().isoformat()
+
+
+def _default_payload(now: datetime | None = None) -> dict[str, Any]:
+    current = now or _now()
+    return {
+        "total": 0,
+        "today": 0,
+        "date": _today_key(current),
+        "updated_at": current.isoformat(),
+    }
+
+
+def _storage() -> JsonStorage:
+    return JsonStorage(str(VISITS_STORAGE_PATH), _default_payload())
+
+
+def _normalize_payload(payload: Any, now: datetime | None = None) -> dict[str, Any]:
+    current = now or _now()
+    default = _default_payload(current)
+    if not isinstance(payload, dict):
+        return default
+
+    date_key = str(payload.get("date") or _today_key(current))
+    today = int(payload.get("today") or 0) if date_key == _today_key(current) else 0
+    total = int(payload.get("total") or 0)
+    return {
+        "total": max(total, 0),
+        "today": max(today, 0),
+        "date": _today_key(current),
+        "updated_at": str(payload.get("updated_at") or current.isoformat()),
+    }
+
+
+def get_visit_stats() -> dict[str, Any]:
+    with _VISITS_LOCK:
+        payload = _normalize_payload(_storage().read())
+        if payload["date"] != _today_key():
+            payload["today"] = 0
+            payload["date"] = _today_key()
+            payload["updated_at"] = _now().isoformat()
+            _storage().write(payload)
+        return {
+            "today": payload["today"],
+            "total": payload["total"],
+            "updated_at": payload["updated_at"],
+        }
+
+
+def increment_visit() -> dict[str, Any]:
+    with _VISITS_LOCK:
+        current = _now()
+        payload = _normalize_payload(_storage().read(), current)
+        payload["today"] += 1
+        payload["total"] += 1
+        payload["date"] = _today_key(current)
+        payload["updated_at"] = current.isoformat()
+        _storage().write(payload)
+        return {
+            "today": payload["today"],
+            "total": payload["total"],
+            "updated_at": payload["updated_at"],
+        }

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -22,3 +22,41 @@
     else link.removeAttribute('aria-current');
   });
 })();
+
+(function initVisitorCounter() {
+  const shell = document.querySelector('.page-shell') || document.body;
+  if (!shell || document.querySelector('[data-visitor-counter]')) return;
+
+  const counter = document.createElement('div');
+  counter.className = 'visitor-counter';
+  counter.setAttribute('data-visitor-counter', '');
+  counter.setAttribute('aria-label', 'Счётчик посещений');
+  counter.hidden = true;
+  shell.appendChild(counter);
+
+  const render = (payload) => {
+    const today = Number(payload && payload.today);
+    const total = Number(payload && payload.total);
+    if (!Number.isFinite(today) || !Number.isFinite(total)) return;
+    counter.textContent = `👁 Сегодня: ${today} · Всего: ${total}`;
+    counter.hidden = false;
+  };
+
+  const load = async () => {
+    try {
+      const visitedKey = 'fxpilot_visit_counted';
+      const shouldIncrement = window.sessionStorage.getItem(visitedKey) !== '1';
+      const response = await fetch(`/api/visits${shouldIncrement ? '?increment=true' : ''}`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) return;
+      const payload = await response.json();
+      if (shouldIncrement) window.sessionStorage.setItem(visitedKey, '1');
+      render(payload);
+    } catch (_) {
+      counter.hidden = true;
+    }
+  };
+
+  load();
+})();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2191,3 +2191,32 @@ body[data-page="home"] .home-link:hover {
 .ai-status-card__grid span { padding: 8px 10px; border: 1px solid rgba(104, 143, 191, 0.18); border-radius: 999px; background: rgba(3, 14, 28, 0.58); }
 .ai-status-card--active { border-color: rgba(34, 197, 94, 0.34); box-shadow: 0 18px 48px rgba(34, 197, 94, 0.08); }
 .ai-status-card--offline { border-color: rgba(239, 68, 68, 0.34); box-shadow: 0 18px 48px rgba(239, 68, 68, 0.08); }
+
+.visitor-counter {
+  position: fixed;
+  right: 18px;
+  bottom: 16px;
+  z-index: 20;
+  padding: 7px 10px;
+  border: 1px solid rgba(104, 143, 191, 0.16);
+  border-radius: 999px;
+  color: rgba(207, 231, 255, 0.72);
+  background: rgba(7, 17, 31, 0.72);
+  box-shadow: 0 12px 28px rgba(2, 6, 23, 0.22);
+  backdrop-filter: blur(12px);
+  font-size: 0.78rem;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.visitor-counter[hidden] {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .visitor-counter {
+    right: 12px;
+    bottom: 10px;
+    font-size: 0.72rem;
+  }
+}

--- a/tests/test_visitor_counter.py
+++ b/tests/test_visitor_counter.py
@@ -1,0 +1,48 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import visitor_counter
+
+
+def _client_with_storage(monkeypatch, tmp_path):
+    monkeypatch.setattr(visitor_counter, "VISITS_STORAGE_PATH", tmp_path / "visitor_counter.json")
+    return TestClient(app)
+
+
+def test_counter_response(monkeypatch, tmp_path):
+    client = _client_with_storage(monkeypatch, tmp_path)
+
+    response = client.get("/api/visits")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["today"] == 0
+    assert payload["total"] == 0
+    assert isinstance(payload["updated_at"], str)
+
+
+def test_increment_once_per_session_cookie(monkeypatch, tmp_path):
+    client = _client_with_storage(monkeypatch, tmp_path)
+
+    first = client.get("/api/visits?increment=true")
+    second = client.get("/api/visits?increment=true")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["today"] == 1
+    assert first.json()["total"] == 1
+    assert second.json()["today"] == 1
+    assert second.json()["total"] == 1
+
+
+def test_counter_recreates_missing_storage_file(monkeypatch, tmp_path):
+    client = _client_with_storage(monkeypatch, tmp_path)
+    storage_file = tmp_path / "visitor_counter.json"
+    if storage_file.exists():
+        storage_file.unlink()
+
+    response = client.get("/api/visits")
+
+    assert response.status_code == 200
+    assert response.json()["today"] == 0
+    assert response.json()["total"] == 0


### PR DESCRIPTION
### Motivation
- Добавить на сайт небольшой ненавязчивый счётчик посещений, который показывает «Сегодня» и «Всего» и не собирает персональные данные.
- Использовать лёгкую локальную персистенцию в проекте и счётчик, который не ломает текущую архитектуру и совместим с Render.

### Description
- Добавлен сервис `app/services/visitor_counter.py`, реализующий JSON-backed хранение через существующий `JsonStorage` и поддерживающий поля `today`, `total` и `updated_at` с ежедневным сбросом счётчика. 
- Добавлен endpoint `GET /api/visits` в `app/main.py` с опцией `?increment=true`, который инкрементит счётчик и ставит cookie `fxpilot_visit_counted` чтобы предотвратить повторный инкремент в одной браузерной сессии. 
- Внесены изменения в фронтенд: в `app/static/nav.js` добавлена лёгкая инициализация счётчика (показывает `👁 Сегодня: X · Всего: Y`) и использует `sessionStorage` на клиенте; в `app/static/styles.css` добавлены компактные тёмные стили для бейджа. 
- Не собираются IP или другие персональные данные, не добавляются сторонние аналитические скрипты и нет всплывающих баннеров; при ошибке API счётчик скрывается без уведомлений.

### Testing
- Запущены автоматические тесты `pytest tests/test_visitor_counter.py` и все 3 теста прошли успешно (`3 passed`).
- Тесты покрывают форму ответа API, поведение «инкремента один раз за сессию» и восстановление при отсутствии файла хранения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a729273248331897554be73c19d74)