### PR TITLE
Фикс YouTube RSS импорта: диагностика и сохранение метаданных источников

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 
+## Что обновлено в версии 4.2
+- FXPilot Media Import Engine теперь строит YouTube RSS только из поддерживаемых публичных RSS-идентификаторов: `channel_id`, `/channel/UC...` и legacy `/user/...`; для `@handle` и `/c/...` без `channel_id` возвращается явная диагностика без HTML scraping и без YouTube Data API.
+- `POST /api/media/import` возвращает детальный контракт `processed/imported/updated/failed/errors`, продолжает импорт остальных источников при ошибке одного источника и сохраняет `channel_id`, `rss_url`, `last_import`, `last_success`, `last_error`, `videos_count` в `data/media_sources.json`.
+- Добавлен `GET /api/media/debug` для проверки provider, RSS URL, channel id, HTTP-статуса запроса, количества найденных видео и последней ошибки источника.
 
 ## Что обновлено в версии 4.1
 - FXPilot TV Sprint 3 Automatic Media Import Engine: добавлены `data/media_sources.json`, `data/media_catalog.json`, нормализованная модель `MediaItem` и модульный `MediaImportEngine` для provider-independent импорта YouTube RSS / будущих Telegram, RSS, Podcast, Vimeo, FXPilot, News и Articles без изменения API.

--- a/app/main.py
+++ b/app/main.py
@@ -545,6 +545,14 @@ def api_media_import() -> dict[str, Any]:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+@app.get("/api/media/debug")
+def api_media_debug() -> list[dict[str, Any]]:
+    try:
+        return media_import_engine.debug_sources()
+    except MediaConfigError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
 @app.get("/api/media/scheduler")
 def api_media_scheduler() -> dict[str, Any]:
     return media_import_engine.scheduler.next_job_payload()

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
+from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qs, urlparse
+from urllib.request import Request, urlopen
 
 import feedparser
 
@@ -15,9 +17,15 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_MEDIA_PROVIDERS = {"youtube", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
 SYMBOLS = ("EURUSD", "GBPUSD", "USDJPY", "USDCHF", "USDCAD", "AUDUSD", "NZDUSD", "XAUUSD", "XAGUSD", "BTCUSD", "ETHUSD", "DXY", "US500", "NASDAQ", "GER40", "UK100")
+YOUTUBE_RSS_BY_CHANNEL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
+YOUTUBE_RSS_BY_USER = "https://www.youtube.com/feeds/videos.xml?user={user}"
 
 
 class MediaConfigError(ValueError):
+    pass
+
+
+class MediaImportError(RuntimeError):
     pass
 
 
@@ -33,183 +41,202 @@ class MediaSource:
     enabled: bool
     feed_url: str | None = None
     channel_id: str | None = None
+    rss_url: str | None = None
+    last_error: str | None = None
+    last_import: str | None = None
+    last_success: str | None = None
+    videos_count: int = 0
 
     def public_payload(self, catalog: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         videos = [item for item in (catalog or []) if item.get("source_id") == self.id]
-        newest = max(videos, key=lambda item: str(item.get("published_at") or ""), default={})
+        latest_import = self.last_import or max((str(item.get("imported_at") or "") for item in videos), default="") or None
+        status = "disabled" if not self.enabled else ("error" if self.last_error else "ok")
         return {
             "id": self.id,
             "name": self.name,
             "provider": self.provider,
             "channel_url": self.channel_url,
+            "channel_id": self.channel_id,
+            "rss_url": self.rss_url or self.feed_url,
             "language": self.language,
             "priority": self.priority,
             "categories": self.categories,
             "enabled": self.enabled,
-            "last_import": newest.get("imported_at"),
-            "videos_count": len(videos),
+            "videos_count": len(videos) if catalog is not None else self.videos_count,
+            "last_import": latest_import,
+            "last_success": self.last_success,
+            "status": status,
+            "last_error": self.last_error,
         }
 
 
 @dataclass
 class MediaItem:
-    id: str
-    provider: str
-    source_id: str
-    title: str
-    author: str
-    youtube_id: str | None
-    url: str
-    thumbnail: str | None
-    published_at: str | None
-    duration: str | None
-    category: str
-    symbol: str
-    language: str
-    description: str
+    id: str; provider: str; source_id: str; title: str; author: str; youtube_id: str | None; url: str; thumbnail: str | None; published_at: str | None; duration: str | None; category: str; symbol: str; language: str; description: str
     tags: list[str] = field(default_factory=list)
     status: str = "imported"
     imported_at: str | None = None
+    def payload(self) -> dict[str, Any]: return asdict(self)
 
-    def payload(self) -> dict[str, Any]:
-        return asdict(self)
+
+@dataclass
+class FetchResult:
+    ok: bool
+    url: str | None
+    request_status: str
+    response_status: int | None = None
+    content: bytes = b""
+    error: str | None = None
+
+
+@dataclass
+class ImportSourceResult:
+    source: MediaSource
+    items: list[MediaItem]
+    request_status: str
+    response_status: int | None
+    videos_found: int
+    error: str | None = None
 
 
 class MediaProvider(Protocol):
     provider_name: str
-    def fetch_latest(self, source: MediaSource) -> list[MediaItem]: ...
+    def fetch_latest(self, source: MediaSource) -> ImportSourceResult: ...
 
 
 class YouTubeRssProvider:
     provider_name = "youtube-rss"
+    def __init__(self, fetcher: Callable[[str], FetchResult] | None = None) -> None:
+        self.fetcher = fetcher or self._default_fetcher
 
-    def fetch_latest(self, source: MediaSource) -> list[MediaItem]:
-        feed_url = source.feed_url or self._build_feed_url(source)
-        if not feed_url:
-            logger.info("media_youtube_rss_unresolved source_id=%s", source.id)
-            return []
-        parsed = feedparser.parse(feed_url)
-        if getattr(parsed, "bozo", False):
-            logger.warning("media_youtube_rss_parse_failed source_id=%s error=%s", source.id, getattr(parsed, "bozo_exception", None))
-        items: list[MediaItem] = []
-        for entry in getattr(parsed, "entries", [])[:20]:
-            youtube_id = self._entry_video_id(entry)
-            if not youtube_id:
-                continue
-            title = str(entry.get("title") or "Без названия").strip()
-            description = str(entry.get("summary") or entry.get("description") or "").strip()
-            published_at = self._published_date(entry)
-            items.append(MediaItem(
-                id=f"youtube:{youtube_id}", provider=self.provider_name, source_id=source.id,
-                title=title, author=str(entry.get("author") or source.name), youtube_id=youtube_id,
-                url=str(entry.get("link") or f"https://www.youtube.com/watch?v={youtube_id}"),
-                thumbnail=self._thumbnail(entry), published_at=published_at, duration=None,
-                category=source.categories[0] if source.categories else "Market Analysis",
-                symbol=detect_symbol(f"{title} {description}"), language=source.language,
-                description=description, tags=[*source.categories, detect_symbol(f"{title} {description}")],
-                imported_at=datetime.now(timezone.utc).isoformat(),
-            ))
-        return items
+    def fetch_latest(self, source: MediaSource) -> ImportSourceResult:
+        resolved = self.resolve_rss(source)
+        if resolved.get("error"):
+            raise MediaImportError(str(resolved["error"]))
+        rss_url = str(resolved["rss_url"])
+        fetched = self.fetcher(rss_url)
+        if not fetched.ok:
+            raise MediaImportError(f"RSS request failed: {fetched.error or fetched.request_status}")
+        parsed = feedparser.parse(fetched.content)
+        if getattr(parsed, "bozo", False) and not getattr(parsed, "entries", []):
+            raise MediaImportError(f"RSS parse failed: {getattr(parsed, 'bozo_exception', 'unknown parse error')}")
+        items = [self._entry_to_item(entry, source) for entry in getattr(parsed, "entries", [])[:20]]
+        items = [item for item in items if item is not None]
+        return ImportSourceResult(replace(source, channel_id=resolved.get("channel_id") or source.channel_id, rss_url=rss_url), items, fetched.request_status, fetched.response_status, len(items))
 
-    def _build_feed_url(self, source: MediaSource) -> str | None:
-        if source.channel_id:
-            return f"https://www.youtube.com/feeds/videos.xml?channel_id={source.channel_id}"
+    def resolve_rss(self, source: MediaSource) -> dict[str, Any]:
+        if source.rss_url or source.feed_url:
+            return {"rss_url": source.rss_url or source.feed_url, "channel_id": source.channel_id, "provider": self.provider_name}
         parsed = urlparse(source.channel_url)
         qs = parse_qs(parsed.query)
-        channel_id = qs.get("channel_id", [None])[0]
+        channel_id = source.channel_id or qs.get("channel_id", [None])[0]
         if channel_id:
-            return f"https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
-        match = re.search(r"/channel/([A-Za-z0-9_-]+)", parsed.path)
-        return f"https://www.youtube.com/feeds/videos.xml?channel_id={match.group(1)}" if match else None
+            return {"rss_url": YOUTUBE_RSS_BY_CHANNEL.format(channel_id=channel_id), "channel_id": channel_id, "provider": self.provider_name}
+        channel_match = re.search(r"/(?:channel)/([A-Za-z0-9_-]+)", parsed.path)
+        if channel_match:
+            channel_id = channel_match.group(1)
+            return {"rss_url": YOUTUBE_RSS_BY_CHANNEL.format(channel_id=channel_id), "channel_id": channel_id, "provider": self.provider_name}
+        user_match = re.search(r"/user/([^/?#]+)", parsed.path)
+        if user_match:
+            user = user_match.group(1)
+            return {"rss_url": YOUTUBE_RSS_BY_USER.format(user=user), "channel_id": None, "provider": self.provider_name}
+        if re.search(r"/(?:@|c/)[^/?#]+", parsed.path):
+            return {"rss_url": None, "channel_id": None, "provider": self.provider_name, "error": "YouTube RSS requires a channel_id for @handle or /c/ URLs. Add channel_id to media_sources.json; HTML scraping and YouTube Data API are intentionally not used."}
+        return {"rss_url": None, "channel_id": None, "provider": self.provider_name, "error": "Unsupported YouTube URL for RSS import. Use /channel/UC..., /user/... or provide channel_id."}
+
+    def _entry_to_item(self, entry: Any, source: MediaSource) -> MediaItem | None:
+        youtube_id = self._entry_video_id(entry)
+        if not youtube_id: return None
+        title = str(entry.get("title") or "Без названия").strip(); description = str(entry.get("summary") or entry.get("description") or "").strip(); symbol = detect_symbol(f"{title} {description}")
+        return MediaItem(id=f"youtube:{youtube_id}", provider=self.provider_name, source_id=source.id, title=title, author=str(entry.get("author") or source.name), youtube_id=youtube_id, url=str(entry.get("link") or f"https://www.youtube.com/watch?v={youtube_id}"), thumbnail=self._thumbnail(entry), published_at=self._published_date(entry), duration=None, category=source.categories[0] if source.categories else "Market Analysis", symbol=symbol, language=source.language, description=description, tags=[*source.categories, symbol], imported_at=datetime.now(timezone.utc).isoformat())
+
+    @staticmethod
+    def _default_fetcher(url: str) -> FetchResult:
+        try:
+            req = Request(url, headers={"User-Agent":"Mozilla/5.0","Accept":"application/rss+xml, application/xml;q=0.9, */*;q=0.8"})
+            with urlopen(req, timeout=15) as response:
+                return FetchResult(True, url, "ok", getattr(response, "status", None), response.read())
+        except HTTPError as exc:
+            return FetchResult(False, url, "http_error", exc.code, error=str(exc))
+        except (URLError, TimeoutError, OSError) as exc:
+            return FetchResult(False, url, "request_error", None, error=str(exc))
 
     @staticmethod
     def _entry_video_id(entry: Any) -> str | None:
-        value = entry.get("yt_videoid") or entry.get("id")
-        if value and ":video:" in str(value):
-            return str(value).rsplit(":", 1)[-1]
-        if value and re.fullmatch(r"[A-Za-z0-9_-]{8,}", str(value)):
-            return str(value)
-        link = str(entry.get("link") or "")
-        return parse_qs(urlparse(link).query).get("v", [None])[0]
-
+        value = entry.get("yt_videoid") or entry.get("yt_videoId") or entry.get("id")
+        if value and ":video:" in str(value): return str(value).rsplit(":", 1)[-1]
+        if value and re.fullmatch(r"[A-Za-z0-9_-]{8,}", str(value)): return str(value)
+        return parse_qs(urlparse(str(entry.get("link") or "")).query).get("v", [None])[0]
     @staticmethod
-    def _published_date(entry: Any) -> str | None:
-        return str(entry.get("published") or entry.get("updated") or "")[:10] or None
-
+    def _published_date(entry: Any) -> str | None: return str(entry.get("published") or entry.get("updated") or "")[:10] or None
     @staticmethod
     def _thumbnail(entry: Any) -> str | None:
         media = entry.get("media_thumbnail") or []
-        if media and isinstance(media, list):
-            return media[0].get("url")
+        if media and isinstance(media, list): return media[0].get("url")
         youtube_id = YouTubeRssProvider._entry_video_id(entry)
         return f"https://i.ytimg.com/vi/{youtube_id}/hqdefault.jpg" if youtube_id else None
 
 
 class EmptyProvider:
-    def __init__(self, provider_name: str) -> None:
-        self.provider_name = provider_name
-    def fetch_latest(self, source: MediaSource) -> list[MediaItem]:
-        logger.info("media_provider_not_implemented provider=%s source_id=%s", self.provider_name, source.id)
-        return []
+    def __init__(self, provider_name: str) -> None: self.provider_name = provider_name
+    def fetch_latest(self, source: MediaSource) -> ImportSourceResult: return ImportSourceResult(source, [], "skipped", None, 0, f"Provider {self.provider_name} is not implemented")
 
 
 def detect_symbol(text: str) -> str:
     normalized = re.sub(r"[^A-Z0-9]", "", str(text).upper())
     for symbol in SYMBOLS:
-        if symbol in normalized:
-            return symbol
+        if symbol in normalized: return symbol
     return "MARKET"
 
 
 class MediaImportScheduler:
-    def __init__(self) -> None:
-        self.enabled = False
-        self.interval_hours = 3
-    def next_job_payload(self) -> dict[str, Any]:
-        return {"enabled": self.enabled, "interval_hours": self.interval_hours, "status": "ready_for_future_cron"}
+    def __init__(self) -> None: self.enabled = False; self.interval_hours = 3
+    def next_job_payload(self) -> dict[str, Any]: return {"enabled": self.enabled, "interval_hours": self.interval_hours, "status": "ready_for_future_cron"}
 
 
 class MediaImportEngine:
-    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None) -> None:
-        self.sources_path = sources_path
-        self.catalog_path = catalog_path
-        self.manual_videos_path = manual_videos_path
-        self.scheduler = MediaImportScheduler()
-
+    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None, youtube_provider: YouTubeRssProvider | None = None) -> None:
+        self.sources_path = sources_path; self.catalog_path = catalog_path; self.manual_videos_path = manual_videos_path; self.scheduler = MediaImportScheduler(); self.youtube_provider = youtube_provider or YouTubeRssProvider()
     def load_sources(self) -> list[MediaSource]:
-        try:
-            payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
-        except FileNotFoundError:
-            return []
+        try: payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
+        except FileNotFoundError: return []
         return self._validate_sources(payload)
-
     def list_sources(self) -> list[dict[str, Any]]:
-        catalog = self.load_catalog()
-        return [s.public_payload(catalog) for s in sorted(self.load_sources(), key=lambda item: (item.priority, item.name.lower()))]
-
+        catalog = self.load_catalog(); return [s.public_payload(catalog) for s in sorted(self.load_sources(), key=lambda item: (item.priority, item.name.lower()))]
     def load_catalog(self) -> list[dict[str, Any]]:
-        base = self._read_json_list(self.manual_videos_path) if self.manual_videos_path else []
-        imported = self._read_json_list(self.catalog_path)
-        return self._sort_media(self._dedupe([*base, *imported]))
-
+        return self._sort_media(self._dedupe([*(self._read_json_list(self.manual_videos_path) if self.manual_videos_path else []), *self._read_json_list(self.catalog_path)]))
     def import_latest(self) -> dict[str, Any]:
-        sources = [s for s in self.load_sources() if s.enabled]
-        existing = self.load_catalog()
-        imported: list[dict[str, Any]] = []
-        errors: list[dict[str, str]] = []
+        sources = [s for s in self.load_sources() if s.enabled]; existing = self.load_catalog(); fetched: list[dict[str, Any]] = []; errors: list[dict[str, str]] = []; processed = 0; failed = 0; now = datetime.now(timezone.utc).isoformat(); updated_sources: list[MediaSource] = []
         for source in sources:
-            provider = self.resolve_provider(source.provider)
+            processed += 1; provider = self.resolve_provider(source.provider)
             try:
-                imported.extend(item.payload() for item in provider.fetch_latest(source))
+                result = provider.fetch_latest(source); fetched.extend(item.payload() for item in result.items)
+                updated_sources.append(replace(result.source, videos_count=result.videos_found, last_import=now, last_success=now, last_error=None, rss_url=result.source.rss_url or result.source.feed_url))
+                if result.error: errors.append({"source": source.name, "reason": result.error})
             except Exception as exc:
-                logger.warning("media_import_source_failed source_id=%s error=%s", source.id, exc)
-                errors.append({"source_id": source.id, "error": str(exc)})
-        merged = self._sort_media(self._dedupe([*existing, *imported]))
-        self.catalog_path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
-        return {"success": True, "sources": len(sources), "new_items": max(0, len(merged) - len(existing)), "updated": datetime.now(timezone.utc).isoformat(), "provider": "youtube-rss", "errors": errors}
-
-    def resolve_provider(self, provider: str) -> MediaProvider:
-        return YouTubeRssProvider() if provider == "youtube" else EmptyProvider(provider)
+                failed += 1; reason = str(exc); logger.warning("media_import_source_failed source_id=%s error=%s", source.id, reason); errors.append({"source": source.name, "reason": reason}); updated_sources.append(replace(source, last_import=now, last_error=reason))
+        merged = self._sort_media(self._dedupe([*existing, *fetched])); before = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in existing}; after = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in merged}
+        self.catalog_path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8"); self._save_sources(updated_sources)
+        return {"success": failed < len(sources) if sources else True, "sources": len(sources), "processed": processed, "imported": len(after - before), "new_items": len(after - before), "updated": max(0, len(fetched) - len(after - before)), "failed": failed, "errors": errors}
+    def debug_sources(self) -> list[dict[str, Any]]:
+        rows=[]
+        for source in self.load_sources():
+            provider = self.resolve_provider(source.provider); resolved = provider.resolve_rss(source) if isinstance(provider, YouTubeRssProvider) else {"provider": provider.provider_name, "error":"provider_not_implemented"}; fetch = FetchResult(False, resolved.get("rss_url"), "not_requested", error=resolved.get("error"))
+            videos=0
+            if resolved.get("rss_url") and source.enabled:
+                fetch = provider.fetcher(str(resolved["rss_url"])) if isinstance(provider, YouTubeRssProvider) else fetch
+                if fetch.ok: videos = len(getattr(feedparser.parse(fetch.content), "entries", []))
+            rows.append({"source": source.name, "provider": resolved.get("provider", source.provider), "rss_url": resolved.get("rss_url"), "channel_id": resolved.get("channel_id") or source.channel_id, "request_status": fetch.request_status, "response_status": fetch.response_status, "videos_found": videos, "last_error": fetch.error or source.last_error})
+        return rows
+    def resolve_provider(self, provider: str) -> MediaProvider: return self.youtube_provider if provider == "youtube" else EmptyProvider(provider)
+    def _save_sources(self, updates: list[MediaSource]) -> None:
+        by_id = {s.id: s for s in updates}; raw = self._read_json_list(self.sources_path); catalog = self.load_catalog()
+        for item in raw:
+            upd = by_id.get(str(item.get("id")))
+            if upd:
+                item.update({"channel_id": upd.channel_id, "rss_url": upd.rss_url or upd.feed_url, "last_error": upd.last_error, "last_import": upd.last_import, "last_success": upd.last_success, "videos_count": len([v for v in catalog if v.get("source_id") == upd.id])})
+                if not upd.last_error: item.pop("last_error", None)
+        self.sources_path.write_text(json.dumps(raw, ensure_ascii=False, indent=2), encoding="utf-8")
 
     def _validate_sources(self, payload: Any) -> list[MediaSource]:
         if not isinstance(payload, list):
@@ -223,7 +250,14 @@ class MediaImportEngine:
             if provider not in SUPPORTED_MEDIA_PROVIDERS: raise MediaConfigError(f"unsupported media provider: {provider}")
             categories = item.get("categories")
             if not isinstance(categories, list) or not all(isinstance(v, str) and v.strip() for v in categories): raise MediaConfigError(f"source {source_id} categories must be strings")
-            result.append(MediaSource(source_id, self._required_str(item,"name",index), provider, self._required_str(item,"channel_url",index), self._required_str(item,"language",index), int(item.get("priority") or 1), [v.strip() for v in categories], bool(item.get("enabled")), item.get("feed_url"), item.get("channel_id")))
+            result.append(MediaSource(
+                id=source_id, name=self._required_str(item,"name",index), provider=provider,
+                channel_url=self._required_str(item,"channel_url",index), language=self._required_str(item,"language",index),
+                priority=int(item.get("priority") or 1), categories=[v.strip() for v in categories],
+                enabled=bool(item.get("enabled")), feed_url=item.get("feed_url"), channel_id=item.get("channel_id"),
+                rss_url=item.get("rss_url"), last_error=item.get("last_error"), last_import=item.get("last_import"),
+                last_success=item.get("last_success"), videos_count=int(item.get("videos_count") or 0),
+            ))
         return result
 
     @staticmethod

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.services.media_import_engine import MediaImportEngine, detect_symbol
+from app.services.media_import_engine import FetchResult, MediaImportEngine, YouTubeRssProvider, detect_symbol
 
 
 def test_media_api_contracts():
@@ -47,3 +47,82 @@ def test_media_import_merges_and_deduplicates_manual_catalog(tmp_path: Path):
     assert len(catalog) == 1
     assert catalog[0]["youtube_id"] == "abc12345678"
     assert catalog[0]["symbol"] == "EURUSD"
+
+
+
+def test_youtube_rss_generation_for_channel_and_user_urls():
+    provider = YouTubeRssProvider()
+    assert provider.resolve_rss(_source("https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw"))["rss_url"] == "https://www.youtube.com/feeds/videos.xml?channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw"
+    assert provider.resolve_rss(_source("https://www.youtube.com/user/GoogleDevelopers"))["rss_url"] == "https://www.youtube.com/feeds/videos.xml?user=GoogleDevelopers"
+
+
+def test_youtube_handle_resolution_requires_channel_id_without_scraping():
+    provider = YouTubeRssProvider()
+    unresolved = provider.resolve_rss(_source("https://www.youtube.com/@demo"))
+    resolved = provider.resolve_rss(_source("https://www.youtube.com/@demo", channel_id="UCdemo123"))
+    assert unresolved["rss_url"] is None
+    assert "requires a channel_id" in unresolved["error"]
+    assert resolved["rss_url"] == "https://www.youtube.com/feeds/videos.xml?channel_id=UCdemo123"
+
+
+def test_media_import_success_updates_catalog_and_source_metadata(tmp_path: Path):
+    engine, catalog_path, sources_path = _engine_with_fetcher(tmp_path, lambda url: FetchResult(True, url, "ok", 200, _sample_feed()))
+    result = engine.import_latest()
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    source = json.loads(sources_path.read_text(encoding="utf-8"))[0]
+    assert result["success"] is True
+    assert result["processed"] == 1
+    assert result["imported"] == 1
+    assert result["failed"] == 0
+    assert catalog[0]["youtube_id"] == "abc12345678"
+    assert source["videos_count"] == 1
+    assert source["last_import"]
+    assert source["last_success"]
+    assert source.get("last_error") is None
+
+
+def test_media_import_failure_continues_remaining_sources(tmp_path: Path):
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([
+        {"id":"bad","name":"Bad","provider":"youtube","channel_url":"https://www.youtube.com/@bad","language":"ru","priority":1,"categories":["Forex"],"enabled":True},
+        {"id":"good","name":"Good","provider":"youtube","channel_url":"https://www.youtube.com/channel/UCgood","language":"ru","priority":2,"categories":["Forex"],"enabled":True}
+    ]), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+    engine = MediaImportEngine(sources_path, catalog_path, youtube_provider=YouTubeRssProvider(lambda url: FetchResult(True, url, "ok", 200, _sample_feed("good1234567"))))
+    result = engine.import_latest()
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    assert result["processed"] == 2
+    assert result["failed"] == 1
+    assert result["imported"] == 1
+    assert catalog[0]["source_id"] == "good"
+    assert result["errors"][0]["source"] == "Bad"
+
+
+def test_media_debug_endpoint_contract():
+    response = TestClient(app).get("/api/media/debug")
+    assert response.status_code == 200
+    assert {"provider", "rss_url", "channel_id", "request_status", "response_status", "videos_found", "last_error"}.issubset(response.json()[0].keys())
+
+
+def _source(channel_url: str, channel_id: str | None = None):
+    from app.services.media_import_engine import MediaSource
+    return MediaSource("demo", "Demo", "youtube", channel_url, "ru", 1, ["Forex"], True, channel_id=channel_id)
+
+
+def _engine_with_fetcher(tmp_path: Path, fetcher):
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([
+        {"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/channel/UCdemo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
+    ]), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+    return MediaImportEngine(sources_path, catalog_path, youtube_provider=YouTubeRssProvider(fetcher)), catalog_path, sources_path
+
+
+def _sample_feed(video_id: str = "abc12345678") -> bytes:
+    xml = f"""<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns='http://www.w3.org/2005/Atom' xmlns:yt='http://www.youtube.com/xml/schemas/2015'>
+  <entry><yt:videoId>{video_id}</yt:videoId><title>EURUSD обзор</title><link href='https://www.youtube.com/watch?v={video_id}'/><author><name>Demo</name></author><published>2026-07-06T00:00:00+00:00</published></entry>
+</feed>"""
+    return xml.encode("utf-8")


### PR DESCRIPTION
### Motivation
- Сделать импорт YouTube через публичные RSS-ленты надёжным и диагностируемым, поскольку в текущей реализации `last_import` был всегда `null` и `videos_count` не обновлялся. 
- Поддержать разные формы YouTube-ссылок (`/channel/UC...`, `/user/...`, `@handle`, `/c/...`) и явно сообщать ограничение для `@handle`/`/c/` без `channel_id` вместо silent-fail. 
- Не использовать YouTube Data API и не скрапить HTML, при этом давать понятную диагностику и продолжать импорт остальных источников при ошибке одного из них. 

### Description
- Расширена модель источника `MediaSource` новыми полями `channel_id`, `rss_url`, `last_error`, `last_import`, `last_success` и `videos_count`, а `public_payload` теперь возвращает диагностические поля и статус. 
- Полностью переработан провайдер RSS `YouTubeRssProvider`: добавлено разрешение RSS для `channel_id`, `/channel/UC...` и `/user/...`, встроенный `fetcher` с HTTP-диагностикой (`FetchResult`), явные ошибки для нерешаемых `@handle`/`/c/` ссылок и преобразование записей в `MediaItem`. 
- `POST /api/media/import` теперь продолжает импорт при ошибках отдельных источников, собирает подробные счётчики `sources/processed/imported/new_items/updated/failed/errors`, обновляет `data/media_catalog.json` newest-first и записывает обновлённые метаданные в `data/media_sources.json`. 
- Добавлен диагностический endpoint `GET /api/media/debug`, возвращающий для каждого источника `provider`, `rss_url`, `channel_id`, `request_status`, `response_status`, `videos_found` и `last_error`. 
- Добавлены unit-тесты для генерации RSS URL, проверки обработки `@handle`, успешного импорта и поведения при ошибках, а также контракт `GET /api/media/debug`, и обновлён `README` с описанием ограничений. 

### Testing
- Запущены модульные тесты `pytest -q tests/test_media_import_engine.py`, все тесты в этом файле прошли успешно (`8 passed`). 
- Выполнена проверка синтаксиса через `python -m py_compile app/services/media_import_engine.py app/main.py`, ошибок компиляции не обнаружено. 
- Полный прогон тестов `pytest -q -x` завершился с одним падением вне области изменений: `tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, поэтому интеграционные тесты в целом не зелёные, но изменения в медиа-импорте покрыты и работают.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4be5b5f6bc833186b811e8e347350f)