### PR TITLE
TV Source Manager: управление источниками FXPilot TV

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 
 ## Что обновлено в версии 4.0
+- FXPilot TV Sprint 3: добавлен внутренний Source Manager на `/tv/sources` и API `GET /api/tv/sources`; источники берутся из `data/tv_sources.json`, валидируются сервисом `TvSourceManager`, а кнопки Import now / Disable / Enable пока показывают статус разработки без scraping, YouTube API и реального импорта.
 - FXPilot TV на `/tv` доведён до production-quality video portal: responsive YouTube player со skeleton-загрузкой и autoplay выбранного ролика, duration/publish/category badges, подсветка текущего видео, поиск, фильтр категорий, сортировка newest-first, smooth-scroll sidebar и группировка Today / Yesterday / Archive.
 - Review-навигация закреплена как стабильный UX-контракт: «Проверить обзор» открывает `/tv/review/<video_id>`, а reusable frontend-компоненты `tv-components.js` позволяют будущему `/api/tv/review/<video_id>` наполнять страницу без переработки UI.
 

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from app.services.signal_audit_logger import log_signal_audit
 from app.services.timing import timing_log
 from app.services.ai_runtime_status import get_ai_status, record_ai_request_failure, record_ai_request_start, record_ai_request_success, run_ai_test_request, startup_ai_healthcheck
 from app.services.visitor_counter import get_visit_stats, increment_visit
+from app.services.tv_source_manager import TvSourceConfigError, TvSourceManager
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -132,6 +133,7 @@ from backend.signal_engine import SignalEngine
 
 canonical_market_service = get_canonical_market_service()
 trade_idea_service = TradeIdeaService(signal_engine=SignalEngine())
+tv_source_manager = TvSourceManager(BASE_DIR.parent / "data" / "tv_sources.json", BASE_DIR.parent / "data" / "tv_videos.json")
 
 class _AnalyticsNewsConnector:
     def _descriptor(self, *, status: str = "unavailable", note_ru: str = "") -> dict[str, str]:
@@ -479,6 +481,11 @@ def tv_review_page(video_id: str):
     return FileResponse(STATIC_DIR / "tv-review.html")
 
 
+@app.get("/tv/sources", include_in_schema=False)
+def tv_sources_page():
+    return FileResponse(STATIC_DIR / "tv-sources.html")
+
+
 def _load_tv_video_catalog() -> list[dict[str, Any]]:
     catalog_path = BASE_DIR.parent / "data" / "tv_videos.json"
     try:
@@ -516,6 +523,25 @@ def _build_tv_review_payload(video: dict[str, Any]) -> dict[str, Any]:
 @app.get("/api/tv/videos")
 def api_tv_videos() -> list[dict[str, Any]]:
     return _load_tv_video_catalog()
+
+
+@app.get("/api/tv/sources")
+def api_tv_sources() -> list[dict[str, Any]]:
+    try:
+        return tv_source_manager.list_public_sources()
+    except TvSourceConfigError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/api/tv/sources/stats")
+def api_tv_sources_stats() -> dict[str, Any]:
+    try:
+        return {
+            "stats": tv_source_manager.dashboard_stats(),
+            "import_jobs": tv_source_manager.prepare_import_jobs(),
+        }
+    except TvSourceConfigError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @app.get("/api/tv/review/{video_id}")

--- a/app/services/tv_source_manager.py
+++ b/app/services/tv_source_manager.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_TV_PROVIDERS = {"youtube", "telegram", "rumble", "vimeo", "podcast", "fxpilot_live"}
+
+
+@dataclass(frozen=True)
+class TvSource:
+    id: str
+    name: str
+    provider: str
+    channel_url: str
+    language: str
+    categories: list[str]
+    priority: int
+    enabled: bool
+    last_import: str | None = None
+    videos_count: int = 0
+
+    def public_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "provider": self.provider,
+            "enabled": self.enabled,
+            "priority": self.priority,
+            "categories": self.categories,
+            "last_import": self.last_import,
+            "videos_count": self.videos_count,
+        }
+
+
+@dataclass(frozen=True)
+class TvImportJob:
+    source_id: str
+    provider: str
+    channel_url: str
+    priority: int
+    requested_at: str
+    status: str = "queued"
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "provider": self.provider,
+            "channel_url": self.channel_url,
+            "priority": self.priority,
+            "requested_at": self.requested_at,
+            "status": self.status,
+        }
+
+
+class TvSourceConfigError(ValueError):
+    """Raised when the FXPilot TV source registry is malformed."""
+
+
+class TvSourceManager:
+    """Management layer for configured FXPilot TV sources.
+
+    This service only validates and exposes source configuration. It does not
+    scrape channels, call provider APIs, or import videos in Sprint 3.
+    """
+
+    def __init__(self, sources_path: Path, videos_path: Path | None = None) -> None:
+        self.sources_path = sources_path
+        self.videos_path = videos_path
+
+    def load_sources(self) -> list[TvSource]:
+        try:
+            payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("tv_sources_config_unavailable path=%s error=%s", self.sources_path, exc)
+            return []
+        return self._validate_sources(payload)
+
+    def list_enabled_sources(self) -> list[TvSource]:
+        return [source for source in self.load_sources() if source.enabled]
+
+    def list_public_sources(self) -> list[dict[str, Any]]:
+        return [source.public_payload() for source in sorted(self.load_sources(), key=lambda item: (item.priority, item.name.lower()))]
+
+    def prepare_import_jobs(self) -> list[dict[str, Any]]:
+        requested_at = datetime.now(timezone.utc).isoformat()
+        return [
+            TvImportJob(
+                source_id=source.id,
+                provider=source.provider,
+                channel_url=source.channel_url,
+                priority=source.priority,
+                requested_at=requested_at,
+            ).payload()
+            for source in sorted(self.list_enabled_sources(), key=lambda item: (item.priority, item.name.lower()))
+        ]
+
+    def dashboard_stats(self) -> dict[str, Any]:
+        sources = self.load_sources()
+        videos = self._load_video_catalog()
+        newest_video = max(videos, key=lambda item: str(item.get("published_at") or ""), default=None)
+        return {
+            "sources": len(sources),
+            "videos": len(videos),
+            "last_update": newest_video.get("published_at") if newest_video else None,
+            "newest_video": newest_video.get("title") if newest_video else None,
+        }
+
+    def _validate_sources(self, payload: Any) -> list[TvSource]:
+        if not isinstance(payload, list):
+            raise TvSourceConfigError("tv_sources.json must contain a list")
+        seen_ids: set[str] = set()
+        sources: list[TvSource] = []
+        for index, item in enumerate(payload):
+            if not isinstance(item, dict):
+                raise TvSourceConfigError(f"source #{index} must be an object")
+            source_id = self._required_str(item, "id", index)
+            if source_id in seen_ids:
+                raise TvSourceConfigError(f"duplicate source id: {source_id}")
+            seen_ids.add(source_id)
+            provider = self._required_str(item, "provider", index).lower()
+            if provider not in SUPPORTED_TV_PROVIDERS:
+                raise TvSourceConfigError(f"unsupported provider for {source_id}: {provider}")
+            categories = item.get("categories")
+            if not isinstance(categories, list) or not all(isinstance(value, str) and value.strip() for value in categories):
+                raise TvSourceConfigError(f"source {source_id} categories must be a list of strings")
+            priority = item.get("priority")
+            if not isinstance(priority, int) or priority < 1:
+                raise TvSourceConfigError(f"source {source_id} priority must be a positive integer")
+            enabled = item.get("enabled")
+            if not isinstance(enabled, bool):
+                raise TvSourceConfigError(f"source {source_id} enabled must be boolean")
+            sources.append(TvSource(
+                id=source_id,
+                name=self._required_str(item, "name", index),
+                provider=provider,
+                channel_url=self._required_str(item, "channel_url", index),
+                language=self._required_str(item, "language", index),
+                categories=[value.strip() for value in categories],
+                priority=priority,
+                enabled=enabled,
+            ))
+        return sources
+
+    def _load_video_catalog(self) -> list[dict[str, Any]]:
+        if not self.videos_path:
+            return []
+        try:
+            payload = json.loads(self.videos_path.read_text(encoding="utf-8"))
+        except Exception:
+            return []
+        return [item for item in payload if isinstance(item, dict)] if isinstance(payload, list) else []
+
+    @staticmethod
+    def _required_str(item: dict[str, Any], field: str, index: int) -> str:
+        value = item.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise TvSourceConfigError(f"source #{index} field {field} must be a non-empty string")
+        return value.strip()

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3205,3 +3205,129 @@ body[data-page="tv-review"] {
 @media (max-width: 820px) {
   .tv-up-next-thumb { width: 100%; height: auto; aspect-ratio: 16 / 9; }
 }
+
+body[data-page="tv-sources"] {
+  background: radial-gradient(circle at 15% 10%, rgba(14, 165, 233, 0.16), transparent 30%), #07111f;
+  color: var(--text);
+}
+
+.tv-admin-shell { max-width: 1280px; }
+.tv-admin-hero { margin-bottom: 24px; }
+
+.tv-source-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.tv-source-stats article {
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  border-radius: 20px;
+  padding: 18px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.94), rgba(8, 18, 34, 0.88));
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.25);
+}
+
+.tv-source-stats span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+}
+
+.tv-source-stats strong {
+  display: block;
+  color: #f8fbff;
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tv-source-table-wrap {
+  overflow-x: auto;
+}
+
+.tv-source-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 900px;
+}
+
+.tv-source-table th,
+.tv-source-table td {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 16px 14px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.tv-source-table th {
+  color: #93e7ff;
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.tv-source-table td { color: #e8eef8; }
+.tv-source-table td strong { display: block; margin-bottom: 5px; }
+.tv-source-table td span { color: var(--muted); font-size: 0.88rem; }
+
+.tv-provider-pill,
+.tv-status-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 7px 11px;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  background: rgba(14, 165, 233, 0.08);
+  color: #bae6fd !important;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.tv-status-pill.is-enabled {
+  border-color: rgba(34, 197, 94, 0.38);
+  background: rgba(34, 197, 94, 0.12);
+  color: #bbf7d0 !important;
+}
+
+.tv-status-pill.is-disabled {
+  border-color: rgba(248, 113, 113, 0.38);
+  background: rgba(248, 113, 113, 0.12);
+  color: #fecaca !important;
+}
+
+.tv-source-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tv-source-actions button {
+  border: 1px solid rgba(125, 211, 252, 0.26);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.88);
+  color: #dff8ff;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 9px 12px;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.tv-source-actions button:hover {
+  background: rgba(14, 165, 233, 0.16);
+  border-color: rgba(125, 211, 252, 0.52);
+  transform: translateY(-1px);
+}
+
+@media (max-width: 900px) {
+  .tv-source-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 560px) {
+  .tv-source-stats { grid-template-columns: 1fr; }
+}

--- a/app/static/tv-sources.html
+++ b/app/static/tv-sources.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FXPilot TV · Source Manager</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  </head>
+  <body data-page="tv-sources">
+    <div class="page-shell tv-shell tv-admin-shell">
+      <header class="site-header tv-hero tv-admin-hero">
+        <div class="tv-hero__grid">
+          <div class="tv-hero__copy">
+            <p class="eyebrow">FXPilot TV · Internal Admin</p>
+            <h1>Source Manager</h1>
+            <p class="lead">Управление источниками видео. Импорт, AI Summary, Reality Check и Trust Score пока не выполняются.</p>
+          </div>
+          <div class="tv-hero__signal" aria-label="Статус Source Manager">
+            <span class="tv-live-dot"></span><strong>Management layer online</strong>
+            <p>Конфигурация источников → подготовка import jobs → будущие провайдеры без изменения API</p>
+          </div>
+        </div>
+      </header>
+
+      <main class="content-stack tv-content">
+        <section class="tv-source-stats" aria-label="Статистика FXPilot TV">
+          <article><span>Sources</span><strong id="tvStatSources">—</strong></article>
+          <article><span>Videos</span><strong id="tvStatVideos">—</strong></article>
+          <article><span>Last update</span><strong id="tvStatLastUpdate">—</strong></article>
+          <article><span>Newest video</span><strong id="tvStatNewestVideo">—</strong></article>
+        </section>
+
+        <section class="panel tv-source-panel" aria-labelledby="tvSourcesTitle">
+          <div class="panel-heading compact">
+            <div>
+              <p class="section-kicker">Автоматические источники</p>
+              <h2 id="tvSourcesTitle">TV Source Manager</h2>
+              <p class="section-text">Список загружается из <code>data/tv_sources.json</code>. Кнопки уже зарезервированы под следующий спринт и пока показывают статус разработки.</p>
+            </div>
+          </div>
+          <div class="tv-source-table-wrap">
+            <table class="tv-source-table">
+              <thead>
+                <tr>
+                  <th>Source</th>
+                  <th>Provider</th>
+                  <th>Priority</th>
+                  <th>Status</th>
+                  <th>Last import</th>
+                  <th>Videos</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="tvSourcesBody">
+                <tr><td colspan="7">Загрузка источников...</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </main>
+    </div>
+    <script src="/static/tv-sources.js"></script>
+  </body>
+</html>

--- a/app/static/tv-sources.js
+++ b/app/static/tv-sources.js
@@ -1,0 +1,56 @@
+(function initTvSourcesAdmin() {
+  const bodyEl = document.getElementById('tvSourcesBody');
+  if (!bodyEl) return;
+
+  const escapeHtml = (value) => String(value ?? '').replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char]));
+  const formatValue = (value) => value ? escapeHtml(value) : '—';
+  const setText = (id, value) => { const el = document.getElementById(id); if (el) el.textContent = value || '—'; };
+
+  function showDevelopmentNotice(action, sourceName) {
+    window.alert(`${action}: функция в разработке для источника ${sourceName}.`);
+  }
+
+  function renderStats(stats) {
+    setText('tvStatSources', String(stats.sources ?? 0));
+    setText('tvStatVideos', String(stats.videos ?? 0));
+    setText('tvStatLastUpdate', stats.last_update || '—');
+    setText('tvStatNewestVideo', stats.newest_video || '—');
+  }
+
+  function renderSources(sources) {
+    if (!sources.length) {
+      bodyEl.innerHTML = '<tr><td colspan="7">Источники не настроены.</td></tr>';
+      return;
+    }
+    bodyEl.innerHTML = sources.map((source) => `
+      <tr>
+        <td><strong>${escapeHtml(source.name)}</strong><span>${escapeHtml((source.categories || []).join(' · '))}</span></td>
+        <td><span class="tv-provider-pill">${escapeHtml(source.provider)}</span></td>
+        <td>${escapeHtml(source.priority)}</td>
+        <td><span class="tv-status-pill ${source.enabled ? 'is-enabled' : 'is-disabled'}">${source.enabled ? 'Enabled' : 'Disabled'}</span></td>
+        <td>${formatValue(source.last_import)}</td>
+        <td>${escapeHtml(source.videos_count ?? 0)}</td>
+        <td>
+          <div class="tv-source-actions">
+            <button type="button" data-action="Import now" data-source="${escapeHtml(source.name)}">Import now</button>
+            <button type="button" data-action="Disable" data-source="${escapeHtml(source.name)}">Disable</button>
+            <button type="button" data-action="Enable" data-source="${escapeHtml(source.name)}">Enable</button>
+          </div>
+        </td>
+      </tr>
+    `).join('');
+  }
+
+  bodyEl.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    showDevelopmentNotice(button.dataset.action, button.dataset.source);
+  });
+
+  Promise.all([
+    fetch('/api/tv/sources', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((response) => { if (!response.ok) throw new Error('sources_unavailable'); return response.json(); }),
+    fetch('/api/tv/sources/stats', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((response) => response.ok ? response.json() : { stats: {} }),
+  ])
+    .then(([sources, statsPayload]) => { renderStats(statsPayload.stats || {}); renderSources(Array.isArray(sources) ? sources : []); })
+    .catch(() => { renderStats({}); bodyEl.innerHTML = '<tr><td colspan="7">Source Manager временно недоступен.</td></tr>'; });
+})();

--- a/data/tv_sources.json
+++ b/data/tv_sources.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "gerchik",
+    "name": "Gerchik & Co",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@gerchikco9785",
+    "language": "ru",
+    "categories": [
+      "Forex",
+      "Smart Money"
+    ],
+    "priority": 1,
+    "enabled": true
+  },
+  {
+    "id": "instaforex",
+    "name": "InstaForex",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@instaforex",
+    "language": "ru",
+    "categories": [
+      "Forex",
+      "Macro"
+    ],
+    "priority": 2,
+    "enabled": true
+  },
+  {
+    "id": "traderevo",
+    "name": "TraderEVO",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@traderevo",
+    "language": "ru",
+    "categories": [
+      "Smart Money"
+    ],
+    "priority": 2,
+    "enabled": true
+  },
+  {
+    "id": "prosto_crypto",
+    "name": "PROSTO КРИПТО",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@prosto_kripto",
+    "language": "ru",
+    "categories": [
+      "Crypto"
+    ],
+    "priority": 2,
+    "enabled": true
+  },
+  {
+    "id": "market_vector",
+    "name": "Market Vector",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@market_vector",
+    "language": "ru",
+    "categories": [
+      "Market Analysis"
+    ],
+    "priority": 2,
+    "enabled": true
+  },
+  {
+    "id": "bazylev",
+    "name": "Aleksandr Bazylev",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@AleksandrBazylev",
+    "language": "ru",
+    "categories": [
+      "Forex"
+    ],
+    "priority": 2,
+    "enabled": true
+  }
+]

--- a/tests/test_tv_source_manager.py
+++ b/tests/test_tv_source_manager.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.tv_source_manager import TvSourceManager
+
+
+def test_tv_sources_api_contract():
+    response = TestClient(app).get("/api/tv/sources")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 6
+    assert set(payload[0]) == {"id", "name", "provider", "enabled", "priority", "categories", "last_import", "videos_count"}
+    assert payload[0]["id"] == "gerchik"
+    assert payload[0]["provider"] == "youtube"
+
+
+def test_tv_source_manager_prepares_jobs_without_importing():
+    manager = TvSourceManager(Path("data/tv_sources.json"), Path("data/tv_videos.json"))
+
+    jobs = manager.prepare_import_jobs()
+
+    assert len(jobs) == 6
+    assert jobs[0]["source_id"] == "gerchik"
+    assert jobs[0]["provider"] == "youtube"
+    assert jobs[0]["status"] == "queued"


### PR DESCRIPTION
### Motivation
- Построить базовый слой управления источниками для FXPilot TV, чтобы автоматически регистрировать и валидировать источники перед реализацией импорта и AI-слоёв. 
- Подготовить архитектуру, расширяемую под разные провайдеры (`youtube`, `telegram`, `rumble`, `vimeo`, `podcast`, `fxpilot_live`) без изменения публичного API.

### Description
- Добавлен конфиг с источниками `data/tv_sources.json` с набором первоначальных каналов (id/name/provider/channel_url/language/categories/priority/enabled). 
- Реализован сервис `TvSourceManager` в `app/services/tv_source_manager.py`, который загружает и валидирует конфигурацию, возвращает публичные payload, список включённых источников, подготавливает очередь import jobs и даёт dashboard-статистику; сервис не выполняет scraping или вызовы provider API. 
- Добавлены backend-роуты `GET /api/tv/sources` и `GET /api/tv/sources/stats` и зарегистрирован экземпляр менеджера в `app/main.py`. 
- Добавлена внутренняя админ-страница `GET /tv/sources` с фронтендом `app/static/tv-sources.html` и контроллером `app/static/tv-sources.js`, а также стили в `app/static/styles.css`; кнопки `Import now`/`Disable`/`Enable` показывают сообщение "функция в разработке" и не выполняют импорт. 
- Добавлены тесты `tests/test_tv_source_manager.py` и обновлён `README` с описанием Sprint 3 ограничений (без YouTube API/scraping/реального импорта). 

### Testing
- Запущена компиляция модулей: `python -m py_compile app/main.py app/services/tv_source_manager.py` — успешно. 
- Запущены автотесты: `pytest tests/test_tv_source_manager.py -q` — 2 passed. 
- FastAPI TestClient smoke checks: запросы к `GET /tv/sources`, `GET /api/tv/sources` и `GET /api/tv/sources/stats` вернули `200` с ожидаемыми `content-type` JSON/HTML (smoke проверки прошли).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bce56bf8883318c70807b4665c3a6)