### PR TITLE
Полировка премиального UI FXPilot TV

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3039,3 +3039,169 @@ body[data-page="tv-review"] {
     grid-template-columns: 1fr;
   }
 }
+
+.tv-premium-player-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  gap: 18px;
+  margin-bottom: 18px;
+  padding: 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(76, 201, 240, 0.22);
+  background: linear-gradient(135deg, rgba(76, 201, 240, 0.11), rgba(139, 92, 246, 0.08) 48%, rgba(3, 12, 24, 0.62));
+}
+
+.tv-premium-player-header h3 { margin: 0 0 10px; font-size: clamp(1.35rem, 2.7vw, 2.25rem); letter-spacing: -0.03em; }
+.tv-premium-player-header p { margin: 0; color: #a8bdd7; line-height: 1.65; }
+
+.tv-player-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.tv-player-meta-grid div {
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(3, 12, 24, 0.52);
+}
+
+.tv-player-meta-grid span,
+.tv-player-meta-grid strong { display: block; }
+.tv-player-meta-grid span { margin-bottom: 6px; color: #7f95b2; font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.tv-player-meta-grid strong { color: #f1f7ff; overflow-wrap: anywhere; }
+
+.tv-watch-status {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: #bbf7d0;
+  background: rgba(34, 197, 94, 0.11);
+  border: 1px solid rgba(34, 197, 94, 0.24);
+  font-size: 0.74rem;
+  font-weight: 900;
+}
+
+.tv-watch-progress,
+.tv-mini-progress {
+  overflow: hidden;
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.tv-watch-progress span,
+.tv-mini-progress i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #38bdf8, #22c55e);
+  box-shadow: 0 0 18px rgba(56, 189, 248, 0.28);
+}
+
+.tv-up-next-card {
+  width: 100%;
+  margin-top: 16px;
+  padding: 16px;
+  display: grid;
+  grid-template-columns: 118px minmax(0, 1fr);
+  gap: 12px 14px;
+  text-align: left;
+  color: var(--text);
+  border-radius: 20px;
+  border: 1px solid rgba(76, 201, 240, 0.2);
+  background: linear-gradient(135deg, rgba(3, 12, 24, 0.78), rgba(15, 35, 62, 0.72));
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tv-up-next-card:hover { transform: translateY(-2px); border-color: rgba(76, 201, 240, 0.5); box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28); }
+.tv-up-next-card .section-kicker { grid-column: 1 / -1; margin: 0; }
+.tv-up-next-card img { width: 118px; height: 74px; object-fit: cover; border-radius: 14px; border: 1px solid rgba(255,255,255,0.08); }
+.tv-up-next-card strong { align-self: end; line-height: 1.35; }
+.tv-up-next-card span { color: var(--muted); }
+
+.tv-review-section {
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease;
+}
+
+.tv-review-section::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  background: linear-gradient(90deg, #38bdf8, #8b5cf6, #22c55e);
+  opacity: 0.75;
+}
+
+.tv-review-section:hover { transform: translateY(-3px); border-color: rgba(76, 201, 240, 0.38); box-shadow: 0 24px 70px rgba(0, 0, 0, 0.34); }
+.tv-review-meta-grid { margin: 14px 0; }
+
+.tv-review-timeline {
+  display: grid;
+  gap: 14px;
+  counter-reset: tvTimeline;
+}
+
+.tv-review-timeline div {
+  position: relative;
+  padding: 18px 18px 18px 58px;
+  border-radius: 20px;
+  border: 1px solid rgba(76, 201, 240, 0.18);
+  background: rgba(3, 12, 24, 0.54);
+}
+
+.tv-review-timeline div::before {
+  counter-increment: tvTimeline;
+  content: counter(tvTimeline);
+  position: absolute;
+  left: 16px;
+  top: 18px;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  color: #06111f;
+  background: linear-gradient(135deg, #9fe7ff, #86efac);
+  font-weight: 900;
+}
+
+.tv-review-timeline div:not(:last-child)::after {
+  content: "↓";
+  position: absolute;
+  left: 28px;
+  bottom: -18px;
+  color: #7dd3fc;
+  font-weight: 900;
+}
+
+.tv-review-timeline span { display: block; color: #8da2bd; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.tv-review-timeline strong { display: block; margin: 6px 0; color: #eaf6ff; font-size: 1.08rem; }
+.tv-review-timeline p { margin: 0; }
+
+@media (max-width: 820px) {
+  .tv-premium-player-header,
+  .tv-player-meta-grid,
+  .tv-up-next-card { grid-template-columns: 1fr; }
+  .tv-up-next-card img { width: 100%; height: auto; aspect-ratio: 16 / 9; }
+}
+
+.tv-up-next-thumb {
+  width: 118px;
+  height: 74px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: radial-gradient(circle at 30% 25%, rgba(76, 201, 240, 0.26), transparent 34%), linear-gradient(135deg, rgba(15, 35, 62, 0.92), rgba(3, 12, 24, 0.92));
+  background-size: cover;
+  background-position: center;
+}
+
+@media (max-width: 820px) {
+  .tv-up-next-thumb { width: 100%; height: auto; aspect-ratio: 16 / 9; }
+}

--- a/app/static/tv-components.js
+++ b/app/static/tv-components.js
@@ -27,6 +27,17 @@ window.FXPilotTv = (() => {
     return `<iframe src="${embedUrl(video.youtube_id, { autoplay })}" title="${escapeHtml(video.title || titleFallback)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"></iframe>`;
   };
 
+  const thumbnailUrl = (video = {}) => video.youtube_id ? `https://i.ytimg.com/vi/${encodeURIComponent(video.youtube_id)}/hqdefault.jpg` : '';
+
+  const metaItems = (video = {}) => [
+    ['Автор', video.author],
+    ['Символ', video.symbol],
+    ['Категория', video.category],
+    ['Таймфрейм', video.timeframe],
+    ['Длительность', video.duration],
+    ['Дата публикации', formatDate(video.published_at)],
+  ].filter(([, value]) => value);
+
   const CategoryBadges = (video = {}) => [
     video.category && `<span class="tv-category-badge">${escapeHtml(video.category)}</span>`,
     video.symbol && `<span class="tv-symbol-badge">${escapeHtml(video.symbol)}</span>`,
@@ -40,5 +51,5 @@ window.FXPilotTv = (() => {
     </section>
   `;
 
-  return { escapeHtml, formatDate, PlayerSkeleton, VideoPlayer, CategoryBadges, ReviewSection };
+  return { escapeHtml, formatDate, thumbnailUrl, metaItems, PlayerSkeleton, VideoPlayer, CategoryBadges, ReviewSection };
 })();

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -2,7 +2,7 @@
   const root = document.getElementById('tvReviewPage');
   if (!root || !window.FXPilotTv) return;
 
-  const { escapeHtml, formatDate, VideoPlayer, CategoryBadges, ReviewSection } = window.FXPilotTv;
+  const { escapeHtml, formatDate, metaItems, VideoPlayer, CategoryBadges, ReviewSection } = window.FXPilotTv;
 
   const getVideoId = () => {
     const parts = window.location.pathname.split('/').filter(Boolean);
@@ -66,6 +66,21 @@
     return `<ul class="tv-premium-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
   }
 
+  function placeholder(text) {
+    return `<p>${escapeHtml(text)}</p><p class="tv-coming-soon">Данные будут доступны после будущего AI / Reality Check слоя</p>`;
+  }
+
+  function reviewTimeline(video) {
+    const items = [
+      ['Video Published', formatDate(video.published_at), 'Реальная дата из локального каталога видео.'],
+      ['Author Thesis', 'Placeholder', 'Тезис автора не извлекается: transcript parsing не подключен.'],
+      ['Current FXPilot View', 'Live context / unavailable', 'Показывается только доступный текущий контекст платформы без изменения торговой логики.'],
+      ['Reality Check', 'Coming Soon', 'Факт-чек будет добавлен позже.'],
+      ['Historical Result', 'Coming Soon', 'Исторический результат не рассчитывается на этом этапе.'],
+    ];
+    return `<div class="tv-review-timeline">${items.map(([title, value, text]) => `<div><span>${escapeHtml(title)}</span><strong>${escapeHtml(value)}</strong><p>${escapeHtml(text)}</p></div>`).join('')}</div>`;
+  }
+
   function ReviewPage(payload, marketPayload) {
     const video = payload.video || {};
     const review = payload.review || {};
@@ -82,21 +97,23 @@
             <time id="reviewPublishDate" datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time>
           </div>
           <h2 id="reviewTitle">${escapeHtml(video.title || 'Видеообзор FXPilot TV')}</h2>
-          <p class="tv-author" id="reviewAuthor">Автор: ${escapeHtml(video.author || 'Не указан')} · ${escapeHtml(video.category || 'Категория не указана')}</p>
+          <div class="tv-player-meta-grid tv-review-meta-grid">${metaItems(video).map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`).join('')}</div>
           <p id="reviewDescription">${escapeHtml(video.description || 'Описание будет добавлено позже.')}</p>
           <p class="tv-review-slogan">Не просто сигналы. Понимание рынка. Проверяем торговые идеи фактами.</p>
         </article>
       </section>
       <div class="tv-review-grid" id="reviewSections">
-        ${ReviewSection({ id: 'videoOverview', className: 'tv-review-section--summary', title: 'Видеообзор', content: `<p>${escapeHtml(review.ai_summary)}</p><p class="tv-coming-soon">AI transcript analysis будет подключен позже</p>` })}
-        ${ReviewSection({ id: 'analysisScope', title: 'Что будет анализироваться', content: PremiumList(['Тезисы автора, уровни, invalidation и риск-менеджмент.', 'Совпадение сценариев с текущим контекстом FXPilot.', 'Фактическая проверка прогноза после движения рынка без изменения торговой логики.']) })}
-        ${ReviewSection({ id: 'currentFxpilotView', className: 'tv-review-section--summary', title: 'Текущий взгляд FXPilot', content: marketContextCard(marketIdea, video.symbol) })}
-        ${ReviewSection({ id: 'smartMoney', title: 'Smart Money', content: '<p>Будущий модуль сопоставит заявленные sweep, BOS/CHOCH, imbalance и premium/discount зоны с фактической структурой рынка.</p>' })}
-        ${ReviewSection({ id: 'orderFlow', title: 'OrderFlow', content: '<p>Будет проверяться наличие подтверждения объемом, реакция у уровней, признаки поглощения и доступность OrderFlow-данных.</p>' })}
-        ${ReviewSection({ id: 'options', title: 'Options', content: '<p>Опционный блок будет отмечать контекстные уровни, доступность метрик и ограничения: опционы — это фильтр вероятности, а не самостоятельный сигнал.</p>' })}
-        ${ReviewSection({ id: 'newsMacro', title: 'News / Macro', content: '<p>Макро-блок подготовлен для проверки календарных рисков, долларового режима, ставок, доходностей и чувствительности выбранного инструмента.</p>' })}
-        ${ReviewSection({ id: 'realityCheck', title: 'Reality Check', content: '<p>После подключения факт-чека FXPilot сравнит прогноз с последующим рынком: что подтвердилось, где сценарий был отменен и насколько четко автор обозначил риск.</p>' })}
-        ${ReviewSection({ id: 'trustScore', className: 'tv-review-section--score', title: 'Trust Score', content: `<div class="tv-review-score">${escapeHtml(review.agreement_score ?? 72)}%</div><p>Премиальный placeholder доверия. Оценка демонстрирует будущий формат и не является реальным рейтингом автора.</p>` })}
+        ${ReviewSection({ id: 'aiSummary', className: 'tv-review-section--summary', title: 'AI Summary', content: placeholder(review.ai_summary || 'AI-резюме недоступно: AI implementation не подключен в этом спринте.') })}
+        ${ReviewSection({ id: 'mainThesis', title: 'Main Thesis', content: placeholder('Главный тезис автора будет показан после подключения безопасного анализа transcript.') })}
+        ${ReviewSection({ id: 'currentFxpilotView', className: 'tv-review-section--summary', title: 'Current FXPilot View', content: marketContextCard(marketIdea, video.symbol) })}
+        ${ReviewSection({ id: 'smartMoney', title: 'Smart Money', content: placeholder('SMC-контекст зарезервирован для будущей сверки sweep, BOS/CHOCH, imbalance и зон ликвидности.') })}
+        ${ReviewSection({ id: 'orderFlow', title: 'OrderFlow', content: placeholder('OrderFlow-блок будет показывать только доступные подтверждения и ограничения данных.') })}
+        ${ReviewSection({ id: 'options', title: 'Options', content: placeholder('Опционный блок будет явно отделять proxy metrics от реальных доступных метрик.') })}
+        ${ReviewSection({ id: 'macro', title: 'Macro', content: placeholder('Макро-карта будет учитывать календарные риски, режим доллара, ставки и доходности после подключения данных.') })}
+        ${ReviewSection({ id: 'institutionalNarrative', className: 'tv-review-section--summary', title: 'Institutional Narrative', content: PremiumList(['Видео: тезис автора будет добавлен после AI-слоя.', 'Платформа: текущий FXPilot-контекст показан отдельно и не является анализом видео.', 'Риск: недоступные данные не подменяются сгенерированными значениями.']) })}
+        ${ReviewSection({ id: 'realityCheck', title: 'Reality Check (Coming Soon)', content: placeholder('Факт-чек прогноза после публикации появится на следующем этапе.') })}
+        ${ReviewSection({ id: 'trustScore', className: 'tv-review-section--score', title: 'Trust Score (Coming Soon)', content: `<div class="tv-review-score">—</div><p>Рейтинг доверия не рассчитывается в этом спринте, чтобы не создавать фиктивные оценки автора.</p>` })}
+        ${ReviewSection({ id: 'reviewTimeline', className: 'tv-review-section--summary', title: 'Timeline', content: reviewTimeline(video) })}
       </div>
     `;
   }

--- a/app/static/tv.js
+++ b/app/static/tv.js
@@ -6,12 +6,16 @@
   const sidebarEl = document.querySelector('.tv-sidebar');
   if (!listEl || !playerEl || !detailsEl || !window.FXPilotTv) return;
 
-  const { escapeHtml, formatDate, PlayerSkeleton, VideoPlayer, CategoryBadges } = window.FXPilotTv;
+  const { escapeHtml, formatDate, thumbnailUrl, metaItems, PlayerSkeleton, VideoPlayer, CategoryBadges } = window.FXPilotTv;
   let videos = [];
   let filteredVideos = [];
   let selectedId = null;
   let query = '';
   let category = 'all';
+  const historyKey = 'fxpilot-tv-watch-history-v1';
+  const readHistory = () => { try { return JSON.parse(localStorage.getItem(historyKey) || '{}'); } catch (_) { return {}; } };
+  const saveHistory = (history) => localStorage.setItem(historyKey, JSON.stringify(history));
+  let watchHistory = readHistory();
 
   const todayKey = new Date().toISOString().slice(0, 10);
   const yesterdayDate = new Date();
@@ -19,12 +23,49 @@
   const yesterdayKey = yesterdayDate.toISOString().slice(0, 10);
 
   const byNewest = (a, b) => String(b.published_at || '').localeCompare(String(a.published_at || ''));
-  const groupTitle = (value) => value === todayKey ? 'Сегодня' : value === yesterdayKey ? 'Вчера' : 'Архив';
-  const groupOrder = (value) => value === todayKey ? 0 : value === yesterdayKey ? 1 : 2;
+  const isSameCategory = (video, name) => String(video.category || '').toLowerCase().includes(name.toLowerCase()) || (video.tags || []).some((tag) => String(tag).toLowerCase().includes(name.toLowerCase()));
+  const playlistGroups = [
+    { title: 'Today', match: (video) => video.published_at === todayKey },
+    { title: 'Yesterday', match: (video) => video.published_at === yesterdayKey },
+    { title: 'Forex', match: (video) => isSameCategory(video, 'forex') || /^(EURUSD|GBPUSD|USDJPY|DXY)$/i.test(video.symbol || '') },
+    { title: 'Macro', match: (video) => isSameCategory(video, 'macro') },
+    { title: 'OrderFlow', match: (video) => isSameCategory(video, 'orderflow') || isSameCategory(video, 'order flow') },
+    { title: 'Options', match: (video) => isSameCategory(video, 'options') },
+  ];
+  const getNextVideo = () => { const index = filteredVideos.findIndex((video) => video.id === selectedId); return filteredVideos[index + 1] || filteredVideos[0] || null; };
 
   function renderPlayer(video) {
     playerEl.innerHTML = PlayerSkeleton('Загрузка выбранного обзора...');
     window.setTimeout(() => { playerEl.innerHTML = VideoPlayer(video, { autoplay: true }); }, 180);
+  }
+
+  function renderHeader(video) {
+    if (!video) return '';
+    return `
+      <div class="tv-premium-player-header">
+        <div>
+          <p class="section-kicker">Premium Player</p>
+          <h3>${escapeHtml(video.title || 'Видеообзор FXPilot TV')}</h3>
+          <p>${escapeHtml(video.description || 'Описание недоступно.')}</p>
+        </div>
+        <div class="tv-player-meta-grid">
+          ${metaItems(video).map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`).join('')}
+        </div>
+      </div>
+    `;
+  }
+
+  function renderUpNext() {
+    const next = getNextVideo();
+    if (!next || next.id === selectedId) return '<div class="tv-up-next-card"><p class="section-kicker">Next Video</p><strong>Следующего видео нет</strong><span>Измените фильтр или вернитесь к каталогу.</span></div>';
+    return `
+      <button class="tv-up-next-card" type="button" data-video-id="${escapeHtml(next.id)}">
+        <p class="section-kicker">Next Video</p>
+        ${thumbnailUrl(next) ? `<span class="tv-up-next-thumb" style="background-image:url('${thumbnailUrl(next)}')"></span>` : `<span class="tv-up-next-thumb"></span>`}
+        <strong>${escapeHtml(next.title)}</strong>
+        <span>${escapeHtml(next.category || 'Категория не указана')}</span>
+      </button>
+    `;
   }
 
   function renderDetails(video) {
@@ -32,15 +73,17 @@
       detailsEl.innerHTML = '<p class="section-text">Каталог видео пуст или временно недоступен.</p>';
       return;
     }
+    const progress = watchHistory[video.id]?.progress || 0;
     detailsEl.innerHTML = `
+      ${renderHeader(video)}
       <div class="tv-detail-top">
         <div>${CategoryBadges(video)}</div>
-        <div class="tv-detail-meta"><span class="tv-duration-badge">${escapeHtml(video.duration || '—')}</span><time datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time></div>
+        <div class="tv-detail-meta"><span class="tv-watch-status">${progress >= 100 ? '✓ Watched' : `Просмотрено ${progress}%`}</span><span class="tv-duration-badge">${escapeHtml(video.duration || '—')}</span><time datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time></div>
       </div>
-      <h3>${escapeHtml(video.title)}</h3>
-      <p class="tv-author">Автор: ${escapeHtml(video.author)} · ${escapeHtml(video.symbol || 'Инструмент не указан')} · ${escapeHtml(video.category || 'Категория не указана')}</p>
-      <p>${escapeHtml(video.description)}</p>
+      <div class="tv-watch-progress" aria-label="Прогресс просмотра"><span style="width:${Math.max(0, Math.min(100, progress))}%"></span></div>
+      <p class="tv-author">Автор: ${escapeHtml(video.author)} · ${escapeHtml(video.symbol || 'Инструмент не указан')} · ${escapeHtml(video.category || 'Категория не указана')} · ${escapeHtml(video.timeframe || 'Таймфрейм не указан')}</p>
       <a class="tv-check-button" href="/tv/review/${encodeURIComponent(video.id)}" aria-label="Открыть AI-разбор обзора ${escapeHtml(video.title)}">Проверить обзор</a>
+      ${renderUpNext()}
     `;
   }
 
@@ -78,30 +121,31 @@
       listEl.innerHTML = '<div class="tv-player-empty"><strong>Видео не найдены</strong><span>Измените поиск или категорию. Каталог FXPilot TV будет расширяться без подключения YouTube API.</span></div>';
       return;
     }
-    const groups = filteredVideos.reduce((acc, video) => {
-      const key = groupTitle(video.published_at);
-      acc[key] = acc[key] || [];
-      acc[key].push(video);
-      return acc;
-    }, {});
-    listEl.innerHTML = Object.entries(groups).sort(([a], [b]) => groupOrder(a === 'Сегодня' ? todayKey : a === 'Вчера' ? yesterdayKey : '') - groupOrder(b === 'Сегодня' ? todayKey : b === 'Вчера' ? yesterdayKey : '')).map(([title, items]) => `
-      <section class="tv-video-group" aria-label="${escapeHtml(title)}">
-        <h4>${escapeHtml(title)}</h4>
-        ${items.map((video) => `
+    listEl.innerHTML = playlistGroups.map((group) => {
+      const items = filteredVideos.filter(group.match);
+      if (!items.length) return '';
+      return `
+      <section class="tv-video-group" aria-label="${escapeHtml(group.title)}">
+        <h4>${escapeHtml(group.title)}</h4>
+        ${items.map((video) => {
+          const progress = watchHistory[video.id]?.progress || 0;
+          return `
           <button class="tv-video-item ${video.id === selectedId ? 'is-active' : ''}" type="button" data-video-id="${escapeHtml(video.id)}" aria-pressed="${video.id === selectedId ? 'true' : 'false'}">
             <span class="tv-video-item__meta">${CategoryBadges(video)}<span class="tv-duration-badge">${escapeHtml(video.duration || '—')}</span></span>
             <strong>${escapeHtml(video.title)}</strong>
             <span class="tv-video-item__info"><b>${escapeHtml(video.symbol || '—')}</b><span>${escapeHtml(video.category || 'Без категории')}</span><time datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time></span>
-            <small>${escapeHtml(video.author)} · ${escapeHtml(video.duration || '—')}</small>
-          </button>
-        `).join('')}
-      </section>
-    `).join('');
+            <span class="tv-mini-progress"><i style="width:${Math.max(0, Math.min(100, progress))}%"></i></span>
+            <small>${progress >= 100 ? '✓ Watched' : progress ? `Просмотрено ${progress}%` : `${escapeHtml(video.author)} · не просмотрено`}</small>
+          </button>`;
+        }).join('')}
+      </section>`;
+    }).join('');
   }
 
   function selectVideo(id) {
     const video = videos.find((item) => item.id === id) || filteredVideos[0] || videos[0];
     selectedId = video ? video.id : null;
+    if (video) { watchHistory[video.id] = { progress: Math.max(watchHistory[video.id]?.progress || 0, 35), updatedAt: new Date().toISOString() }; saveHistory(watchHistory); }
     renderPlayer(video);
     renderDetails(video);
     renderList();


### PR DESCRIPTION
### Motivation
- Сделать интерфейс FXPilot TV более премиальным и удобным для пользователя без изменений бэкенда, AI-логики, парсинга транскриптов или вызова YouTube API.

### Description
- Добавлен премиальный заголовок плеера с метаданными (название, автор, символ, категория, таймфрейм, длительность, дата публикации) и универсальной сеткой метаданных через `metaItems` для переиспользования в плеере и на странице review.
- Введена карточка `Up Next` с миниатюрой (хелпер `thumbnailUrl`) и логикой следующего видео, а также хранение прогресса просмотра в `localStorage` под ключом `fxpilot-tv-watch-history-v1` для отображения индикатора/статуса просмотра.
- Переработана боковая плейлист-логика: группировка по секциям `Today`, `Yesterday`, `Forex`, `Macro`, `OrderFlow`, `Options` с подсветкой выбранного видео и мини-прогрессом для каждой записи.
- Обновлена страница review: заменены плейсхолдеры на премиальные карточки (AI Summary, Main Thesis, Current FXPilot View, Smart Money, OrderFlow, Options, Macro, Institutional Narrative, Reality Check, Trust Score) и добавлена визуальная Timeline с честными «Coming Soon»/placeholder-описаниями; добавлены соответствующие стили и улучшения типографики/hover/транзишнов в `styles.css`.

### Testing
- Проверена синтаксическая корректность JS-файлов с помощью `node --check app/static/tv.js && node --check app/static/tv-review.js && node --check app/static/tv-components.js`, тесты прошли успешно. 
- Проверено получение страниц локально с помощью `curl -fsS http://127.0.0.1:8000/tv` и `curl -fsS http://127.0.0.1:8000/tv/review/<video_id>`, запросы вернули валидный HTML и страницы отрисовываются. 
- Созданы полноразмерные скриншоты страниц `/tv` и `/tv/review/<video_id>` с помощью Playwright для ручной визуальной валидации, скриншоты сгенерированы успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bba72aa0c8331a365e7297552dff5)