### PR TITLE
Начало FXPilot 2.0 — добавлен FXPilot TV и новая философия

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,3 +447,9 @@ Backend сохраняет реальный уровень индикатора 
 - Debug endpoint `GET /api/ai/test` отправляет короткий запрос `Reply with OK` в текущую модель OpenRouter и возвращает `success`, `provider`, `model`, `response`, `latency_ms` и, при ошибке, текст причины.
 - При старте FastAPI выполняется неблокирующий health-check OpenRouter. Если ключ отсутствует или провайдер недоступен, приложение не падает: причина сохраняется в runtime status, а существующая fallback-логика продолжает работать.
 - Каждый интегрированный LLM-вызов логирует модель, время запроса, latency, успех или ошибку. UI на главной странице и `/ideas` показывает блок `AI Status`, а карточки идей отображают источник: `Grok`, `Fallback Engine` или `Rule Engine`.
+
+## FXPilot 2.0
+
+FXPilot 2.0 starts with the **FXPilot Intelligence** philosophy: not just signals, but market understanding backed by facts. The homepage now states this direction, and the public navigation includes the new **FXPilot TV** foundation at `/tv`.
+
+FXPilot TV is currently a premium UX/UI foundation only. It intentionally does not implement YouTube ingestion, backend video processing, or AI video analysis yet. The page describes the future roadmap for video cataloging, AI summaries, FXPilot comparison, Reality Check, Trust Score, Market Memory, and AI Mentor.

--- a/app/main.py
+++ b/app/main.py
@@ -469,6 +469,11 @@ def ideas_page():
     return FileResponse(STATIC_DIR / "ideas.html")
 
 
+@app.get("/tv", include_in_schema=False)
+def tv_page():
+    return FileResponse(STATIC_DIR / "tv.html")
+
+
 @app.get("/news", include_in_schema=False)
 def news_page():
     return FileResponse(STATIC_DIR / "news.html")

--- a/app/static/ideas.html
+++ b/app/static/ideas.html
@@ -114,7 +114,7 @@
           <a href="/news">Новости</a>
           <a href="/calendar">Календарь</a>
           <a href="/heatmap/page">Тепловая карта</a>
-          <a href="/ideas/market">API идей</a>
+          <a href="/tv">🎥 FXPilot TV</a>
         </div>
       </nav>
       <div class="ideas-page-header">

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -13,11 +13,9 @@
       <header class="site-header">
         <div>
           <p class="eyebrow">Главная</p>
-          <h1>AI FOREX SIGNAL PLATFORM</h1>
-          <p class="lead">
-            Платформа для идей, новостей и рыночной аналитики в едином интерфейсе. Здесь только ключевые разделы,
-            без лишнего контента.
-          </p>
+          <h1>FXPilot Intelligence</h1>
+          <p class="lead hero-philosophy">Не просто сигналы.<br />Понимание рынка.</p>
+          <p class="hero-caption">Проверяем торговые идеи фактами.</p>
         </div>
         <nav class="top-nav">
           <a href="/">Главная</a>
@@ -28,6 +26,7 @@
           <a href="/news">Новости</a>
           <a href="/calendar">Календарь</a>
           <a href="/heatmap/page">Тепловая карта</a>
+          <a href="/tv">🎥 FXPilot TV</a>
         </nav>
       </header>
 
@@ -90,6 +89,10 @@
             <a class="nav-card" href="/heatmap/page">
               <strong>Тепловая карта</strong>
               <span>Динамика валютных пар.</span>
+            </a>
+            <a class="nav-card nav-card--featured" href="/tv">
+              <strong>🎥 FXPilot TV</strong>
+              <span>AI-анализ видео, проверка прогнозов и будущие рейтинги доверия аналитиков.</span>
             </a>
           </div>
         </section>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2220,3 +2220,205 @@ body[data-page="home"] .home-link:hover {
     font-size: 0.72rem;
   }
 }
+
+.hero-philosophy {
+  margin-bottom: 8px;
+  font-size: clamp(1.28rem, 2.5vw, 1.85rem);
+  color: #dff6ff;
+}
+
+.hero-caption {
+  margin: 0;
+  color: #9fb6d8;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.nav-card--featured {
+  border-color: rgba(76, 201, 240, 0.38);
+  background: linear-gradient(145deg, rgba(14, 34, 60, 0.96), rgba(33, 24, 69, 0.88));
+}
+
+body[data-page="tv"] {
+  background:
+    radial-gradient(circle at 12% 8%, rgba(76, 201, 240, 0.24), transparent 28%),
+    radial-gradient(circle at 85% 12%, rgba(139, 92, 246, 0.24), transparent 30%),
+    radial-gradient(circle at 50% 80%, rgba(34, 197, 94, 0.09), transparent 32%),
+    linear-gradient(180deg, #030812 0%, #07111f 58%, #040812 100%);
+}
+
+.tv-shell { padding-bottom: 28px; }
+
+.tv-hero {
+  position: relative;
+  overflow: hidden;
+  min-height: 440px;
+}
+
+.tv-hero::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  background:
+    linear-gradient(120deg, rgba(76, 201, 240, 0.12), transparent 38%, rgba(139, 92, 246, 0.14)),
+    radial-gradient(circle at 78% 62%, rgba(76, 201, 240, 0.16), transparent 22%);
+  pointer-events: none;
+}
+
+.tv-hero > * { position: relative; z-index: 1; }
+
+.tv-hero__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  gap: 28px;
+  align-items: end;
+  padding-top: 54px;
+}
+
+.tv-hero__copy h1 {
+  margin: 0;
+  font-size: clamp(3.2rem, 8vw, 7.5rem);
+  letter-spacing: -0.08em;
+  line-height: 0.9;
+}
+
+.tv-hero__copy .lead {
+  margin: 24px 0 0;
+  max-width: 720px;
+  font-size: clamp(1.25rem, 2.8vw, 2.25rem);
+  color: #d9eeff;
+}
+
+.tv-hero__signal {
+  padding: 22px;
+  border-radius: 28px;
+  border: 1px solid rgba(143, 210, 255, 0.28);
+  background: rgba(5, 14, 28, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 28px 80px rgba(0, 0, 0, 0.35);
+}
+
+.tv-hero__signal strong { display: block; margin: 10px 0 8px; font-size: 1.35rem; }
+.tv-hero__signal p { margin: 0; color: var(--muted); line-height: 1.55; }
+
+.tv-live-dot {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #54ffb5;
+  box-shadow: 0 0 0 8px rgba(84, 255, 181, 0.12), 0 0 26px rgba(84, 255, 181, 0.75);
+}
+
+.tv-content .panel { border-color: rgba(118, 171, 231, 0.2); }
+.tv-intro h2, .tv-roadmap h2, .tv-vision h2 { margin-top: 0; }
+.tv-intro .section-text { max-width: 980px; font-size: 1.05rem; }
+
+.tv-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.tv-feature-card {
+  position: relative;
+  overflow: hidden;
+  min-height: 250px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 22px;
+  border-radius: 26px;
+  border: 1px solid rgba(104, 143, 191, 0.2);
+  background: linear-gradient(150deg, rgba(12, 25, 45, 0.98), rgba(9, 16, 32, 0.92));
+  box-shadow: 0 22px 60px rgba(2, 6, 23, 0.32);
+}
+
+.tv-feature-card::after {
+  content: "";
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  right: -70px;
+  top: -70px;
+  border-radius: 999px;
+  background: rgba(76, 201, 240, 0.12);
+  filter: blur(2px);
+}
+
+.tv-card-icon { color: #7dd3fc; font-weight: 900; letter-spacing: 0.16em; }
+.tv-feature-card h3 { margin: 0; font-size: 1.45rem; }
+.tv-feature-card p { margin: 0; color: var(--muted); line-height: 1.6; }
+.tv-badge {
+  margin-top: auto;
+  width: max-content;
+  padding: 8px 12px;
+  border-radius: 999px;
+  color: #dff6ff;
+  border: 1px solid rgba(76, 201, 240, 0.34);
+  background: rgba(76, 201, 240, 0.1);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.tv-timeline {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(140px, 1fr));
+  gap: 10px;
+  overflow-x: auto;
+  padding: 22px 2px 4px;
+}
+
+.tv-timeline div {
+  min-height: 128px;
+  padding: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(139, 92, 246, 0.24);
+  background: rgba(7, 17, 31, 0.82);
+}
+
+.tv-timeline strong, .tv-timeline span { display: block; }
+.tv-timeline strong { color: #93e7ff; margin-bottom: 14px; }
+.tv-timeline span { color: #e8eef8; line-height: 1.35; }
+
+.tv-vision {
+  background:
+    linear-gradient(135deg, rgba(76, 201, 240, 0.13), transparent 42%),
+    linear-gradient(160deg, rgba(13, 28, 49, 0.98), rgba(16, 12, 38, 0.94));
+}
+
+.tv-vision p:not(.section-kicker) {
+  max-width: 760px;
+  color: #dcecff;
+  font-size: clamp(1.08rem, 2vw, 1.42rem);
+  line-height: 1.55;
+}
+
+.tv-footer {
+  margin-top: 20px;
+  padding: 24px 28px;
+  border: 1px solid rgba(104, 143, 191, 0.18);
+  border-radius: 28px;
+  background: rgba(5, 14, 28, 0.82);
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  color: #dbeafe;
+}
+
+.tv-footer strong { font-size: 1.1rem; letter-spacing: 0.12em; text-transform: uppercase; }
+.tv-footer span { color: var(--muted); text-align: right; line-height: 1.45; }
+
+@media (max-width: 980px) {
+  .tv-hero__grid { grid-template-columns: 1fr; padding-top: 30px; }
+  .tv-card-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 640px) {
+  .tv-card-grid { grid-template-columns: 1fr; }
+  .tv-footer { align-items: flex-start; flex-direction: column; }
+  .tv-footer span { text-align: left; }
+}

--- a/app/static/tv.html
+++ b/app/static/tv.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FXPilot TV · AI-анализ видео</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="shortcut icon" href="/favicon.svg">
+  </head>
+  <body data-page="tv">
+    <div class="page-shell tv-shell">
+      <header class="site-header tv-hero">
+        <nav class="top-nav" aria-label="Основная навигация">
+          <a href="/">Главная</a>
+          <a href="/ideas">Идеи</a>
+          <a href="/stats">Статистика</a>
+          <a href="/archive">Архив</a>
+          <a href="/analytics">Аналитика</a>
+          <a href="/news">Новости</a>
+          <a href="/calendar">Календарь</a>
+          <a href="/heatmap/page">Тепловая карта</a>
+          <a href="/tv" class="is-active" aria-current="page">🎥 FXPilot TV</a>
+        </nav>
+
+        <div class="tv-hero__grid">
+          <div class="tv-hero__copy">
+            <p class="eyebrow">FXPilot 2.0 · Intelligence Layer</p>
+            <h1>FXPilot TV</h1>
+            <p class="lead">AI-анализ видео.<br />Проверка прогнозов.<br />Понимание рынка.</p>
+          </div>
+          <div class="tv-hero__signal" aria-label="Концепция FXPilot TV">
+            <span class="tv-live-dot"></span>
+            <strong>Future module</strong>
+            <p>Видео → смысл → сравнение → проверка фактом</p>
+          </div>
+        </div>
+      </header>
+
+      <main class="content-stack tv-content">
+        <section class="panel tv-intro">
+          <p class="section-kicker">Философия модуля</p>
+          <h2>Это не ещё одна страница с YouTube-видео.</h2>
+          <p class="section-text">FXPilot TV задуман как интеллектуальная система, которая собирает профессиональную рыночную аналитику, сжимает длинные видео в ясные AI-резюме и сопоставляет выводы аналитиков с собственным взглядом FXPilot.</p>
+          <p class="section-text">После выхода прогноза платформа будет возвращаться к нему позже: проверять, что действительно произошло на рынке, фиксировать точность идей и постепенно строить рейтинги доверия к аналитикам. Цель — не шум, а проверяемое понимание.</p>
+        </section>
+
+        <section class="panel">
+          <div class="panel-heading compact">
+            <div>
+              <p class="section-kicker">Feature Preview</p>
+              <h2>Премиальные возможности FXPilot TV</h2>
+              <p class="section-text">Функции ниже формируют UX-фундамент нового модуля. Реальная видеоинтеграция, YouTube и AI-обработка будут добавлены в следующих этапах.</p>
+            </div>
+          </div>
+          <div class="tv-card-grid">
+            <article class="tv-feature-card"><span class="tv-card-icon">01</span><h3>Видеоаналитика</h3><p>Кураторский каталог профессиональных обзоров рынка с фокусом на валюты, золото, индексы и макро-сценарии.</p><span class="tv-badge">Coming Soon</span></article>
+            <article class="tv-feature-card"><span class="tv-card-icon">02</span><h3>AI Summary</h3><p>Короткое резюме длинных видео: ключевые тезисы, уровни, сценарии, риски и условия отмены прогноза.</p><span class="tv-badge">Coming Soon</span></article>
+            <article class="tv-feature-card"><span class="tv-card-icon">03</span><h3>Reality Check</h3><p>Проверка прогнозов после факта: что совпало с рынком, что было ошибкой и какие выводы полезны трейдеру.</p><span class="tv-badge">Coming Soon</span></article>
+            <article class="tv-feature-card"><span class="tv-card-icon">04</span><h3>Trust Score</h3><p>Рейтинг доверия аналитиков на основе проверяемых прогнозов, дисциплины сценариев и прозрачности аргументации.</p><span class="tv-badge">Coming Soon</span></article>
+            <article class="tv-feature-card"><span class="tv-card-icon">05</span><h3>Market Memory</h3><p>Память рынка: архив идей, повторяющиеся паттерны, история точности и контекст предыдущих прогнозов.</p><span class="tv-badge">Coming Soon</span></article>
+            <article class="tv-feature-card"><span class="tv-card-icon">06</span><h3>AI Mentor</h3><p>Будущий наставник, который объясняет логику аналитиков, сравнивает сценарии и помогает задавать правильные вопросы.</p><span class="tv-badge">Coming Soon</span></article>
+          </div>
+        </section>
+
+        <section class="panel tv-roadmap">
+          <p class="section-kicker">Roadmap</p>
+          <h2>Путь к интеллектуальному видео-модулю</h2>
+          <div class="tv-timeline">
+            <div><strong>Phase 1</strong><span>Video catalog</span></div>
+            <div><strong>Phase 2</strong><span>AI Summary</span></div>
+            <div><strong>Phase 3</strong><span>FXPilot comparison</span></div>
+            <div><strong>Phase 4</strong><span>Reality Check</span></div>
+            <div><strong>Phase 5</strong><span>Trust Score</span></div>
+            <div><strong>Phase 6</strong><span>Market Memory</span></div>
+            <div><strong>Phase 7</strong><span>AI Mentor</span></div>
+          </div>
+        </section>
+
+        <section class="panel tv-vision">
+          <p class="section-kicker">Vision</p>
+          <h2>Почему мы создаем FXPilot TV?</h2>
+          <p>Сегодня трейдер получает десятки противоречивых прогнозов.</p>
+          <p>FXPilot TV создается для того, чтобы проверять торговые идеи фактами.</p>
+          <p>Наша цель —<br />не заменить аналитиков,</p>
+          <p>а помочь понять,<br />какие выводы подтверждаются рынком.</p>
+        </section>
+      </main>
+
+      <footer class="tv-footer">
+        <strong>FXPilot 2.0</strong>
+        <span>Not just signals.<br />Understanding the market.</span>
+      </footer>
+    </div>
+    <script src="/static/nav.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Задать новую философию платформы как «FXPilot Intelligence» и обновить главный геро-блок для отражения фокуса на понимании рынка. 
- Заложить UX/UI-фундамент для модуля видеоаналитики `FXPilot TV` без внедрения backend-видео, YouTube-интеграции или AI-анализа на этом этапе. 
- Сделать доступ к будущему модулю видимым в навигации, при этом не ломая существующие API-маршруты и контракт `/api/ideas/market`.

### Description
- Обновлён главный экран: заменён заголовок и текст героя в `app/static/index.html` на «FXPilot Intelligence», подзаголовок `Не просто сигналы. Понимание рынка.` и подпись `Проверяем торговые идеи фактами.`. 
- В публичной навигации заменён пункт `API идей` на `🎥 FXPilot TV` в `app/static/index.html` и `app/static/ideas.html`, при этом API-маршрут остался неизменным. 
- Добавлена новая статическая страница `app/static/tv.html` и маршрут `GET /tv` в `app/main.py`, содержащие header, русскоязычное введение, шесть премиальных карточек функций с бейджем `Coming Soon`, таймлайн дорожной карты, блок видения и футер `FXPilot 2.0`. 
- Добавлены стили для модуля в `app/static/styles.css` и краткое описание направления `FXPilot 2.0` в `README.md` для документирования ограничений (без бэкенда/YouTube/AI). 

### Testing
- `python3 -m py_compile app/main.py` проверка синтаксиса `app/main.py` — успешно. 
- Быстрый smoke-test через `FastAPI TestClient` для путей `/`, `/tv` и `/ideas/market` вернул HTTP `200` для всех трёх маршрутов — успешно. 
- Запуск сервера показал, что страница `GET /tv` доступна и отвечает, но попытка сделать скриншот через Playwright завершилась неудачей из-за отсутствия модуля `playwright` в среде — сервер запущен, screenshot не выполнен. 
- Внесённые изменения оставляют все backend-маршруты и контракты нетронутыми; на данный момент реализована только полноценная UX/UI-основа.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8d4a5d7c83318a8cde9fd5d586cf)