### PR TITLE
Fix media import execution pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ signals_data/heatmap.json
 signals_data/market_ideas.json
 signals_data/market_news.json
 signals_data/signals.json
+data/media_import_debug.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NicolasSavin AI FOREX SIGNAL PLATFORM — Версия 4.0
+- Media Import execution hardened: `/admin/media` now displays the raw `POST /api/media/import` JSON/error result, refreshes sources/catalog after success, and `/api/media/debug` reads the last import run log with per-source RSS URL, HTTP status, entries found, imported count and exact error reason.
 
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 

--- a/app/main.py
+++ b/app/main.py
@@ -135,7 +135,15 @@ from backend.signal_engine import SignalEngine
 canonical_market_service = get_canonical_market_service()
 trade_idea_service = TradeIdeaService(signal_engine=SignalEngine())
 tv_source_manager = TvSourceManager(BASE_DIR.parent / "data" / "tv_sources.json", BASE_DIR.parent / "data" / "tv_videos.json")
-media_import_engine = MediaImportEngine(BASE_DIR.parent / "data" / "media_sources.json", BASE_DIR.parent / "data" / "media_catalog.json", BASE_DIR.parent / "data" / "tv_videos.json")
+MEDIA_SOURCES_PATH = BASE_DIR.parent / "data" / "media_sources.json"
+MEDIA_CATALOG_PATH = BASE_DIR.parent / "data" / "media_catalog.json"
+MEDIA_MANUAL_VIDEOS_PATH = BASE_DIR.parent / "data" / "tv_videos.json"
+MEDIA_DEBUG_PATH = BASE_DIR.parent / "data" / "media_import_debug.json"
+
+def create_media_import_engine() -> MediaImportEngine:
+    return MediaImportEngine(MEDIA_SOURCES_PATH, MEDIA_CATALOG_PATH, MEDIA_MANUAL_VIDEOS_PATH, debug_path=MEDIA_DEBUG_PATH)
+
+media_import_engine = create_media_import_engine()
 
 class _AnalyticsNewsConnector:
     def _descriptor(self, *, status: str = "unavailable", note_ru: str = "") -> dict[str, str]:
@@ -540,15 +548,15 @@ def api_media_sources() -> list[dict[str, Any]]:
 @app.post("/api/media/import")
 def api_media_import() -> dict[str, Any]:
     try:
-        return media_import_engine.import_latest()
+        return create_media_import_engine().import_latest()
     except MediaConfigError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @app.get("/api/media/debug")
-def api_media_debug() -> list[dict[str, Any]]:
+def api_media_debug() -> dict[str, Any]:
     try:
-        return media_import_engine.debug_sources()
+        return create_media_import_engine().debug_sources()
     except MediaConfigError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -120,14 +120,17 @@ class YouTubeRssProvider:
             raise MediaImportError(str(resolved["error"]))
         rss_url = str(resolved["rss_url"])
         fetched = self.fetcher(rss_url)
+        logger.info("media_import_rss_fetch source_id=%s rss_url=%s http_status=%s request_status=%s", source.id, rss_url, fetched.response_status, fetched.request_status)
+        resolved_source = replace(source, channel_id=resolved.get("channel_id") or source.channel_id, rss_url=rss_url)
         if not fetched.ok:
-            raise MediaImportError(f"RSS request failed: {fetched.error or fetched.request_status}")
+            return ImportSourceResult(resolved_source, [], fetched.request_status, fetched.response_status, 0, f"RSS request failed: {fetched.error or fetched.request_status}")
         parsed = feedparser.parse(fetched.content)
-        if getattr(parsed, "bozo", False) and not getattr(parsed, "entries", []):
-            raise MediaImportError(f"RSS parse failed: {getattr(parsed, 'bozo_exception', 'unknown parse error')}")
-        items = [self._entry_to_item(entry, source) for entry in getattr(parsed, "entries", [])[:20]]
+        entries = list(getattr(parsed, "entries", []))
+        if getattr(parsed, "bozo", False) and not entries:
+            return ImportSourceResult(resolved_source, [], fetched.request_status, fetched.response_status, 0, f"RSS parse failed: {getattr(parsed, 'bozo_exception', 'unknown parse error')}")
+        items = [self._entry_to_item(entry, source) for entry in entries[:20]]
         items = [item for item in items if item is not None]
-        return ImportSourceResult(replace(source, channel_id=resolved.get("channel_id") or source.channel_id, rss_url=rss_url), items, fetched.request_status, fetched.response_status, len(items))
+        return ImportSourceResult(resolved_source, items, fetched.request_status, fetched.response_status, len(entries))
 
     def resolve_rss(self, source: MediaSource) -> dict[str, Any]:
         if source.rss_url or source.feed_url:
@@ -200,8 +203,8 @@ class MediaImportScheduler:
 
 
 class MediaImportEngine:
-    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None, youtube_provider: YouTubeRssProvider | None = None) -> None:
-        self.sources_path = sources_path; self.catalog_path = catalog_path; self.manual_videos_path = manual_videos_path; self.scheduler = MediaImportScheduler(); self.youtube_provider = youtube_provider or YouTubeRssProvider()
+    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None, youtube_provider: YouTubeRssProvider | None = None, debug_path: Path | None = None) -> None:
+        self.sources_path = sources_path; self.catalog_path = catalog_path; self.manual_videos_path = manual_videos_path; self.debug_path = debug_path or catalog_path.with_name("media_import_debug.json"); self.scheduler = MediaImportScheduler(); self.youtube_provider = youtube_provider or YouTubeRssProvider()
     def load_sources(self) -> list[MediaSource]:
         try: payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
         except FileNotFoundError: return []
@@ -211,30 +214,109 @@ class MediaImportEngine:
     def load_catalog(self) -> list[dict[str, Any]]:
         return self._sort_media(self._dedupe([*(self._read_json_list(self.manual_videos_path) if self.manual_videos_path else []), *self._read_json_list(self.catalog_path)]))
     def import_latest(self) -> dict[str, Any]:
-        sources = [s for s in self.load_sources() if s.enabled]; existing = self.load_catalog(); fetched: list[dict[str, Any]] = []; errors: list[dict[str, str]] = []; processed = 0; failed = 0; now = datetime.now(timezone.utc).isoformat(); updated_sources: list[MediaSource] = []
+        sources = [s for s in self.load_sources() if s.enabled]
+        existing = self.load_catalog()
+        fetched: list[dict[str, Any]] = []
+        errors: list[dict[str, str]] = []
+        processed = 0
+        failed = 0
+        now = datetime.now(timezone.utc).isoformat()
+        run_log: dict[str, Any] = {"started_at": now, "finished_at": None, "sources": []}
+        updated_sources: list[MediaSource] = []
+
         for source in sources:
-            processed += 1; provider = self.resolve_provider(source.provider)
+            processed += 1
+            provider = self.resolve_provider(source.provider)
+            source_log: dict[str, Any] = {
+                "source_id": source.id,
+                "source": source.name,
+                "provider": source.provider,
+                "rss_url": source.rss_url or source.feed_url,
+                "http_status": None,
+                "request_status": "not_requested",
+                "entries_found": 0,
+                "imported_count": 0,
+                "error": None,
+            }
             try:
-                result = provider.fetch_latest(source); fetched.extend(item.payload() for item in result.items)
+                result = provider.fetch_latest(source)
+                source_log.update({
+                    "rss_url": result.source.rss_url or result.source.feed_url or source_log["rss_url"],
+                    "http_status": result.response_status,
+                    "request_status": result.request_status,
+                    "entries_found": result.videos_found,
+                    "imported_count": len(result.items),
+                    "error": result.error,
+                })
+                if result.error:
+                    failed += 1
+                    errors.append({"source": source.name, "reason": result.error})
+                    updated_sources.append(replace(result.source, videos_count=0, last_import=now, last_error=result.error, rss_url=result.source.rss_url or result.source.feed_url, status="error"))
+                    logger.warning("media_import_source_failed source_id=%s rss_url=%s http_status=%s error=%s", source.id, source_log["rss_url"], result.response_status, result.error)
+                    continue
+
+                fetched.extend(item.payload() for item in result.items)
                 updated_sources.append(replace(result.source, videos_count=result.videos_found, last_import=now, last_success=now, last_error=None, rss_url=result.source.rss_url or result.source.feed_url))
-                if result.error: errors.append({"source": source.name, "reason": result.error})
+                logger.info("media_import_source_ok source_id=%s rss_url=%s http_status=%s entries=%s imported=%s", source.id, source_log["rss_url"], result.response_status, result.videos_found, len(result.items))
             except Exception as exc:
-                failed += 1; reason = str(exc); logger.warning("media_import_source_failed source_id=%s error=%s", source.id, reason); errors.append({"source": source.name, "reason": reason}); updated_sources.append(replace(source, last_import=now, last_error="YouTube RSS requires channel_id" if "requires a channel_id" in reason else reason, status="needs_channel_id" if "requires a channel_id" in reason else "error"))
-        merged = self._sort_media(self._dedupe([*existing, *fetched])); before = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in existing}; after = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in merged}
-        self.catalog_path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8"); self._save_sources(updated_sources)
-        return {"success": failed < len(sources) if sources else True, "sources": len(sources), "processed": processed, "imported": len(after - before), "new_items": len(after - before), "updated": max(0, len(fetched) - len(after - before)), "failed": failed, "errors": errors}
-    def debug_sources(self) -> list[dict[str, Any]]:
+                failed += 1
+                reason = str(exc)
+                logger.warning("media_import_source_failed source_id=%s error=%s", source.id, reason)
+                errors.append({"source": source.name, "reason": reason})
+                source_log["error"] = reason
+                updated_sources.append(replace(source, last_import=now, last_error="YouTube RSS requires channel_id" if "requires a channel_id" in reason else reason, status="needs_channel_id" if "requires a channel_id" in reason else "error"))
+            finally:
+                run_log["sources"].append(source_log)
+
+        merged = self._sort_media(self._dedupe([*existing, *fetched]))
+        before = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in existing}
+        after = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in merged}
+        self.catalog_path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
+        self._save_sources(updated_sources)
+        run_log["finished_at"] = datetime.now(timezone.utc).isoformat()
+        self.debug_path.write_text(json.dumps(run_log, ensure_ascii=False, indent=2), encoding="utf-8")
+        imported = len(after - before)
+        return {"success": failed == 0, "processed": processed, "imported": imported, "updated": max(0, len(fetched) - imported), "failed": failed, "errors": errors, "catalog_size": len(merged), "sources": len(sources), "new_items": imported}
+
+    def debug_sources(self) -> dict[str, Any]:
+        last_run = {"started_at": None, "finished_at": None, "sources": []}
+        try:
+            payload = json.loads(self.debug_path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                last_run.update(payload)
+        except Exception:
+            pass
         rows=[]
         for source in self.load_sources():
-            provider = self.resolve_provider(source.provider); resolved = provider.resolve_rss(source) if isinstance(provider, YouTubeRssProvider) else {"provider": provider.provider_name, "error":"provider_not_implemented"}; fetch = FetchResult(False, resolved.get("rss_url"), "not_requested", error=resolved.get("error"))
-            videos=0
-            if resolved.get("rss_url") and source.enabled:
-                fetch = provider.fetcher(str(resolved["rss_url"])) if isinstance(provider, YouTubeRssProvider) else fetch
-                if fetch.ok: videos = len(getattr(feedparser.parse(fetch.content), "entries", []))
+            provider = self.resolve_provider(source.provider)
+            resolved = provider.resolve_rss(source) if isinstance(provider, YouTubeRssProvider) else {"provider": provider.provider_name, "error":"provider_not_implemented"}
             channel_id = resolved.get("channel_id") or source.channel_id
             blocking_reason = "Нужен YouTube channel_id для RSS-импорта" if source.provider == "youtube" and not channel_id else None
-            rows.append({"source": source.name, "channel_url": source.channel_url, "provider": resolved.get("provider", source.provider), "rss_url": resolved.get("rss_url") or source.rss_url, "channel_id": channel_id, "can_import": blocking_reason is None, "blocking_reason": blocking_reason, "request_status": fetch.request_status, "response_status": fetch.response_status, "videos_found": videos, "last_error": fetch.error or source.last_error})
-        return rows
+            matching_logs = [row for row in last_run.get("sources", []) if row.get("source_id") == source.id]
+            last_source_run = matching_logs[-1] if matching_logs else {}
+            rows.append({
+                "source": source.name,
+                "source_id": source.id,
+                "channel_url": source.channel_url,
+                "provider": resolved.get("provider", source.provider),
+                "rss_url": resolved.get("rss_url") or source.rss_url,
+                "channel_id": channel_id,
+                "can_import": blocking_reason is None,
+                "blocking_reason": blocking_reason,
+                "last_import": source.last_import,
+                "last_success": source.last_success,
+                "videos_count": source.videos_count,
+                "last_error": source.last_error,
+                "last_run": {
+                    "rss_url": last_source_run.get("rss_url"),
+                    "http_status": last_source_run.get("http_status"),
+                    "request_status": last_source_run.get("request_status"),
+                    "entries_found": last_source_run.get("entries_found"),
+                    "imported_count": last_source_run.get("imported_count"),
+                    "error": last_source_run.get("error"),
+                },
+            })
+        return {"last_import_run": last_run, "sources": rows}
     def resolve_provider(self, provider: str) -> MediaProvider: return self.youtube_provider if provider == "youtube" else EmptyProvider(provider)
     def _save_sources(self, updates: list[MediaSource]) -> None:
         by_id = {s.id: s for s in updates}; raw = self._read_json_list(self.sources_path); catalog = self.load_catalog()

--- a/app/static/media-admin.html
+++ b/app/static/media-admin.html
@@ -38,6 +38,7 @@
               <p class="section-text">Кнопки Enable / Disable зарезервированы под следующий спринт. Import Now уже вызывает серверный engine.</p>
             </div>
             <div class="tv-source-actions"><button type="button" id="mediaImportNow">Import Now</button></div>
+              <pre id="mediaImportResult" class="media-import-result" aria-live="polite">—</pre>
           </div>
           <div class="tv-source-table-wrap">
             <table class="tv-source-table">

--- a/app/static/media-admin.js
+++ b/app/static/media-admin.js
@@ -2,10 +2,12 @@
   const sourcesBody = document.getElementById('mediaSourcesBody');
   const newestBody = document.getElementById('mediaNewestBody');
   const importButton = document.getElementById('mediaImportNow');
+  const importResult = document.getElementById('mediaImportResult');
   if (!sourcesBody || !newestBody) return;
   const escapeHtml = (value) => String(value ?? '').replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char]));
   const setText = (id, value) => { const el = document.getElementById(id); if (el) el.textContent = value || '—'; };
   const formatValue = (value) => value ? escapeHtml(value) : '—';
+  const showImportResult = (payload) => { if (importResult) importResult.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2); };
 
   function implementationNotice(action, sourceName) { window.alert(`${action}: Implementation in next sprint${sourceName ? ` для ${sourceName}` : ''}.`); }
 
@@ -49,9 +51,21 @@
   sourcesBody.addEventListener('click', (event) => { const button = event.target.closest('button[data-action]'); if (button) implementationNotice(button.dataset.action, button.dataset.source); });
   importButton?.addEventListener('click', () => {
     setText('mediaImportStatus', 'Import running...');
-    fetch('/api/media/import', { method: 'POST', headers: { Accept: 'application/json' } }).then((r) => r.json()).then((payload) => {
-      setText('mediaImportStatus', payload.success ? `Imported: ${payload.new_items} new` : 'Import failed'); refresh();
-    }).catch(() => setText('mediaImportStatus', 'Import failed'));
+    showImportResult('Import running...');
+    fetch('/api/media/import', { method: 'POST', headers: { Accept: 'application/json' } })
+      .then((response) => response.json().catch(() => ({ success: false, errors: [{ reason: 'Invalid JSON response' }] })).then((payload) => {
+        if (!response.ok) throw payload;
+        return payload;
+      }))
+      .then((payload) => {
+        showImportResult(payload);
+        setText('mediaImportStatus', payload.success ? `Imported: ${payload.imported ?? payload.new_items ?? 0} new · catalog: ${payload.catalog_size ?? '—'}` : `Import failed: ${(payload.errors || []).map((e) => e.reason || e).join('; ') || 'unknown error'}`);
+        return refresh();
+      })
+      .catch((error) => {
+        showImportResult(error);
+        setText('mediaImportStatus', `Import failed: ${(error && (error.detail || error.message)) || 'request error'}`);
+      });
   });
   refresh();
 })();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3527,3 +3527,14 @@ body[data-page="tv-sources"] {
     aspect-ratio: 16 / 9;
   }
 }
+.media-import-result {
+  margin-top: 0.75rem;
+  max-width: 520px;
+  white-space: pre-wrap;
+  color: #d8e4ff;
+  background: rgba(5, 10, 24, 0.72);
+  border: 1px solid rgba(103, 132, 255, 0.24);
+  border-radius: 12px;
+  padding: 0.75rem;
+  font-size: 0.82rem;
+}

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -102,7 +102,9 @@ def test_media_import_failure_continues_remaining_sources(tmp_path: Path):
 def test_media_debug_endpoint_contract():
     response = TestClient(app).get("/api/media/debug")
     assert response.status_code == 200
-    assert {"provider", "rss_url", "channel_id", "request_status", "response_status", "videos_found", "last_error"}.issubset(response.json()[0].keys())
+    payload = response.json()
+    assert {"started_at", "finished_at", "sources"}.issubset(payload["last_import_run"].keys())
+    assert {"provider", "rss_url", "channel_id", "can_import", "last_run", "last_error"}.issubset(payload["sources"][0].keys())
 
 
 def _source(channel_url: str, channel_id: str | None = None):
@@ -166,6 +168,6 @@ def test_debug_sources_exposes_blocking_reason_for_missing_channel_id(tmp_path: 
         {"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/@demo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
     ]), encoding="utf-8")
     catalog_path.write_text("[]", encoding="utf-8")
-    row = MediaImportEngine(sources_path, catalog_path).debug_sources()[0]
+    row = MediaImportEngine(sources_path, catalog_path).debug_sources()["sources"][0]
     assert row["can_import"] is False
     assert row["blocking_reason"] == "Нужен YouTube channel_id для RSS-импорта"


### PR DESCRIPTION
### Motivation
- Исправить ситуацию, когда кнопка Import Now не запускала реальный импорт YouTube RSS и не сохраняла результаты в каталог/метаданные источников. 
- Сделать ошибки импортного пайплайна видимыми и диагностируемыми для оператора через админку и отдельный debug-эндпойнт. 
- Сохранить существующие manual-видео в каталоге и не менять UX/торговую логику.

### Description
- Обновлён `MediaImportEngine.import_latest` для последовательного импорта по-источникам с per-source логом (`started_at/finished_at/rss_url/http_status/entries_found/imported_count/error`), записью `data/media_catalog.json` и обновлением `data/media_sources.json` полями `last_import`, `last_success`, `last_error`, `videos_count` и `rss_url`.
- `YouTubeRssProvider.fetch_latest` теперь возвращает `ImportSourceResult` с детальной ошибкой вместо немедленного исключения, логирует HTTP/request status и парсит feedparser-entries в `MediaItem`.
- Добавлен путь для записи runtime debug-файла `data/media_import_debug.json` (исключён из git) и новый формат возвращаемого payload для `debug_sources` — `{"last_import_run": {...}, "sources": [...]}` с per-source last_run.
- API: `POST /api/media/import` и `GET /api/media/debug` теперь создают свежий `MediaImportEngine` и используют новый контракт/логи; `GET /api/media/sources` и `/api/media` сохранены обратносуместными.
- Admin UI: `/admin/media` обновлён так, чтобы `Import Now` вызывал `POST /api/media/import`, отображал сырой JSON/ошибку в интерфейсе и затем обновлял список источников и каталог; добавлены минимальные CSS/markup для вывода результата.
- Тесты и документация: обновлены unit-тесты контрактов `tests/test_media_import_engine.py`, добавлена строка в `README.md` и `.gitignore` для `data/media_import_debug.json`.

### Testing
- Запущен таргетный набор тестов `pytest -q tests/test_media_import_engine.py`, все тесты в этом файле прошли успешно. 
- Выполнен ручной смоук-тест `POST /api/media/import` через `TestClient`, endpoint вернул HTTP 200 с детальным JSON результатов и явными причинами ошибок для каждого источника; в CI-окружении внешние RSS-запросы упёрлись в сетевой Tunnel `403 Forbidden`, поэтому импорт реальных YouTube-плейлистов в этой среде невозможен, но ошибки и логирование отображены корректно. 
- Прогон полного тест-сьюта `pytest` обнаружил не связанное с медиапайплайном падение в `tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, которое не относится к изменений media import; это оставлено как отдельная, существующая проблема.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7adb91a88331b70e3031f0d3ab58)