### PR TITLE
Исправить импорт YouTube RSS — добавить `channel_id`/`rss_url` для источников FXPilot TV

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 
 ## Что обновлено в версии 4.2
+- YouTube источники FXPilot TV теперь содержат явные `channel_id` и `rss_url`; импорт строит RSS по `channel_id`, а источники без `channel_id` получают статус `needs_channel_id` и понятную диагностику в `/api/media/debug` и `/admin/media`. Добавлен помощник `python scripts/resolve_youtube_channels.py` для ручного поиска отсутствующих ID без YouTube Data API и без HTML scraping в приложении.
 - FXPilot Media Import Engine теперь строит YouTube RSS только из поддерживаемых публичных RSS-идентификаторов: `channel_id`, `/channel/UC...` и legacy `/user/...`; для `@handle` и `/c/...` без `channel_id` возвращается явная диагностика без HTML scraping и без YouTube Data API.
 - `POST /api/media/import` возвращает детальный контракт `processed/imported/updated/failed/errors`, продолжает импорт остальных источников при ошибке одного источника и сохраняет `channel_id`, `rss_url`, `last_import`, `last_success`, `last_error`, `videos_count` в `data/media_sources.json`.
 - Добавлен `GET /api/media/debug` для проверки provider, RSS URL, channel id, HTTP-статуса запроса, количества найденных видео и последней ошибки источника.

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -46,11 +46,14 @@ class MediaSource:
     last_import: str | None = None
     last_success: str | None = None
     videos_count: int = 0
+    status: str | None = None
 
     def public_payload(self, catalog: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         videos = [item for item in (catalog or []) if item.get("source_id") == self.id]
         latest_import = self.last_import or max((str(item.get("imported_at") or "") for item in videos), default="") or None
-        status = "disabled" if not self.enabled else ("error" if self.last_error else "ok")
+        status = self.status or ("disabled" if not self.enabled else ("error" if self.last_error else "ok"))
+        if self.provider == "youtube" and self.enabled and not self.channel_id:
+            status = "needs_channel_id"
         return {
             "id": self.id,
             "name": self.name,
@@ -67,6 +70,8 @@ class MediaSource:
             "last_success": self.last_success,
             "status": status,
             "last_error": self.last_error,
+            "blocking_reason": "Нужен YouTube channel_id для RSS-импорта" if status == "needs_channel_id" else None,
+            "can_import": not (self.provider == "youtube" and self.enabled and not self.channel_id),
         }
 
 
@@ -214,7 +219,7 @@ class MediaImportEngine:
                 updated_sources.append(replace(result.source, videos_count=result.videos_found, last_import=now, last_success=now, last_error=None, rss_url=result.source.rss_url or result.source.feed_url))
                 if result.error: errors.append({"source": source.name, "reason": result.error})
             except Exception as exc:
-                failed += 1; reason = str(exc); logger.warning("media_import_source_failed source_id=%s error=%s", source.id, reason); errors.append({"source": source.name, "reason": reason}); updated_sources.append(replace(source, last_import=now, last_error=reason))
+                failed += 1; reason = str(exc); logger.warning("media_import_source_failed source_id=%s error=%s", source.id, reason); errors.append({"source": source.name, "reason": reason}); updated_sources.append(replace(source, last_import=now, last_error="YouTube RSS requires channel_id" if "requires a channel_id" in reason else reason, status="needs_channel_id" if "requires a channel_id" in reason else "error"))
         merged = self._sort_media(self._dedupe([*existing, *fetched])); before = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in existing}; after = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in merged}
         self.catalog_path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8"); self._save_sources(updated_sources)
         return {"success": failed < len(sources) if sources else True, "sources": len(sources), "processed": processed, "imported": len(after - before), "new_items": len(after - before), "updated": max(0, len(fetched) - len(after - before)), "failed": failed, "errors": errors}
@@ -226,7 +231,9 @@ class MediaImportEngine:
             if resolved.get("rss_url") and source.enabled:
                 fetch = provider.fetcher(str(resolved["rss_url"])) if isinstance(provider, YouTubeRssProvider) else fetch
                 if fetch.ok: videos = len(getattr(feedparser.parse(fetch.content), "entries", []))
-            rows.append({"source": source.name, "provider": resolved.get("provider", source.provider), "rss_url": resolved.get("rss_url"), "channel_id": resolved.get("channel_id") or source.channel_id, "request_status": fetch.request_status, "response_status": fetch.response_status, "videos_found": videos, "last_error": fetch.error or source.last_error})
+            channel_id = resolved.get("channel_id") or source.channel_id
+            blocking_reason = "Нужен YouTube channel_id для RSS-импорта" if source.provider == "youtube" and not channel_id else None
+            rows.append({"source": source.name, "channel_url": source.channel_url, "provider": resolved.get("provider", source.provider), "rss_url": resolved.get("rss_url") or source.rss_url, "channel_id": channel_id, "can_import": blocking_reason is None, "blocking_reason": blocking_reason, "request_status": fetch.request_status, "response_status": fetch.response_status, "videos_found": videos, "last_error": fetch.error or source.last_error})
         return rows
     def resolve_provider(self, provider: str) -> MediaProvider: return self.youtube_provider if provider == "youtube" else EmptyProvider(provider)
     def _save_sources(self, updates: list[MediaSource]) -> None:
@@ -234,8 +241,10 @@ class MediaImportEngine:
         for item in raw:
             upd = by_id.get(str(item.get("id")))
             if upd:
-                item.update({"channel_id": upd.channel_id, "rss_url": upd.rss_url or upd.feed_url, "last_error": upd.last_error, "last_import": upd.last_import, "last_success": upd.last_success, "videos_count": len([v for v in catalog if v.get("source_id") == upd.id])})
-                if not upd.last_error: item.pop("last_error", None)
+                item.update({"channel_id": upd.channel_id, "rss_url": upd.rss_url or upd.feed_url, "last_error": upd.last_error, "last_import": upd.last_import, "last_success": upd.last_success, "videos_count": len([v for v in catalog if v.get("source_id") == upd.id]), "status": upd.status})
+                if not upd.last_error:
+                    item.pop("last_error", None)
+                    item.pop("status", None)
         self.sources_path.write_text(json.dumps(raw, ensure_ascii=False, indent=2), encoding="utf-8")
 
     def _validate_sources(self, payload: Any) -> list[MediaSource]:
@@ -256,7 +265,7 @@ class MediaImportEngine:
                 priority=int(item.get("priority") or 1), categories=[v.strip() for v in categories],
                 enabled=bool(item.get("enabled")), feed_url=item.get("feed_url"), channel_id=item.get("channel_id"),
                 rss_url=item.get("rss_url"), last_error=item.get("last_error"), last_import=item.get("last_import"),
-                last_success=item.get("last_success"), videos_count=int(item.get("videos_count") or 0),
+                last_success=item.get("last_success"), videos_count=int(item.get("videos_count") or 0), status=item.get("status"),
             ))
         return result
 

--- a/app/static/media-admin.js
+++ b/app/static/media-admin.js
@@ -12,15 +12,20 @@
   function renderSources(sources) {
     setText('mediaStatSources', String(sources.length));
     if (!sources.length) { sourcesBody.innerHTML = '<tr><td colspan="6">Источники не настроены.</td></tr>'; return; }
-    sourcesBody.innerHTML = sources.map((source) => `
+    sourcesBody.innerHTML = sources.map((source) => {
+      const needsChannelId = source.status === 'needs_channel_id' || (source.provider === 'youtube' && !source.channel_id);
+      const statusLabel = needsChannelId ? 'Нужен YouTube channel_id для RSS-импорта' : (source.enabled ? 'Enabled' : 'Disabled');
+      const statusClass = needsChannelId ? 'is-disabled' : (source.enabled ? 'is-enabled' : 'is-disabled');
+      return `
       <tr>
         <td><strong>${escapeHtml(source.name)}</strong><span>${escapeHtml(source.channel_url || '')}</span></td>
         <td><span class="tv-provider-pill">${escapeHtml(source.provider)}</span></td>
-        <td><span class="tv-status-pill ${source.enabled ? 'is-enabled' : 'is-disabled'}">${source.enabled ? 'Enabled' : 'Disabled'}</span></td>
+        <td><span class="tv-status-pill ${statusClass}">${escapeHtml(statusLabel)}</span></td>
         <td>${formatValue(source.last_import)}</td>
         <td>${escapeHtml(source.videos_count ?? 0)}</td>
         <td><div class="tv-source-actions"><button data-action="Import Now" data-source="${escapeHtml(source.name)}">Import Now</button><button data-action="Disable" data-source="${escapeHtml(source.name)}">Disable</button><button data-action="Enable" data-source="${escapeHtml(source.name)}">Enable</button></div></td>
-      </tr>`).join('');
+      </tr>`;
+    }).join('');
   }
 
   function renderMedia(items) {

--- a/data/media_sources.json
+++ b/data/media_sources.json
@@ -1,8 +1,88 @@
 [
-  {"id":"gerchik","name":"Gerchik & Co","provider":"youtube","channel_url":"https://www.youtube.com/@gerchikco9785","language":"ru","priority":1,"categories":["Forex","Smart Money"],"enabled":true},
-  {"id":"instaforex","name":"InstaForex","provider":"youtube","channel_url":"https://www.youtube.com/@instaforex","language":"ru","priority":2,"categories":["Forex","Macro"],"enabled":true},
-  {"id":"traderevo","name":"TraderEVO","provider":"youtube","channel_url":"https://www.youtube.com/@traderevo","language":"ru","priority":2,"categories":["Smart Money"],"enabled":true},
-  {"id":"prosto_crypto","name":"PROSTO КРИПТО","provider":"youtube","channel_url":"https://www.youtube.com/@prosto_kripto","language":"ru","priority":2,"categories":["Crypto"],"enabled":true},
-  {"id":"market_vector","name":"Market Vector","provider":"youtube","channel_url":"https://www.youtube.com/@market_vector","language":"ru","priority":2,"categories":["Market Analysis"],"enabled":true},
-  {"id":"bazylev","name":"Aleksandr Bazylev","provider":"youtube","channel_url":"https://www.youtube.com/@AleksandrBazylev","language":"ru","priority":2,"categories":["Forex"],"enabled":true}
+  {
+    "id": "gerchik",
+    "name": "Gerchik & Co",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@gerchikco9785",
+    "language": "ru",
+    "priority": 1,
+    "categories": [
+      "Forex",
+      "Smart Money"
+    ],
+    "enabled": true,
+    "channel_id": "UCh8-SAbji1gKC1g55O4IcBA",
+    "rss_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCh8-SAbji1gKC1g55O4IcBA"
+  },
+  {
+    "id": "instaforex",
+    "name": "InstaForex",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@instaforex",
+    "language": "ru",
+    "priority": 2,
+    "categories": [
+      "Forex",
+      "Macro"
+    ],
+    "enabled": true,
+    "channel_id": "UCmhqA0PXvpSj8kuN3zshpDw",
+    "rss_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCmhqA0PXvpSj8kuN3zshpDw"
+  },
+  {
+    "id": "traderevo",
+    "name": "TraderEVO",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@traderevo",
+    "language": "ru",
+    "priority": 2,
+    "categories": [
+      "Smart Money"
+    ],
+    "enabled": true,
+    "channel_id": "UCOmYjA62I2btofTh6cmvxug",
+    "rss_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCOmYjA62I2btofTh6cmvxug"
+  },
+  {
+    "id": "prosto_crypto",
+    "name": "PROSTO КРИПТО",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@prosto_kripto",
+    "language": "ru",
+    "priority": 2,
+    "categories": [
+      "Crypto"
+    ],
+    "enabled": true,
+    "channel_id": "UCJMHJhC3OSDsMydCqzOUf9g",
+    "rss_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCJMHJhC3OSDsMydCqzOUf9g"
+  },
+  {
+    "id": "market_vector",
+    "name": "Market Vector",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@market_vector",
+    "language": "ru",
+    "priority": 2,
+    "categories": [
+      "Market Analysis"
+    ],
+    "enabled": true,
+    "channel_id": "UCv3fcYvaZctSjsvyK8anXXA",
+    "rss_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCv3fcYvaZctSjsvyK8anXXA"
+  },
+  {
+    "id": "bazylev",
+    "name": "Aleksandr Bazylev",
+    "provider": "youtube",
+    "channel_url": "https://www.youtube.com/@AleksandrBazylev",
+    "language": "ru",
+    "priority": 2,
+    "categories": [
+      "Forex"
+    ],
+    "enabled": true,
+    "channel_id": "UCF7DHh7tYFv2Fm6lkFIa2MA",
+    "rss_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCF7DHh7tYFv2Fm6lkFIa2MA"
+  }
 ]

--- a/scripts/resolve_youtube_channels.py
+++ b/scripts/resolve_youtube_channels.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Report YouTube sources that still need a channel_id for RSS import."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCES_PATH = ROOT / "data" / "media_sources.json"
+
+
+def main() -> int:
+    try:
+        payload = json.loads(SOURCES_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"Не найден файл источников: {SOURCES_PATH}")
+        return 0
+    except json.JSONDecodeError as exc:
+        print(f"Некорректный JSON в {SOURCES_PATH}: {exc}")
+        return 0
+
+    missing = [
+        source for source in payload
+        if isinstance(source, dict)
+        and source.get("provider") == "youtube"
+        and not str(source.get("channel_id") or "").strip()
+    ]
+
+    if not missing:
+        print("Все YouTube источники уже содержат channel_id.")
+        return 0
+
+    print("YouTube источники без channel_id:")
+    for source in missing:
+        print(f"- {source.get('id', 'unknown')}: {source.get('name', 'Без названия')} — {source.get('channel_url', 'нет URL')}")
+    print()
+    print("Как заполнить channel_id:")
+    print("1. Open the YouTube channel page -> View page source -> search for channelId")
+    print("2. Use any public channel ID lookup tool manually")
+    print("3. Добавьте channel_id и rss_url в data/media_sources.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -126,3 +126,46 @@ def _sample_feed(video_id: str = "abc12345678") -> bytes:
   <entry><yt:videoId>{video_id}</yt:videoId><title>EURUSD обзор</title><link href='https://www.youtube.com/watch?v={video_id}'/><author><name>Demo</name></author><published>2026-07-06T00:00:00+00:00</published></entry>
 </feed>"""
     return xml.encode("utf-8")
+
+
+def test_youtube_source_with_channel_id_uses_channel_rss(tmp_path: Path):
+    requested = []
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([
+        {"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/@demo","channel_id":"UCexplicit","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
+    ]), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+    engine = MediaImportEngine(
+        sources_path,
+        catalog_path,
+        youtube_provider=YouTubeRssProvider(lambda url: requested.append(url) or FetchResult(True, url, "ok", 200, _sample_feed())),
+    )
+    engine.import_latest()
+    assert requested == ["https://www.youtube.com/feeds/videos.xml?channel_id=UCexplicit"]
+
+
+def test_youtube_source_without_channel_id_returns_needs_channel_id(tmp_path: Path):
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([
+        {"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/@demo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
+    ]), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+    result = MediaImportEngine(sources_path, catalog_path).import_latest()
+    source = json.loads(sources_path.read_text(encoding="utf-8"))[0]
+    assert result["failed"] == 1
+    assert source["status"] == "needs_channel_id"
+    assert source["last_error"] == "YouTube RSS requires channel_id"
+
+
+def test_debug_sources_exposes_blocking_reason_for_missing_channel_id(tmp_path: Path):
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([
+        {"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/@demo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
+    ]), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+    row = MediaImportEngine(sources_path, catalog_path).debug_sources()[0]
+    assert row["can_import"] is False
+    assert row["blocking_reason"] == "Нужен YouTube channel_id для RSS-импорта"


### PR DESCRIPTION
### Motivation
- Текущие YouTube-источники используют `@handle` и возвращали ноль видео, потому что RSS требует явный `channel_id`. 
- Не менять движок, не использовать YouTube Data API и не скрапить HTML, поэтому нужно добавить поддержку явного `channel_id` в данных и диагностировать отсутствие ID. 

### Description
- В `data/media_sources.json` добавлены поля `channel_id` и `rss_url` для всех текущих YouTube-источников, чтобы импорт мог строить корректный RSS (пример: `https://www.youtube.com/feeds/videos.xml?channel_id=UC...`).
- В `app/services/media_import_engine.py` добавлены поле `status` в модель `MediaSource`, логика формирования `public_payload` расширена ключами `status`, `blocking_reason` и `can_import`, и импортер теперь помечает источник как `needs_channel_id` и сохраняет `last_error = "YouTube RSS requires channel_id"` когда `channel_id` отсутствует.
- Метод `debug_sources` теперь возвращает `channel_url`, `channel_id`, `rss_url`, `can_import` и `blocking_reason` для каждого YouTube-источника; `_save_sources` сохраняет `status` и обновлённые метаданные в `data/media_sources.json`.
- UI админки обновлён (`app/static/media-admin.js`) для отображения на русском `Нужен YouTube channel_id для RSS-импорта` вместо простого OK для таких источников.
- Добавлен скрипт-помощник `scripts/resolve_youtube_channels.py`, который перечисляет YouTube-источники без `channel_id` и выводит инструкции по ручному получению ID, при этом приложение не пытается автоматически скрапить или вызывать YouTube API.
- Добавлены и обновлены тесты в `tests/test_media_import_engine.py` для проверки: импорт по `channel_id`, поведение при отсутствии `channel_id` и присутствие `blocking_reason` в `debug_sources`.
- Обновлён `README.md` с описанием нового поведения и инструкции по скрипту.

### Testing
- Запущены unit-тесты: `python -m pytest tests/test_media_import_engine.py -q`, все тесты прошли: `11 passed`.
- Запущен помощник: `python scripts/resolve_youtube_channels.py`, скрипт корректно сообщает об отсутствии/наличии `channel_id` (в рабочем дереве сейчас все перечисленные источники уже содержат `channel_id`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7097a1a48331acc77e82198f19f2)