### PR TITLE
Add YouTube source resolver and admin endpoints for Media Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,3 +473,13 @@ Backend сохраняет реальный уровень индикатора 
 FXPilot 2.0 starts with the **FXPilot Intelligence** philosophy: not just signals, but market understanding backed by facts. The homepage now states this direction, and the public navigation includes the new **FXPilot TV** foundation at `/tv`.
 
 FXPilot TV is currently a premium UX/UI foundation only. It intentionally does not implement YouTube ingestion, backend video processing, or AI video analysis yet. The page describes the future roadmap for video cataloging, AI summaries, FXPilot comparison, Reality Check, Trust Score, Market Memory, and AI Mentor.
+
+## Media Import: YouTube Source Resolver
+
+FXPilot Media Admin can add YouTube sources from a channel URL only. The backend resolves the real `channel_id` from `/channel/UC...`, `@handle`, `/c/...`, or `/user/...` public channel URLs without the YouTube Data API, validates the generated RSS feed, and stores `channel_id`, `rss_url`, feed title, entry count, and resolver diagnostics in `data/media_sources.json`.
+
+Admin endpoints:
+
+- `POST /api/media/resolve-source` — resolve and validate one YouTube channel URL.
+- `POST /api/media/sources` — resolve, validate, duplicate-check, and save a source.
+- `POST /api/media/resolve-all` — re-resolve enabled YouTube sources and refresh stored RSS metadata.

--- a/app/main.py
+++ b/app/main.py
@@ -545,6 +545,32 @@ def api_media_sources() -> list[dict[str, Any]]:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+@app.post("/api/media/resolve-source")
+async def api_media_resolve_source(request: Request) -> dict[str, Any]:
+    payload = await request.json()
+    try:
+        return create_media_import_engine().resolve_source_url(str(payload.get("provider") or ""), str(payload.get("channel_url") or ""))
+    except (MediaConfigError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/media/sources")
+async def api_media_add_source(request: Request) -> dict[str, Any]:
+    payload = await request.json()
+    try:
+        return create_media_import_engine().add_source(payload)
+    except MediaConfigError as exc:
+        raise HTTPException(status_code=409 if "duplicate" in str(exc).lower() else 400, detail=str(exc)) from exc
+
+
+@app.post("/api/media/resolve-all")
+def api_media_resolve_all() -> dict[str, Any]:
+    try:
+        return create_media_import_engine().resolve_all_youtube_sources()
+    except MediaConfigError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 @app.post("/api/media/import")
 def api_media_import() -> dict[str, Any]:
     try:

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -14,6 +14,8 @@ from urllib.request import Request, urlopen
 
 import feedparser
 
+from app.services.youtube_source_resolver import YouTubeSourceResolver
+
 logger = logging.getLogger(__name__)
 
 SUPPORTED_MEDIA_PROVIDERS = {"youtube", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
@@ -48,6 +50,11 @@ class MediaSource:
     last_success: str | None = None
     videos_count: int = 0
     status: str | None = None
+    resolved_from: str | None = None
+    rss_validation_status: str | None = None
+    feed_title: str | None = None
+    entry_count: int = 0
+    last_resolve_error: str | None = None
 
     def public_payload(self, catalog: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         videos = [item for item in (catalog or []) if item.get("source_id") == self.id]
@@ -71,6 +78,11 @@ class MediaSource:
             "last_success": self.last_success,
             "status": status,
             "last_error": self.last_error,
+            "resolved_from": self.resolved_from,
+            "rss_validation_status": self.rss_validation_status,
+            "feed_title": self.feed_title,
+            "entry_count": self.entry_count,
+            "last_resolve_error": self.last_resolve_error,
             "blocking_reason": "Нужен YouTube channel_id для RSS-импорта" if status == "needs_channel_id" else None,
             "can_import": not (self.provider == "youtube" and self.enabled and not self.channel_id),
         }
@@ -114,8 +126,9 @@ class MediaProvider(Protocol):
 
 class YouTubeRssProvider:
     provider_name = "youtube-rss"
-    def __init__(self, fetcher: Callable[[str], FetchResult] | None = None) -> None:
+    def __init__(self, fetcher: Callable[[str], FetchResult] | None = None, resolver: YouTubeSourceResolver | None = None) -> None:
         self.fetcher = fetcher or self._default_fetcher
+        self.resolver = resolver or YouTubeSourceResolver()
 
     def fetch_latest(self, source: MediaSource) -> ImportSourceResult:
         resolved = self.resolve_rss(source)
@@ -176,24 +189,18 @@ class YouTubeRssProvider:
             return base
 
     def resolve_rss(self, source: MediaSource) -> dict[str, Any]:
-        if source.rss_url or source.feed_url:
-            return {"rss_url": source.rss_url or source.feed_url, "channel_id": source.channel_id, "provider": self.provider_name}
+        if source.rss_url and source.channel_id:
+            return {"rss_url": source.rss_url, "channel_id": source.channel_id, "provider": self.provider_name, "resolved_from": source.resolved_from}
+        if source.channel_id:
+            return {"rss_url": YOUTUBE_RSS_BY_CHANNEL.format(channel_id=source.channel_id), "channel_id": source.channel_id, "provider": self.provider_name, "resolved_from": source.resolved_from or "saved_channel_id"}
         parsed = urlparse(source.channel_url)
-        qs = parse_qs(parsed.query)
-        channel_id = source.channel_id or qs.get("channel_id", [None])[0]
-        if channel_id:
-            return {"rss_url": YOUTUBE_RSS_BY_CHANNEL.format(channel_id=channel_id), "channel_id": channel_id, "provider": self.provider_name}
-        channel_match = re.search(r"/(?:channel)/([A-Za-z0-9_-]+)", parsed.path)
-        if channel_match:
-            channel_id = channel_match.group(1)
-            return {"rss_url": YOUTUBE_RSS_BY_CHANNEL.format(channel_id=channel_id), "channel_id": channel_id, "provider": self.provider_name}
         user_match = re.search(r"/user/([^/?#]+)", parsed.path)
         if user_match:
             user = user_match.group(1)
-            return {"rss_url": YOUTUBE_RSS_BY_USER.format(user=user), "channel_id": None, "provider": self.provider_name}
-        if re.search(r"/(?:@|c/)[^/?#]+", parsed.path):
-            return {"rss_url": None, "channel_id": None, "provider": self.provider_name, "error": "YouTube RSS requires a channel_id for @handle or /c/ URLs. Add channel_id to media_sources.json; HTML scraping and YouTube Data API are intentionally not used."}
-        return {"rss_url": None, "channel_id": None, "provider": self.provider_name, "error": "Unsupported YouTube URL for RSS import. Use /channel/UC..., /user/... or provide channel_id."}
+            return {"rss_url": YOUTUBE_RSS_BY_USER.format(user=user), "channel_id": None, "provider": self.provider_name, "resolved_from": "url_user_path"}
+        resolved = self.resolver.resolve(source.channel_url, validate_rss=False)
+        resolved["provider"] = self.provider_name
+        return resolved
 
     def _entry_to_item(self, entry: Any, source: MediaSource) -> MediaItem | None:
         youtube_id = self._entry_video_id(entry)
@@ -410,6 +417,11 @@ class MediaImportEngine:
                 "last_success": source.last_success,
                 "videos_count": source.videos_count,
                 "last_error": source.last_error,
+                "resolved_from": source.resolved_from or resolved.get("resolved_from"),
+                "rss_validation_status": source.rss_validation_status,
+                "feed_title": source.feed_title,
+                "entry_count": source.entry_count,
+                "last_resolve_error": source.last_resolve_error,
                 "last_run": {
                     "rss_url": last_source_run.get("rss_url"),
                     "http_status": last_source_run.get("http_status"),
@@ -430,13 +442,75 @@ class MediaImportEngine:
             return {"source_id": source.id, "source": source.name, "provider": source.provider, "error": "provider_not_implemented"}
         return provider.rss_test(source)
 
+
+    def resolve_source_url(self, provider: str, channel_url: str) -> dict[str, Any]:
+        if provider.lower() != "youtube":
+            raise MediaConfigError("only youtube source resolving is supported")
+        return self.youtube_provider.resolver.resolve(channel_url, validate_rss=True)
+
+    def add_source(self, payload: dict[str, Any]) -> dict[str, Any]:
+        source_id = self._required_str(payload, "id", 0)
+        provider = self._required_str(payload, "provider", 0).lower()
+        if provider != "youtube":
+            raise MediaConfigError("only youtube sources can be added from Media Admin")
+        existing_raw = self._read_json_list(self.sources_path)
+        if any(str(item.get("id")) == source_id for item in existing_raw):
+            raise MediaConfigError(f"duplicate media source id: {source_id}")
+        resolved = self.resolve_source_url(provider, self._required_str(payload, "channel_url", 0))
+        if not resolved.get("ok"):
+            raise MediaConfigError(str(resolved.get("error") or "Unable to resolve YouTube channel_id from URL"))
+        channel_id = str(resolved.get("channel_id"))
+        if any(str(item.get("channel_id") or "") == channel_id for item in existing_raw):
+            raise MediaConfigError(f"duplicate youtube channel_id: {channel_id}")
+        categories = payload.get("categories")
+        if isinstance(categories, str):
+            categories = [v.strip() for v in categories.split(",") if v.strip()]
+        if not isinstance(categories, list) or not categories:
+            raise MediaConfigError("categories must be a non-empty list")
+        item = {
+            "id": source_id, "name": self._required_str(payload, "name", 0), "provider": provider,
+            "channel_url": self._required_str(payload, "channel_url", 0), "language": str(payload.get("language") or "ru").strip(),
+            "priority": int(payload.get("priority") or 1), "categories": [str(v).strip() for v in categories if str(v).strip()],
+            "enabled": bool(payload.get("enabled", True)), "channel_id": channel_id, "rss_url": resolved.get("rss_url"),
+            "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"),
+            "feed_title": resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0),
+            "last_resolve_error": resolved.get("last_resolve_error"),
+        }
+        existing_raw.append(item)
+        self._validate_sources(existing_raw)
+        self.sources_path.write_text(json.dumps(existing_raw, ensure_ascii=False, indent=2), encoding="utf-8")
+        return self._validate_sources([item])[0].public_payload()
+
+    def resolve_all_youtube_sources(self) -> dict[str, Any]:
+        raw = self._read_json_list(self.sources_path)
+        results = []
+        seen_channels: set[str] = set()
+        for item in raw:
+            if str(item.get("provider") or "").lower() != "youtube" or not bool(item.get("enabled")):
+                continue
+            resolved = self.resolve_source_url("youtube", str(item.get("channel_url") or ""))
+            row = {"id": item.get("id"), "name": item.get("name"), **resolved}
+            if resolved.get("ok"):
+                channel_id = str(resolved.get("channel_id"))
+                if channel_id in seen_channels:
+                    row.update({"ok": False, "error": f"duplicate youtube channel_id during resolve-all: {channel_id}"})
+                else:
+                    seen_channels.add(channel_id)
+                    item.update({"channel_id": channel_id, "rss_url": resolved.get("rss_url"), "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"), "feed_title": resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0), "last_resolve_error": resolved.get("last_resolve_error")})
+                    item.pop("last_error", None); item.pop("status", None)
+            else:
+                item.update({"last_resolve_error": resolved.get("error"), "rss_validation_status": "error", "last_error": resolved.get("error"), "status": "error"})
+            results.append(row)
+        self.sources_path.write_text(json.dumps(raw, ensure_ascii=False, indent=2), encoding="utf-8")
+        return {"success": all(r.get("ok") for r in results), "results": results}
+
     def resolve_provider(self, provider: str) -> MediaProvider: return self.youtube_provider if provider == "youtube" else EmptyProvider(provider)
     def _save_sources(self, updates: list[MediaSource]) -> None:
         by_id = {s.id: s for s in updates}; raw = self._read_json_list(self.sources_path); catalog = self.load_catalog()
         for item in raw:
             upd = by_id.get(str(item.get("id")))
             if upd:
-                item.update({"channel_id": upd.channel_id, "rss_url": upd.rss_url or upd.feed_url, "last_error": upd.last_error, "last_import": upd.last_import, "last_success": upd.last_success, "videos_count": len([v for v in catalog if v.get("source_id") == upd.id]), "status": upd.status})
+                item.update({"channel_id": upd.channel_id, "rss_url": upd.rss_url or upd.feed_url, "last_error": upd.last_error, "last_import": upd.last_import, "last_success": upd.last_success, "videos_count": len([v for v in catalog if v.get("source_id") == upd.id]), "status": upd.status, "resolved_from": upd.resolved_from, "rss_validation_status": upd.rss_validation_status, "feed_title": upd.feed_title, "entry_count": upd.entry_count, "last_resolve_error": upd.last_resolve_error})
                 if not upd.last_error:
                     item.pop("last_error", None)
                     item.pop("status", None)
@@ -461,6 +535,9 @@ class MediaImportEngine:
                 enabled=bool(item.get("enabled")), feed_url=item.get("feed_url"), channel_id=item.get("channel_id"),
                 rss_url=item.get("rss_url"), last_error=item.get("last_error"), last_import=item.get("last_import"),
                 last_success=item.get("last_success"), videos_count=int(item.get("videos_count") or 0), status=item.get("status"),
+                resolved_from=item.get("resolved_from"), rss_validation_status=item.get("rss_validation_status"),
+                feed_title=item.get("feed_title"), entry_count=int(item.get("entry_count") or 0),
+                last_resolve_error=item.get("last_resolve_error"),
             ))
         return result
 

--- a/app/services/youtube_source_resolver.py
+++ b/app/services/youtube_source_resolver.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urlunparse, parse_qs
+from urllib.request import Request, urlopen
+
+import feedparser
+
+YOUTUBE_RSS_BY_CHANNEL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
+CHANNEL_ID_RE = re.compile(r"UC[A-Za-z0-9_-]{4,30}")
+
+@dataclass
+class HttpResult:
+    ok: bool
+    url: str
+    status: int | None = None
+    content: bytes = b""
+    headers: dict[str, str] = field(default_factory=dict)
+    error: str | None = None
+
+class YouTubeSourceResolver:
+    def __init__(self, fetcher: Callable[[str, str], HttpResult] | None = None) -> None:
+        self.fetcher = fetcher or self._default_fetcher
+
+    def resolve(self, channel_url: str, validate_rss: bool = True) -> dict[str, Any]:
+        normalized = self.normalize_url(channel_url)
+        channel_id = self._extract_channel_id_from_url(normalized)
+        resolved_from = "url_channel_path" if channel_id else None
+        if not channel_id:
+            fetched = self.fetcher(normalized, "html")
+            if not fetched.ok:
+                return self._error(f"Unable to resolve YouTube channel_id from URL: {fetched.error or fetched.status or 'request failed'}. YouTube RSS requires a channel_id resolved from the channel URL", normalized)
+            html = fetched.content.decode("utf-8", errors="replace")
+            extracted = self.extract_channel_id_from_html(html)
+            channel_id = extracted[0] if extracted else None
+            resolved_from = extracted[1] if extracted else None
+        if not channel_id:
+            return self._error("Unable to resolve YouTube channel_id from URL", normalized)
+        rss_url = YOUTUBE_RSS_BY_CHANNEL.format(channel_id=channel_id)
+        result: dict[str, Any] = {"ok": True, "channel_id": channel_id, "rss_url": rss_url, "resolved_from": resolved_from, "error": None, "normalized_url": normalized}
+        if validate_rss:
+            result.update(self.validate_rss(rss_url))
+        return result
+
+    @staticmethod
+    def normalize_url(channel_url: str) -> str:
+        value = str(channel_url or "").strip()
+        if not value:
+            raise ValueError("channel_url is required")
+        if not re.match(r"^https?://", value, re.I):
+            value = "https://" + value
+        parsed = urlparse(value)
+        if "youtube.com" not in parsed.netloc.lower() and "youtu.be" not in parsed.netloc.lower():
+            raise ValueError("Only YouTube channel URLs are supported")
+        path = re.sub(r"/+$", "", parsed.path or "/")
+        return urlunparse(("https", parsed.netloc.lower().replace("m.youtube.com", "www.youtube.com"), path, "", parsed.query, ""))
+
+    @staticmethod
+    def extract_channel_id_from_html(html: str) -> tuple[str, str] | None:
+        patterns = [
+            (r'"channelId"\s*:\s*"(UC[A-Za-z0-9_-]{4,30})"', "html_channelId"),
+            (r'"externalId"\s*:\s*"(UC[A-Za-z0-9_-]{4,30})"', "html_externalId"),
+            (r'<meta[^>]+itemprop=["\']channelId["\'][^>]+content=["\'](UC[A-Za-z0-9_-]{4,30})["\']', "meta_channelId"),
+            (r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\'][^"\']*/channel/(UC[A-Za-z0-9_-]{4,30})["\']', "canonical_channel"),
+            (r'https://www\.youtube\.com/channel/(UC[A-Za-z0-9_-]{4,30})', "canonical_channel"),
+        ]
+        for pattern, source in patterns:
+            match = re.search(pattern, html)
+            if match:
+                return match.group(1), source
+        return None
+
+    def validate_rss(self, rss_url: str) -> dict[str, Any]:
+        fetched = self.fetcher(rss_url, "rss")
+        content_type = next((v for k, v in fetched.headers.items() if k.lower() == "content-type"), None)
+        base: dict[str, Any] = {"rss_validation_status": "error", "http_status": fetched.status, "content_type": content_type, "feed_title": None, "entry_count": 0, "last_resolve_error": fetched.error}
+        if not fetched.ok or fetched.status != 200:
+            base["error"] = f"RSS validation failed: HTTP {fetched.status or fetched.error or 'request error'}"
+            return base
+        body = fetched.content or b""
+        if not ("xml" in str(content_type or "").lower() or body.lstrip().startswith(b"<")):
+            base["error"] = "RSS validation failed: response is not XML/feed content"
+            return base
+        parsed = feedparser.parse(body)
+        entries = list(getattr(parsed, "entries", []))
+        feed = getattr(parsed, "feed", {})
+        base.update({"rss_validation_status": "ok", "feed_title": getattr(feed, "get", lambda *_: None)("title"), "entry_count": len(entries), "last_resolve_error": None})
+        return base
+
+    @staticmethod
+    def _extract_channel_id_from_url(url: str) -> str | None:
+        parsed = urlparse(url)
+        qs_id = parse_qs(parsed.query).get("channel_id", [None])[0]
+        if qs_id and CHANNEL_ID_RE.fullmatch(qs_id):
+            return qs_id
+        match = re.search(r"/channel/(UC[A-Za-z0-9_-]{4,30})(?:/|$)", parsed.path)
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _error(error: str, normalized_url: str | None = None) -> dict[str, Any]:
+        return {"ok": False, "channel_id": None, "rss_url": None, "resolved_from": None, "error": error, "normalized_url": normalized_url}
+
+    @staticmethod
+    def _default_fetcher(url: str, kind: str) -> HttpResult:
+        accept = "text/html,*/*" if kind == "html" else "application/rss+xml, application/xml;q=0.9, */*;q=0.8"
+        try:
+            req = Request(url, headers={"User-Agent": "Mozilla/5.0", "Accept": accept})
+            with urlopen(req, timeout=15) as response:
+                return HttpResult(True, url, getattr(response, "status", None), response.read(), dict(response.headers.items()))
+        except HTTPError as exc:
+            return HttpResult(False, url, exc.code, exc.read() if hasattr(exc, "read") else b"", dict(exc.headers.items()) if exc.headers else {}, str(exc))
+        except (URLError, TimeoutError, OSError) as exc:
+            return HttpResult(False, url, error=str(exc))

--- a/app/static/media-admin.html
+++ b/app/static/media-admin.html
@@ -17,7 +17,7 @@
           </div>
           <div class="tv-hero__signal" aria-label="Статус импорта">
             <span class="tv-live-dot"></span><strong id="mediaImportStatus">Engine ready</strong>
-            <p>Архитектура готова к регулярным обновлениям без YouTube Data API и без scraping HTML.</p>
+            <p>Архитектура готова к регулярным обновлениям без YouTube Data API: channel_id определяется автоматически по URL канала.</p>
           </div>
         </div>
       </header>
@@ -28,6 +28,26 @@
           <article><span>Imported videos</span><strong id="mediaStatVideos">—</strong></article>
           <article><span>Last update</span><strong id="mediaStatLastUpdate">—</strong></article>
           <article><span>Newest media</span><strong id="mediaStatNewest">—</strong></article>
+        </section>
+
+
+        <section class="panel tv-source-panel" aria-labelledby="mediaAddTitle">
+          <div class="section-heading split-heading">
+            <div><p class="section-kicker">Add source</p><h2 id="mediaAddTitle">Добавить YouTube-источник</h2><p class="section-text">Введите только URL канала — FXPilot определит channel_id, проверит RSS и сохранит валидный источник.</p></div>
+            <div class="tv-source-actions"><button type="button" id="mediaResolveAll">Re-resolve all YouTube sources</button></div>
+          </div>
+          <form id="mediaSourceForm" class="media-source-form">
+            <label>ID<input name="id" placeholder="gerchik" required /></label>
+            <label>Название<input name="name" placeholder="Gerchik & Co" required /></label>
+            <label>Provider<select name="provider"><option value="youtube">youtube</option></select></label>
+            <label>URL канала<input name="channel_url" placeholder="https://www.youtube.com/@channel" required /></label>
+            <label>Язык<input name="language" value="ru" required /></label>
+            <label>Категории<input name="categories" placeholder="Forex, Smart Money" required /></label>
+            <label>Priority<input name="priority" type="number" value="1" min="1" /></label>
+            <label class="media-check"><input name="enabled" type="checkbox" checked /> Enabled</label>
+            <div class="tv-source-actions"><button type="button" id="mediaResolveSource">Resolve</button><button type="submit">Save Source</button><button type="button" id="mediaImportNowForm">Import Now</button></div>
+          </form>
+          <pre id="mediaResolveResult" class="media-import-result" aria-live="polite">—</pre>
         </section>
 
         <section class="panel tv-source-panel" aria-labelledby="mediaSourcesTitle">

--- a/app/static/media-admin.js
+++ b/app/static/media-admin.js
@@ -3,12 +3,16 @@
   const newestBody = document.getElementById('mediaNewestBody');
   const importButton = document.getElementById('mediaImportNow');
   const importResult = document.getElementById('mediaImportResult');
+  const sourceForm = document.getElementById('mediaSourceForm');
+  const resolveResult = document.getElementById('mediaResolveResult');
   if (!sourcesBody || !newestBody) return;
   const escapeHtml = (value) => String(value ?? '').replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char]));
   const setText = (id, value) => { const el = document.getElementById(id); if (el) el.textContent = value || '—'; };
   const formatValue = (value) => value ? escapeHtml(value) : '—';
   const showImportResult = (payload) => { if (importResult) importResult.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2); };
 
+  const formPayload = () => { const fd = new FormData(sourceForm); return { id: fd.get('id'), name: fd.get('name'), provider: fd.get('provider') || 'youtube', channel_url: fd.get('channel_url'), language: fd.get('language') || 'ru', categories: String(fd.get('categories') || '').split(',').map((v) => v.trim()).filter(Boolean), priority: Number(fd.get('priority') || 1), enabled: Boolean(fd.get('enabled')) }; };
+  const showResolve = (payload) => { if (resolveResult) resolveResult.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2); };
   function implementationNotice(action, sourceName) { window.alert(`${action}: Implementation in next sprint${sourceName ? ` для ${sourceName}` : ''}.`); }
 
   function renderSources(sources) {
@@ -75,5 +79,26 @@
   }
 
   importButton?.addEventListener('click', runImport);
+  document.getElementById('mediaImportNowForm')?.addEventListener('click', runImport);
+  document.getElementById('mediaResolveSource')?.addEventListener('click', () => {
+    const payload = formPayload();
+    showResolve('Resolving...');
+    fetch('/api/media/resolve-source', { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: JSON.stringify({ provider: payload.provider, channel_url: payload.channel_url }) })
+      .then((r) => r.json().then((data) => { if (!r.ok) throw data; return data; }))
+      .then(showResolve).catch(showResolve);
+  });
+  sourceForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    showResolve('Saving...');
+    fetch('/api/media/sources', { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: JSON.stringify(formPayload()) })
+      .then((r) => r.json().then((data) => { if (!r.ok) throw data; return data; }))
+      .then((payload) => { showResolve(payload); sourceForm.reset(); return refresh(); }).catch(showResolve);
+  });
+  document.getElementById('mediaResolveAll')?.addEventListener('click', () => {
+    showResolve('Re-resolving all YouTube sources...');
+    fetch('/api/media/resolve-all', { method: 'POST', headers: { Accept: 'application/json' } })
+      .then((r) => r.json().then((data) => { if (!r.ok) throw data; return data; }))
+      .then((payload) => { showResolve(payload); return refresh(); }).catch(showResolve);
+  });
   refresh();
 })();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3538,3 +3538,4 @@ body[data-page="tv-sources"] {
   padding: 0.75rem;
   font-size: 0.82rem;
 }
+.media-source-form{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:12px;margin-top:14px}.media-source-form label{display:grid;gap:6px;color:#90a4c3;font-size:.82rem;text-transform:uppercase;letter-spacing:.06em}.media-source-form input,.media-source-form select{border:1px solid rgba(104,143,191,.24);background:rgba(8,18,30,.9);color:#e8eef8;border-radius:12px;padding:11px}.media-source-form .media-check{display:flex;align-items:center;gap:10px;text-transform:none;letter-spacing:0}.media-source-form .tv-source-actions{align-items:end}

--- a/tests/test_youtube_source_resolver.py
+++ b/tests/test_youtube_source_resolver.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+
+from app.services.media_import_engine import MediaImportEngine
+from app.services.youtube_source_resolver import HttpResult, YouTubeSourceResolver
+
+CHANNEL_ID = "UC_x5XG1OV2P6uZZ5FSM9Ttw"
+
+
+def test_resolver_extracts_channel_url_without_fetching():
+    calls = []
+    resolver = YouTubeSourceResolver(lambda url, kind: calls.append((url, kind)) or HttpResult(False, url, error="no"))
+    result = resolver.resolve(f"https://www.youtube.com/channel/{CHANNEL_ID}", validate_rss=False)
+    assert result["ok"] is True
+    assert result["channel_id"] == CHANNEL_ID
+    assert result["rss_url"].endswith(f"channel_id={CHANNEL_ID}")
+    assert calls == []
+
+
+def test_resolver_extracts_channel_id_from_sample_html():
+    html = f'<html><script>{{"channelId":"{CHANNEL_ID}"}}</script></html>'.encode()
+    resolver = YouTubeSourceResolver(lambda url, kind: HttpResult(True, url, 200, html, {"Content-Type": "text/html"}))
+    result = resolver.resolve("https://www.youtube.com/@demo", validate_rss=False)
+    assert result["ok"] is True
+    assert result["channel_id"] == CHANNEL_ID
+    assert result["resolved_from"] == "html_channelId"
+
+
+def test_resolver_failed_resolve():
+    resolver = YouTubeSourceResolver(lambda url, kind: HttpResult(True, url, 200, b"<html></html>", {"Content-Type": "text/html"}))
+    result = resolver.resolve("https://www.youtube.com/@missing", validate_rss=False)
+    assert result["ok"] is False
+    assert result["error"] == "Unable to resolve YouTube channel_id from URL"
+
+
+def test_rss_validation_success_and_failure():
+    feed = b"<?xml version='1.0'?><feed xmlns='http://www.w3.org/2005/Atom'><title>Demo Feed</title><entry><title>One</title></entry></feed>"
+    resolver = YouTubeSourceResolver(lambda url, kind: HttpResult(True, url, 200, feed, {"Content-Type": "application/atom+xml"}))
+    ok = resolver.validate_rss("https://www.youtube.com/feeds/videos.xml?channel_id=UCdemo")
+    assert ok["rss_validation_status"] == "ok"
+    assert ok["feed_title"] == "Demo Feed"
+    assert ok["entry_count"] == 1
+
+    bad = YouTubeSourceResolver(lambda url, kind: HttpResult(False, url, 404, b"not found", {"Content-Type": "text/plain"}, "404"))
+    failed = bad.validate_rss("https://www.youtube.com/feeds/videos.xml?channel_id=UCdemo")
+    assert failed["rss_validation_status"] == "error"
+    assert "HTTP 404" in failed["error"]
+
+
+def test_duplicate_source_protection(tmp_path: Path):
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([{"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw","language":"ru","priority":1,"categories":["Forex"],"enabled":True,"channel_id":CHANNEL_ID}]), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+    feed = b"<?xml version='1.0'?><feed xmlns='http://www.w3.org/2005/Atom'><title>Demo</title></feed>"
+    resolver = YouTubeSourceResolver(lambda url, kind: HttpResult(True, url, 200, feed, {"Content-Type": "application/xml"}))
+    engine = MediaImportEngine(sources_path, catalog_path)
+    engine.youtube_provider.resolver = resolver
+    try:
+        engine.add_source({"id":"demo","name":"Other","provider":"youtube","channel_url":"https://www.youtube.com/channel/UCaaaaaaaaaaaaaaaaaaaaaa","language":"ru","priority":1,"categories":["Forex"],"enabled":True})
+    except Exception as exc:
+        assert "duplicate media source id" in str(exc)
+    else:
+        raise AssertionError("duplicate id accepted")


### PR DESCRIPTION
### Motivation
- YouTube channel URLs with handles (`@…`), `/c/`, `/user/` and canonical variants produced unreliable `channel_id` values and caused RSS 404s; admins should not need to manually look up `channel_id` values. 
- Implement a resolver that finds the real `channel_id` from a channel URL (without using the YouTube Data API), validates the RSS feed and makes adding/importing stable and user-friendly.

### Description
- Added `app/services/youtube_source_resolver.py` implementing `YouTubeSourceResolver` which normalizes channel URLs, extracts `channel_id` from `/channel/UC...` paths or by scraping public channel HTML metadata patterns (`"channelId"`, `"externalId"`, `<meta itemprop="channelId" ...>`, canonical `/channel/UC...` links) and validates the resulting RSS feed. 
- Integrated resolver into the media import flow (`app/services/media_import_engine.py`): added resolver-backed logic, new metadata fields on `MediaSource` (`resolved_from`, `rss_validation_status`, `feed_title`, `entry_count`, `last_resolve_error`), methods `resolve_source_url`, `add_source`, and `resolve_all_youtube_sources`, and persisted resolver/RSS diagnostics when saving sources. 
- Exposed API endpoints in `app/main.py`: `POST /api/media/resolve-source` (resolve+validate a single URL), `POST /api/media/sources` (resolve, duplicate-check and save a new source), and `POST /api/media/resolve-all` (re-resolve enabled YouTube sources). 
- Updated Media Admin UI (`app/static/media-admin.html`, `app/static/media-admin.js`, `app/static/styles.css`) to add an Add Source form, Resolve / Save Source / Import Now controls, resolver result display, and a "Re-resolve all YouTube sources" action. 
- Added tests `tests/test_youtube_source_resolver.py` covering direct `/channel/` extraction, HTML metadata extraction, failed resolve, RSS validation success/failure and duplicate-source protection; integrated resolver into existing media import tests.

### Testing
- Compiled changed modules with `python -m py_compile app/services/youtube_source_resolver.py app/services/media_import_engine.py app/main.py` and confirmed no syntax errors. (succeeded)
- Ran targeted unit tests `pytest -q tests/test_youtube_source_resolver.py tests/test_media_import_engine.py`; resolver and media-import related tests passed (all added/changed tests succeeded). (succeeded)
- Ran full test suite during validation and observed a pre-existing, unrelated test failure in `tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`; this failure is outside the scope of the YouTube resolver changes. (unrelated failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c8eb3150083319177146daf2ecb86)