### PR TITLE
Исправление диагностики импорта медиа: логирование шагов и вызов `import_latest()`

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -548,9 +548,14 @@ def api_media_sources() -> list[dict[str, Any]]:
 @app.post("/api/media/import")
 def api_media_import() -> dict[str, Any]:
     try:
-        return create_media_import_engine().import_latest()
+        engine = create_media_import_engine()
+        return engine.import_latest()
     except MediaConfigError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        logger.exception("media_import_config_failed")
+        raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
+    except Exception as exc:
+        logger.exception("media_import_failed_before_completion")
+        raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
 
 
 @app.get("/api/media/debug")

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -214,14 +214,17 @@ class MediaImportEngine:
     def load_catalog(self) -> list[dict[str, Any]]:
         return self._sort_media(self._dedupe([*(self._read_json_list(self.manual_videos_path) if self.manual_videos_path else []), *self._read_json_list(self.catalog_path)]))
     def import_latest(self) -> dict[str, Any]:
+        now = datetime.now(timezone.utc).isoformat()
+        run_log: dict[str, Any] = {"started_at": now, "finished_at": None, "sources": [], "steps": ["ENTER import_latest()"]}
+        self._persist_debug_run(run_log)
+        logger.info("ENTER import_latest()")
+
         sources = [s for s in self.load_sources() if s.enabled]
         existing = self.load_catalog()
         fetched: list[dict[str, Any]] = []
         errors: list[dict[str, str]] = []
         processed = 0
         failed = 0
-        now = datetime.now(timezone.utc).isoformat()
-        run_log: dict[str, Any] = {"started_at": now, "finished_at": None, "sources": []}
         updated_sources: list[MediaSource] = []
 
         for source in sources:
@@ -239,7 +242,15 @@ class MediaImportEngine:
                 "error": None,
             }
             try:
+                run_log["steps"].append(f"Processing source {source.name}")
+                run_log["steps"].append("Fetching RSS...")
+                logger.info("Processing source %s", source.name)
+                logger.info("Fetching RSS...")
                 result = provider.fetch_latest(source)
+                run_log["steps"].append(f"HTTP {result.response_status if result.response_status is not None else result.request_status}")
+                run_log["steps"].append("Parsing...")
+                logger.info("HTTP %s", result.response_status if result.response_status is not None else result.request_status)
+                logger.info("Parsing...")
                 source_log.update({
                     "rss_url": result.source.rss_url or result.source.feed_url or source_log["rss_url"],
                     "http_status": result.response_status,
@@ -257,13 +268,16 @@ class MediaImportEngine:
 
                 fetched.extend(item.payload() for item in result.items)
                 updated_sources.append(replace(result.source, videos_count=result.videos_found, last_import=now, last_success=now, last_error=None, rss_url=result.source.rss_url or result.source.feed_url))
+                run_log["steps"].append(f"Imported {len(result.items)}")
+                logger.info("Imported %s", len(result.items))
                 logger.info("media_import_source_ok source_id=%s rss_url=%s http_status=%s entries=%s imported=%s", source.id, source_log["rss_url"], result.response_status, result.videos_found, len(result.items))
             except Exception as exc:
                 failed += 1
                 reason = str(exc)
-                logger.warning("media_import_source_failed source_id=%s error=%s", source.id, reason)
-                errors.append({"source": source.name, "reason": reason})
+                logger.exception("media_import_source_failed source_id=%s", source.id)
+                errors.append({"source": source.name, "reason": reason, "exception_type": exc.__class__.__name__})
                 source_log["error"] = reason
+                source_log["exception_type"] = exc.__class__.__name__
                 updated_sources.append(replace(source, last_import=now, last_error="YouTube RSS requires channel_id" if "requires a channel_id" in reason else reason, status="needs_channel_id" if "requires a channel_id" in reason else "error"))
             finally:
                 run_log["sources"].append(source_log)
@@ -271,12 +285,20 @@ class MediaImportEngine:
         merged = self._sort_media(self._dedupe([*existing, *fetched]))
         before = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in existing}
         after = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in merged}
+        run_log["steps"].append("Saving catalog...")
+        logger.info("Saving catalog...")
         self.catalog_path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
         self._save_sources(updated_sources)
         run_log["finished_at"] = datetime.now(timezone.utc).isoformat()
-        self.debug_path.write_text(json.dumps(run_log, ensure_ascii=False, indent=2), encoding="utf-8")
+        run_log["steps"].append("DONE")
+        logger.info("DONE")
+        self._persist_debug_run(run_log)
         imported = len(after - before)
         return {"success": failed == 0, "processed": processed, "imported": imported, "updated": max(0, len(fetched) - imported), "failed": failed, "errors": errors, "catalog_size": len(merged), "sources": len(sources), "new_items": imported}
+
+    def _persist_debug_run(self, run_log: dict[str, Any]) -> None:
+        self.debug_path.parent.mkdir(parents=True, exist_ok=True)
+        self.debug_path.write_text(json.dumps(run_log, ensure_ascii=False, indent=2), encoding="utf-8")
 
     def debug_sources(self) -> dict[str, Any]:
         last_run = {"started_at": None, "finished_at": None, "sources": []}

--- a/app/static/media-admin.js
+++ b/app/static/media-admin.js
@@ -48,8 +48,14 @@
       .catch(() => { sourcesBody.innerHTML = '<tr><td colspan="6">Media Engine временно недоступен.</td></tr>'; newestBody.innerHTML = '<tr><td colspan="5">Каталог временно недоступен.</td></tr>'; });
   }
 
-  sourcesBody.addEventListener('click', (event) => { const button = event.target.closest('button[data-action]'); if (button) implementationNotice(button.dataset.action, button.dataset.source); });
-  importButton?.addEventListener('click', () => {
+  sourcesBody.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    if (button.dataset.action === 'Import Now') { runImport(); return; }
+    implementationNotice(button.dataset.action, button.dataset.source);
+  });
+
+  function runImport() {
     setText('mediaImportStatus', 'Import running...');
     showImportResult('Import running...');
     fetch('/api/media/import', { method: 'POST', headers: { Accept: 'application/json' } })
@@ -66,6 +72,8 @@
         showImportResult(error);
         setText('mediaImportStatus', `Import failed: ${(error && (error.detail || error.message)) || 'request error'}`);
       });
-  });
+  }
+
+  importButton?.addEventListener('click', runImport);
   refresh();
 })();

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -107,6 +107,43 @@ def test_media_debug_endpoint_contract():
     assert {"provider", "rss_url", "channel_id", "can_import", "last_run", "last_error"}.issubset(payload["sources"][0].keys())
 
 
+
+def test_media_import_endpoint_calls_engine_once(monkeypatch):
+    import app.main as main
+
+    calls = []
+
+    class DummyEngine:
+        def import_latest(self):
+            calls.append("import_latest")
+            return {"success": True, "processed": 0, "imported": 0, "updated": 0, "failed": 0, "errors": [], "catalog_size": 0, "sources": 0, "new_items": 0}
+
+    monkeypatch.setattr(main, "create_media_import_engine", lambda: DummyEngine())
+    response = TestClient(app).post("/api/media/import")
+
+    assert response.status_code == 200
+    assert calls == ["import_latest"]
+    assert response.json()["success"] is True
+
+
+def test_import_latest_persists_started_at_before_source_loading_failure(tmp_path: Path):
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    debug_path = tmp_path / "media_import_debug.json"
+    sources_path.write_text(json.dumps({"invalid": "shape"}), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+
+    engine = MediaImportEngine(sources_path, catalog_path, debug_path=debug_path)
+    try:
+        engine.import_latest()
+    except Exception:
+        pass
+
+    payload = json.loads(debug_path.read_text(encoding="utf-8"))
+    assert payload["started_at"]
+    assert payload["finished_at"] is None
+    assert payload["steps"] == ["ENTER import_latest()"]
+
 def _source(channel_url: str, channel_id: str | None = None):
     from app.services.media_import_engine import MediaSource
     return MediaSource("demo", "Demo", "youtube", channel_url, "ru", 1, ["Forex"], True, channel_id=channel_id)


### PR DESCRIPTION
### Motivation
- Найти причину, почему `import_latest()` не запускался и дать точную диагностику выполнения импорта через `/api/media/debug` и админ-интерфейс. 
- Сделать так, чтобы нажатие `Import Now` действительно выполняло `POST /api/media/import`, а не показывало плейсхолдер.
- Не менять архитектуру, а только починить путь выполнения и видимую диагностику.

### Description
- На уровне API `POST /api/media/import` теперь явно создаёт engine и вызывает `create_media_import_engine().import_latest()`; ошибки до завершения возвращают структурированный объект с `error` и `exception_type` и логгируются (`app/main.py`).
- В `MediaImportEngine.import_latest()` добавлена немедленная запись `started_at` и начальный шаг `ENTER import_latest()` который сразу сохраняется в debug-файл; реализована пошаговая запись `steps` (обработка источника, fetch, HTTP, парсинг, импорт, сохранение, DONE) и сохранение через новый метод `_persist_debug_run()` (`app/services/media_import_engine.py`).
- Улучшено логирование исключений и добавление типа исключения в ошибки/отчёт по источнику, чтобы исключения не «глотались» (`app/services/media_import_engine.py`).
- Фронтенд `/admin/media` изменён так, чтобы все кнопки `Import Now` (и строковые, и основная кнопка) выполняли реальный `POST /api/media/import` через общую функцию `runImport()` вместо показа уведомления-реализации в будущем (`app/static/media-admin.js`).
- Добавлены регрессионные тесты, проверяющие, что `POST /api/media/import` вызывает `import_latest()` ровно один раз и что `started_at` сохраняется даже при ошибке чтения sources (`tests/test_media_import_engine.py`).

### Testing
- Запущен набор тестов `pytest -q tests/test_media_import_engine.py`, все тесты прошли: `13 passed`.
- Запущена проверка API через `TestClient` — `POST /api/media/import` возвращает JSON-ответ и `GET /api/media/debug` содержит ненулевой `started_at` и первые шаги `steps`, что доказывает запуск `import_latest()` в рантайме; внешний fetch в этой среде блокируется туннелем (403), поэтому реальные RSS-запросы не импортировали данные. 
- `git diff --check` и линтовые проверки использовались до фикса (без ошибок в изменённых файлах).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7de2b66083319b87f1920739035c)