### PR TITLE
Build FXPilot TV AI Review Engine v1

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3331,3 +3331,199 @@ body[data-page="tv-sources"] {
 @media (max-width: 560px) {
   .tv-source-stats { grid-template-columns: 1fr; }
 }
+
+.tv-intel-video {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.82fr) minmax(0, 1.18fr);
+  gap: 20px;
+  align-items: stretch;
+}
+
+.tv-intel-thumb {
+  min-height: 280px;
+  border-radius: 22px;
+  border: 1px solid rgba(76, 201, 240, 0.22);
+  background: radial-gradient(circle at 30% 20%, rgba(76, 201, 240, 0.28), transparent 34%), linear-gradient(135deg, rgba(15, 35, 62, 0.94), rgba(3, 12, 24, 0.94));
+  background-position: center;
+  background-size: cover;
+  box-shadow: inset 0 -90px 120px rgba(3, 12, 24, 0.56), 0 22px 55px rgba(0, 0, 0, 0.24);
+}
+
+.tv-intel-video__body h2 {
+  margin: 16px 0 14px;
+  font-size: clamp(1.5rem, 3vw, 2.35rem);
+}
+
+.tv-premium-placeholder {
+  min-height: 120px;
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(76, 201, 240, 0.2);
+  background: linear-gradient(135deg, rgba(76, 201, 240, 0.1), rgba(139, 92, 246, 0.08), rgba(3, 12, 24, 0.58));
+}
+
+.tv-premium-placeholder strong {
+  color: #eaf6ff;
+  font-size: 1.05rem;
+}
+
+.tv-premium-placeholder p {
+  margin: 0;
+}
+
+.tv-intel-card-grid,
+.tv-coming-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.tv-intel-card {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  gap: 14px;
+  min-height: 172px;
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(3, 12, 24, 0.52);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.tv-intel-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(76, 201, 240, 0.34);
+}
+
+.tv-intel-card__icon {
+  width: 54px;
+  height: 54px;
+  display: grid;
+  place-items: center;
+  border-radius: 18px;
+  color: #06111f;
+  background: linear-gradient(135deg, #9fe7ff, #86efac);
+  font-size: 1.35rem;
+  font-weight: 900;
+}
+
+.tv-intel-card span,
+.tv-confluence-list span,
+.tv-snapshot-grid span {
+  display: block;
+  color: #8da2bd;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tv-intel-card h3 {
+  margin: 5px 0 8px;
+  color: #f1f7ff;
+}
+
+.tv-intel-card p {
+  margin: 0 0 10px;
+}
+
+.tv-intel-card small {
+  color: #9fe7ff;
+  font-weight: 900;
+}
+
+.tv-intel-card.is-conflict { border-color: rgba(248, 113, 113, 0.35); }
+.tv-intel-card.is-neutral { border-color: rgba(245, 158, 11, 0.25); }
+.tv-intel-card.is-agree { border-color: rgba(34, 197, 94, 0.28); }
+
+.tv-snapshot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.tv-snapshot-grid div,
+.tv-confluence-list div {
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(3, 12, 24, 0.54);
+}
+
+.tv-snapshot-grid strong,
+.tv-confluence-list strong {
+  display: block;
+  margin-top: 8px;
+  color: #eaf6ff;
+  overflow-wrap: anywhere;
+}
+
+.tv-confluence-score {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 16px;
+  padding: 18px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(76, 201, 240, 0.12), rgba(34, 197, 94, 0.08));
+  border: 1px solid rgba(76, 201, 240, 0.22);
+}
+
+.tv-confluence-score strong {
+  color: #9fe7ff;
+  font-size: clamp(3rem, 8vw, 5.6rem);
+  line-height: 0.9;
+}
+
+.tv-confluence-score span {
+  color: #eaf6ff;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.tv-confluence-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.tv-confluence-list .is-agree strong { color: #86efac; }
+.tv-confluence-list .is-neutral strong { color: #fef3c7; }
+.tv-confluence-list .is-conflict strong { color: #fecaca; }
+
+.tv-verdict {
+  padding: 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(76, 201, 240, 0.24);
+  background: radial-gradient(circle at top left, rgba(76, 201, 240, 0.18), transparent 36%), rgba(3, 12, 24, 0.62);
+}
+
+.tv-verdict strong {
+  display: block;
+  margin-bottom: 12px;
+  color: #eaf6ff;
+  font-size: clamp(1.3rem, 2.5vw, 2rem);
+}
+
+.tv-verdict p:last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 820px) {
+  .tv-intel-video,
+  .tv-intel-card-grid,
+  .tv-coming-grid,
+  .tv-snapshot-grid,
+  .tv-confluence-list {
+    grid-template-columns: 1fr;
+  }
+
+  .tv-intel-thumb {
+    min-height: auto;
+    aspect-ratio: 16 / 9;
+  }
+}

--- a/app/static/tv-review.html
+++ b/app/static/tv-review.html
@@ -17,12 +17,12 @@
         <div class="tv-hero__grid">
           <div class="tv-hero__copy">
             <p class="eyebrow">FXPilot TV · Review Page</p>
-            <h1>Разбор видеообзора</h1>
-            <p class="lead">Первый рабочий экран review: плеер, метаданные и готовые секции для будущего JSON из API.</p>
+            <h1>AI Review Engine v1</h1>
+            <p class="lead">Интеллектуальный отчёт по видео и текущей аналитике FXPilot: без LLM, transcript parsing и YouTube API.</p>
           </div>
           <div class="tv-hero__signal" aria-label="Статус review">
-            <span class="tv-live-dot"></span><strong>Review UI ready</strong>
-            <p>/api/tv/review/&lt;video_id&gt; → ReviewPage component → будущая AI-логика</p>
+            <span class="tv-live-dot"></span><strong>Market intelligence ready</strong>
+            <p>/api/tv/review/&lt;video_id&gt; + /api/ideas/market → reusable intelligence modules</p>
           </div>
         </div>
       </header>

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -2,7 +2,7 @@
   const root = document.getElementById('tvReviewPage');
   if (!root || !window.FXPilotTv) return;
 
-  const { escapeHtml, formatDate, metaItems, VideoPlayer, CategoryBadges, ReviewSection } = window.FXPilotTv;
+  const { escapeHtml, formatDate, thumbnailUrl, CategoryBadges, ReviewSection } = window.FXPilotTv;
 
   const getVideoId = () => {
     const parts = window.location.pathname.split('/').filter(Boolean);
@@ -12,7 +12,17 @@
   const asArray = (value) => Array.isArray(value) ? value : [];
   const firstDefined = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
   const normalizeSymbol = (value) => String(value || '').replace(/[^A-Z0-9]/gi, '').toUpperCase();
+  const normalizeText = (value) => String(value || '').trim();
   const formatValue = (value) => firstDefined(value, '—');
+  const toNumber = (value) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+  const percent = (value) => {
+    const number = toNumber(value);
+    if (number === null) return '—';
+    return `${Math.max(0, Math.min(100, Math.round(number)))}%`;
+  };
 
   function flattenIdeas(payload) {
     if (!payload || typeof payload !== 'object') return [];
@@ -26,96 +36,142 @@
     return flattenIdeas(payload).find((idea) => normalizeSymbol(firstDefined(idea.symbol, idea.pair, idea.instrument, idea.ticker)) === wanted) || null;
   }
 
-  function marketContextCard(idea, symbol) {
-    if (!idea) {
-      return `<p class="tv-context-empty">Текущий контекст FXPilot по инструменту ${escapeHtml(symbol || '—')} пока недоступен.</p>`;
-    }
+  function directionOf(idea) {
+    const raw = normalizeText(firstDefined(idea?.action, idea?.direction, idea?.signal, idea?.final_signal, idea?.recommendation, idea?.bias, 'WAIT'));
+    const upper = raw.toUpperCase();
+    if (['BUY', 'ПОКУПКА', 'LONG', 'BULLISH', 'БЫЧИЙ'].includes(upper)) return 'BUY';
+    if (['SELL', 'ПРОДАЖА', 'SHORT', 'BEARISH', 'МЕДВЕЖИЙ'].includes(upper)) return 'SELL';
+    return upper || 'WAIT';
+  }
 
-    const action = firstDefined(idea.action, idea.direction, idea.signal, idea.recommendation, idea.bias, 'WAIT');
-    const confidence = firstDefined(idea.confidence, idea.score, idea.confidence_score, idea.prop_score, idea.total_score);
-    const grade = firstDefined(idea.grade, idea.rating, idea.quality_grade);
-    const entry = firstDefined(idea.entry, idea.entry_price, idea.entryPrice, idea.levels?.entry);
-    const sl = firstDefined(idea.sl, idea.stop_loss, idea.stopLoss, idea.levels?.sl, idea.levels?.stop_loss);
-    const tp = firstDefined(idea.tp, idea.take_profit, idea.takeProfit, idea.levels?.tp, idea.levels?.take_profit);
-    const rows = [
-      ['Действие / направление', action],
-      ['Confidence / score', confidence],
-      ['Grade', grade],
-      ['Entry / SL / TP', [entry, sl, tp].map(formatValue).join(' / ')],
-      ['Источник данных', firstDefined(idea.data_source_label, idea.source_label, idea.market_data?.data_source_label)],
-      ['Качество данных', firstDefined(idea.data_source_quality, idea.source_quality, idea.market_data?.data_source_quality)],
-      ['OrderFlow доступен', firstDefined(idea.orderflow_available, idea.order_flow_available, idea.orderflow?.available)],
-      ['Market structure', firstDefined(idea.market_structure, idea.structure, idea.smc?.market_structure)],
-      ['Trend regime', firstDefined(idea.trend_regime, idea.regime, idea.market_regime)],
-      ['News risk', firstDefined(idea.news_risk, idea.newsRisk, idea.news?.risk)],
-      ['Options доступны', firstDefined(idea.options_available, idea.options?.available)],
+  function marketModel(idea, symbol) {
+    const entry = firstDefined(idea?.entry, idea?.entry_price, idea?.entryPrice, idea?.levels?.entry, idea?.setup?.entry);
+    const sl = firstDefined(idea?.sl, idea?.stop_loss, idea?.stopLoss, idea?.levels?.sl, idea?.levels?.stop_loss);
+    const tp = firstDefined(idea?.tp, idea?.take_profit, idea?.takeProfit, idea?.levels?.tp, idea?.levels?.take_profit);
+    const confidence = firstDefined(idea?.confidence, idea?.score, idea?.confidence_score, idea?.prop_score, idea?.total_score, idea?.confluence);
+    return {
+      symbol: firstDefined(idea?.symbol, idea?.pair, idea?.instrument, symbol, '—'),
+      price: firstDefined(idea?.current_price, idea?.price, idea?.market_price, idea?.market_data?.price, idea?.snapshot?.price),
+      direction: idea ? directionOf(idea) : 'WAIT',
+      entry,
+      sl,
+      tp,
+      confidence,
+      grade: firstDefined(idea?.grade, idea?.rating, idea?.quality_grade, idea?.prop_grade),
+      mode: firstDefined(idea?.mode, idea?.signal_mode, idea?.data_mode, idea?.market_data?.mode, idea?.data_source_label),
+      updatedAt: firstDefined(idea?.updated_at, idea?.timestamp, idea?.created_at, idea?.market_data?.updated_at),
+      trend: firstDefined(idea?.trend, idea?.trend_regime, idea?.regime, idea?.market_regime, idea?.market_context?.trend),
+      structure: firstDefined(idea?.market_structure, idea?.structure, idea?.smc?.market_structure, idea?.market_context?.structure),
+      newsRisk: firstDefined(idea?.news_risk, idea?.newsRisk, idea?.news?.risk, idea?.news_context?.risk),
+      orderflowAvailable: firstDefined(idea?.orderflow_available, idea?.order_flow_available, idea?.orderflow?.available),
+      orderflowBias: firstDefined(idea?.orderflow_bias, idea?.orderFlowBias, idea?.orderflow?.bias),
+      optionsAvailable: firstDefined(idea?.options_available, idea?.optionsAvailable, idea?.options?.available),
+      optionsBias: firstDefined(idea?.options_bias, idea?.optionsBias, idea?.external_options_bias, idea?.options?.bias),
+      institutional: firstDefined(idea?.institutional_narrative, idea?.narrative, idea?.market_context?.institutional_narrative),
+      sourceQuality: firstDefined(idea?.data_source_quality, idea?.source_quality, idea?.market_data?.data_source_quality),
+    };
+  }
+
+  function statusFrom(value, direction) {
+    const text = normalizeText(value).toUpperCase();
+    if (!text) return 'neutral';
+    if (direction && text.includes(direction)) return 'agree';
+    if (['BUY', 'SELL'].includes(text) && text !== direction) return 'conflict';
+    if (text.includes('BEAR') && direction === 'BUY') return 'conflict';
+    if (text.includes('BULL') && direction === 'SELL') return 'conflict';
+    if (text.includes('RISK') || text.includes('CONFLICT')) return 'conflict';
+    if (text.includes('NEUTRAL') || text.includes('WAIT') || text.includes('ОЖИД')) return 'neutral';
+    return 'agree';
+  }
+
+  function intelligenceCards(model) {
+    const direction = model.direction;
+    return [
+      { icon: '◇', title: 'Smart Money', status: statusFrom(model.structure, direction), summary: model.structure ? `Структура рынка: ${model.structure}` : 'SMC-контекст не найден в текущем payload FXPilot.', confidence: model.confidence },
+      { icon: '⇄', title: 'OrderFlow', status: model.orderflowAvailable ? statusFrom(model.orderflowBias || direction, direction) : 'neutral', summary: model.orderflowAvailable ? `OrderFlow bias: ${formatValue(model.orderflowBias || direction)}` : 'OrderFlow недоступен или отключён; подтверждение не подменяется proxy-значением.', confidence: model.orderflowAvailable ? model.confidence : null },
+      { icon: '🏛', title: 'Institutional Narrative', status: statusFrom(model.institutional || direction, direction), summary: model.institutional || `Институциональный сценарий следует текущему направлению FXPilot: ${direction}.`, confidence: model.confidence },
+      { icon: '⌁', title: 'Options', status: model.optionsAvailable ? statusFrom(model.optionsBias, direction) : 'neutral', summary: model.optionsAvailable ? `Options bias: ${formatValue(model.optionsBias)}. Метрики помечены как доступные из текущего FXPilot.` : 'Опционные данные недоступны; proxy metrics не используются.', confidence: model.optionsAvailable ? model.confidence : null },
+      { icon: '📰', title: 'News', status: statusFrom(model.newsRisk, direction), summary: model.newsRisk ? `Новостной риск: ${model.newsRisk}` : 'Новостной фон не содержит явного конфликта в текущем payload.', confidence: model.confidence },
+      { icon: '▣', title: 'Market Structure', status: statusFrom(model.structure, direction), summary: model.structure ? `Текущая структура: ${model.structure}` : 'Структурный слой пока не вернул детализированное состояние.', confidence: model.confidence },
+      { icon: '↗', title: 'Trend', status: statusFrom(model.trend || direction, direction), summary: model.trend ? `Трендовый режим: ${model.trend}` : `Тренд читается через направление текущего сигнала: ${direction}.`, confidence: model.confidence },
+      { icon: '⚖', title: 'Risk / Reward', status: model.entry && model.sl && model.tp ? 'agree' : 'neutral', summary: model.entry && model.sl && model.tp ? `План уровней: вход ${model.entry}, SL ${model.sl}, TP ${model.tp}.` : 'Полный набор Entry / SL / TP не найден, оценка R/R нейтральная.', confidence: model.confidence },
     ];
+  }
 
-    return `
-      <div class="tv-market-context-card">
-        <div class="tv-context-head"><span>${escapeHtml(firstDefined(idea.symbol, symbol))}</span><strong>${escapeHtml(action)}</strong></div>
-        <div class="tv-context-grid">
-          ${rows.map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(formatValue(value))}</strong></div>`).join('')}
+  const statusLabel = (status) => ({ agree: 'Agree', neutral: 'Neutral', conflict: 'Conflict' }[status] || 'Neutral');
+
+  function renderVideoSection(video) {
+    const thumb = thumbnailUrl(video);
+    return ReviewSection({ id: 'videoIntel', className: 'tv-review-section--summary', title: 'Видео', content: `
+      <div class="tv-intel-video">
+        <div class="tv-intel-thumb" style="${thumb ? `background-image:url('${escapeHtml(thumb)}')` : ''}" aria-label="Thumbnail"></div>
+        <div class="tv-intel-video__body">
+          <div class="tv-detail-top"><div>${CategoryBadges(video)}<span class="tv-duration-badge">${escapeHtml(formatValue(video.duration))}</span></div><time datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time></div>
+          <h2>${escapeHtml(video.title || 'Видеообзор FXPilot TV')}</h2>
+          <div class="tv-player-meta-grid tv-review-meta-grid">
+            ${[['Автор', video.author], ['Дата публикации', formatDate(video.published_at)], ['Длительность', video.duration], ['Категория', video.category], ['Символ', video.symbol], ['Таймфрейм', video.timeframe]].map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(formatValue(value))}</strong></div>`).join('')}
+          </div>
         </div>
-        <p class="tv-context-note">Контекст загружен из /api/ideas/market. Это не анализ видео и не новый торговый сигнал.</p>
-      </div>
-    `;
+      </div>` });
   }
 
-  function PremiumList(items) {
-    return `<ul class="tv-premium-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
+  function renderAuthorThesis() {
+    return ReviewSection({ id: 'authorThesis', className: 'tv-review-section--summary tv-author-thesis', title: 'Тезис автора', content: '<div class="tv-premium-placeholder"><strong>No transcript available.</strong><p>AI Summary will appear after transcript analysis.</p></div>' });
   }
 
-  function placeholder(text) {
-    return `<p>${escapeHtml(text)}</p><p class="tv-coming-soon">Данные будут доступны после будущего AI / Reality Check слоя</p>`;
+  function renderFxPilotAnalysis(cards) {
+    return ReviewSection({ id: 'fxpilotAnalysis', className: 'tv-review-section--summary', title: 'FXPilot Analysis', content: `<div class="tv-intel-card-grid">${cards.map((card) => `<article class="tv-intel-card is-${escapeHtml(card.status)}"><div class="tv-intel-card__icon">${escapeHtml(card.icon)}</div><div><span>${escapeHtml(statusLabel(card.status))}</span><h3>${escapeHtml(card.title)}</h3><p>${escapeHtml(card.summary)}</p><small>Confidence: ${escapeHtml(percent(card.confidence))}</small></div></article>`).join('')}</div>` });
   }
 
-  function reviewTimeline(video) {
+  function renderSnapshot(model) {
+    const rows = [['Current price', model.price], ['Direction', model.direction], ['Entry', model.entry], ['SL', model.sl], ['TP', model.tp], ['Confidence', percent(model.confidence)], ['Grade', model.grade], ['Mode', model.mode], ['Update time', model.updatedAt]];
+    return ReviewSection({ id: 'marketSnapshot', className: 'tv-review-section--summary', title: 'Market Snapshot', content: `<div class="tv-snapshot-grid">${rows.map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(formatValue(value))}</strong></div>`).join('')}</div><p class="tv-context-note">Снимок построен из /api/ideas/market и не является анализом transcript.</p>` });
+  }
+
+  function confluence(model) {
+    const direction = model.direction;
     const items = [
-      ['Video Published', formatDate(video.published_at), 'Реальная дата из локального каталога видео.'],
-      ['Author Thesis', 'Placeholder', 'Тезис автора не извлекается: transcript parsing не подключен.'],
-      ['Current FXPilot View', 'Live context / unavailable', 'Показывается только доступный текущий контекст платформы без изменения торговой логики.'],
-      ['Reality Check', 'Coming Soon', 'Факт-чек будет добавлен позже.'],
-      ['Historical Result', 'Coming Soon', 'Исторический результат не рассчитывается на этом этапе.'],
+      ['Direction', ['BUY', 'SELL'].includes(direction) ? 'agree' : 'neutral'],
+      ['Entry zone', model.entry ? 'agree' : 'neutral'],
+      ['Trend', statusFrom(model.trend || direction, direction)],
+      ['Structure', statusFrom(model.structure, direction)],
+      ['News', statusFrom(model.newsRisk, direction)],
+      ['OrderFlow', model.orderflowAvailable ? statusFrom(model.orderflowBias || direction, direction) : 'neutral'],
     ];
-    return `<div class="tv-review-timeline">${items.map(([title, value, text]) => `<div><span>${escapeHtml(title)}</span><strong>${escapeHtml(value)}</strong><p>${escapeHtml(text)}</p></div>`).join('')}</div>`;
+    const score = Math.round(items.reduce((sum, [, status]) => sum + (status === 'agree' ? 100 : status === 'neutral' ? 50 : 0), 0) / items.length);
+    return { items, score };
+  }
+
+  function renderConfluence(result) {
+    return ReviewSection({ id: 'confluence', className: 'tv-review-section--summary', title: 'Confluence', content: `<div class="tv-confluence-score"><strong>${result.score}</strong><span>Agreement Score</span></div><div class="tv-confluence-list">${result.items.map(([label, status]) => `<div class="is-${escapeHtml(status)}"><span>${escapeHtml(label)}</span><strong>${escapeHtml(statusLabel(status))}</strong></div>`).join('')}</div>` });
+  }
+
+  function renderVerdict(model, confluenceResult) {
+    const directionText = model.direction === 'BUY' ? 'BUY' : model.direction === 'SELL' ? 'SELL' : 'WAIT';
+    const orderflow = confluenceResult.items.find(([label]) => label === 'OrderFlow')?.[1];
+    const news = confluenceResult.items.find(([label]) => label === 'News')?.[1];
+    const tone = confluenceResult.score >= 70 ? 'поддерживает текущий сценарий' : confluenceResult.score >= 45 ? 'даёт смешанную картину' : 'конфликтует с текущим сценарием';
+    const lines = [
+      `FXPilot сейчас ${tone} по ${model.symbol}: направление ${directionText}.`,
+      `OrderFlow: ${statusLabel(orderflow)}.`,
+      `News: ${statusLabel(news)}.`,
+      model.institutional ? `Institutional Narrative: ${model.institutional}.` : `Institutional Narrative поддерживает ${directionText}, если текущий сигнал не WAIT.`,
+    ];
+    return ReviewSection({ id: 'preliminaryVerdict', className: 'tv-review-section--summary tv-verdict-section', title: 'Preliminary Verdict', content: `<div class="tv-verdict"><strong>${confluenceResult.score >= 70 ? 'Scenario Supported' : confluenceResult.score >= 45 ? 'Needs Confirmation' : 'Scenario Conflict'}</strong>${lines.map((line) => `<p>${escapeHtml(line)}</p>`).join('')}</div>` });
+  }
+
+  function renderComingSoon() {
+    const modules = ['Reality Check', 'Trust Score', 'AI Summary', 'Transcript', 'Historical Similarity'];
+    return ReviewSection({ id: 'comingSoon', className: 'tv-review-section--summary', title: 'Coming Soon', content: `<div class="tv-coming-grid">${modules.map((item) => `<div class="tv-premium-placeholder"><strong>${escapeHtml(item)}</strong><p>Будущий AI-модуль подключится к этому reusable блоку без редизайна страницы.</p></div>`).join('')}</div>` });
   }
 
   function ReviewPage(payload, marketPayload) {
     const video = payload.video || {};
-    const review = payload.review || {};
     const marketIdea = findMarketContext(marketPayload, video.symbol);
-    const player = VideoPlayer(video, { autoplay: false, titleFallback: 'FXPilot TV Review' });
-
-    return `
-      <section class="panel tv-review-watch" id="tvReviewWatch" data-video-id="${escapeHtml(video.id)}">
-        <a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a>
-        <div class="tv-player-frame tv-review-player" id="reviewPlayer">${player}</div>
-        <article class="tv-selected-card tv-review-meta" id="reviewVideoMeta">
-          <div class="tv-detail-top">
-            <div id="reviewBadges">${CategoryBadges(video)}<span class="tv-duration-badge" id="reviewDuration">${escapeHtml(video.duration || '—')}</span></div>
-            <time id="reviewPublishDate" datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time>
-          </div>
-          <h2 id="reviewTitle">${escapeHtml(video.title || 'Видеообзор FXPilot TV')}</h2>
-          <div class="tv-player-meta-grid tv-review-meta-grid">${metaItems(video).map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`).join('')}</div>
-          <p id="reviewDescription">${escapeHtml(video.description || 'Описание будет добавлено позже.')}</p>
-          <p class="tv-review-slogan">Не просто сигналы. Понимание рынка. Проверяем торговые идеи фактами.</p>
-        </article>
-      </section>
-      <div class="tv-review-grid" id="reviewSections">
-        ${ReviewSection({ id: 'aiSummary', className: 'tv-review-section--summary', title: 'AI Summary', content: placeholder(review.ai_summary || 'AI-резюме недоступно: AI implementation не подключен в этом спринте.') })}
-        ${ReviewSection({ id: 'mainThesis', title: 'Main Thesis', content: placeholder('Главный тезис автора будет показан после подключения безопасного анализа transcript.') })}
-        ${ReviewSection({ id: 'currentFxpilotView', className: 'tv-review-section--summary', title: 'Current FXPilot View', content: marketContextCard(marketIdea, video.symbol) })}
-        ${ReviewSection({ id: 'smartMoney', title: 'Smart Money', content: placeholder('SMC-контекст зарезервирован для будущей сверки sweep, BOS/CHOCH, imbalance и зон ликвидности.') })}
-        ${ReviewSection({ id: 'orderFlow', title: 'OrderFlow', content: placeholder('OrderFlow-блок будет показывать только доступные подтверждения и ограничения данных.') })}
-        ${ReviewSection({ id: 'options', title: 'Options', content: placeholder('Опционный блок будет явно отделять proxy metrics от реальных доступных метрик.') })}
-        ${ReviewSection({ id: 'macro', title: 'Macro', content: placeholder('Макро-карта будет учитывать календарные риски, режим доллара, ставки и доходности после подключения данных.') })}
-        ${ReviewSection({ id: 'institutionalNarrative', className: 'tv-review-section--summary', title: 'Institutional Narrative', content: PremiumList(['Видео: тезис автора будет добавлен после AI-слоя.', 'Платформа: текущий FXPilot-контекст показан отдельно и не является анализом видео.', 'Риск: недоступные данные не подменяются сгенерированными значениями.']) })}
-        ${ReviewSection({ id: 'realityCheck', title: 'Reality Check (Coming Soon)', content: placeholder('Факт-чек прогноза после публикации появится на следующем этапе.') })}
-        ${ReviewSection({ id: 'trustScore', className: 'tv-review-section--score', title: 'Trust Score (Coming Soon)', content: `<div class="tv-review-score">—</div><p>Рейтинг доверия не рассчитывается в этом спринте, чтобы не создавать фиктивные оценки автора.</p>` })}
-        ${ReviewSection({ id: 'reviewTimeline', className: 'tv-review-section--summary', title: 'Timeline', content: reviewTimeline(video) })}
-      </div>
-    `;
+    const model = marketModel(marketIdea, video.symbol);
+    const cards = intelligenceCards(model);
+    const confluenceResult = confluence(model);
+    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">AI Review Engine v1: текущая разведка FXPilot без LLM, transcript parsing и YouTube API.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoSection(video)}${renderAuthorThesis()}${renderFxPilotAnalysis(cards)}${renderSnapshot(model)}${renderConfluence(confluenceResult)}${renderVerdict(model, confluenceResult)}${renderComingSoon()}</div>`;
   }
 
   async function loadReview() {


### PR DESCRIPTION
### Motivation
- Turn the existing Review page into an intelligence report that combines video metadata and the current FXPilot market view from `/api/ideas/market` without LLMs or transcript parsing. 
- Make every block reusable so future AI modules can simply replace the data source without layout changes. 
- Preserve the premium FXPilot TV style and responsive layout while clearly separating platform signals from any future AI-generated narrative.

### Description
- Reworked review UI: updated `app/static/tv-review.html` hero copy to `AI Review Engine v1` and clarified data sources (`/api/tv/review/<video_id>` + `/api/ideas/market`).
- Implemented a modular intelligence page in `app/static/tv-review.js` with reusable sections: Video metadata, Author Thesis placeholder, FXPilot Analysis cards, Market Snapshot, Confluence scoring, Preliminary Verdict and Coming Soon placeholders; all sections consume the market payload when available.
- Added a small market model and helpers that normalize FXPilot idea fields, derive `direction`, `entry/SL/TP`, `confidence`, `trend`, `structure`, `orderflow` and `options`, and build intelligence cards and confluence score (0–100).
- Added new UI styles in `app/static/styles.css` for the intelligence layout (thumbnail, intel cards, confluence score, snapshot grid, premium placeholders) following the existing dark FXPilot TV theme and responsive rules.

### Testing
- Ran `node --check app/static/tv-review.js` which succeeded. 
- Ran `python3 -m py_compile app/main.py` which succeeded. 
- Fetched the review payload via `curl` against the running app and verified the review route returned `200` and JSON payload. 
- Ran `pytest` for `tests/api/test_ideas_api.py`; two tests passed and one existing unrelated test failed (`test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback` expects `narrative_source == 'model'` but received `'fallback'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bdc36d7948331be1717195d46e022)