### PR TITLE
Добавить провайдер YouTube Data API для FXPilot TV

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 
+
+## Что обновлено в версии 4.3
+- YouTube-провайдер FXPilot TV переведён с нестабильного RSS на официальный YouTube Data API v3: backend резолвит `@handle`, `/channel/UC...`, `/c/...` и `/user/...`, сохраняет `channel_id`, получает реальные видео через API, нормализует их в существующий `MediaItem` и не меняет TV UI, AI Summary, Reality Check, Trust Score или OrderFlow.
+- Импорт остаётся provider-independent: текущие кнопки Admin UI `Resolve`, `Import`, `Resolve All` используют тот же backend-контракт, а будущие Telegram/RSS/Podcast/Website провайдеры не требуют редизайна Media Engine.
+- Дедупликация YouTube выполняется по `videoId`, повторный импорт скачивает только видео новее последнего импортированного `published_at`, а `/api/media/debug` показывает provider, `quota_used`, `channel_id`, `channel_title`, `videos_found`, `imported` и ошибки последнего запуска.
+
+### Настройка YouTube Data API v3
+1. Откройте Google Cloud Console и создайте новый проект или выберите существующий.
+2. В разделе APIs & Services включите **YouTube Data API v3**.
+3. В разделе Credentials создайте API key и при необходимости ограничьте его по API/доменам окружения.
+4. Добавьте переменную окружения `YOUTUBE_API_KEY=<ваш ключ>` в backend/Render Environment.
+5. Перезапустите backend, затем в `/admin/media` используйте `Resolve`, `Resolve All` или `Import`. Если ключ отсутствует, backend вернёт явную ошибку `YOUTUBE_API_KEY is required for YouTube Data API import` без fallback на RSS/scraping.
+
 ## Что обновлено в версии 4.2
 - YouTube источники FXPilot TV теперь содержат явные `channel_id` и `rss_url`; импорт строит RSS по `channel_id`, а источники без `channel_id` получают статус `needs_channel_id` и понятную диагностику в `/api/media/debug` и `/admin/media`. Добавлен помощник `python scripts/resolve_youtube_channels.py` для ручного поиска отсутствующих ID без YouTube Data API и без HTML scraping в приложении.
 - FXPilot Media Import Engine теперь строит YouTube RSS только из поддерживаемых публичных RSS-идентификаторов: `channel_id`, `/channel/UC...` и legacy `/user/...`; для `@handle` и `/c/...` без `channel_id` возвращается явная диагностика без HTML scraping и без YouTube Data API.

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -83,7 +83,7 @@ class MediaSource:
             "feed_title": self.feed_title,
             "entry_count": self.entry_count,
             "last_resolve_error": self.last_resolve_error,
-            "blocking_reason": "Нужен YouTube channel_id для RSS-импорта" if status == "needs_channel_id" else None,
+            "blocking_reason": "Нужен YouTube API key или корректный channel_id" if status == "needs_channel_id" else None,
             "can_import": not (self.provider == "youtube" and self.enabled and not self.channel_id),
         }
 
@@ -117,6 +117,8 @@ class ImportSourceResult:
     videos_found: int
     error: str | None = None
     parser_diagnostic: str | None = None
+    quota_used: int | None = None
+    channel_title: str | None = None
 
 
 class MediaProvider(Protocol):
@@ -289,8 +291,12 @@ class MediaImportScheduler:
 
 
 class MediaImportEngine:
-    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None, youtube_provider: YouTubeRssProvider | None = None, debug_path: Path | None = None) -> None:
-        self.sources_path = sources_path; self.catalog_path = catalog_path; self.manual_videos_path = manual_videos_path; self.debug_path = debug_path or catalog_path.with_name("media_import_debug.json"); self.scheduler = MediaImportScheduler(); self.youtube_provider = youtube_provider or YouTubeRssProvider()
+    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None, youtube_provider: MediaProvider | None = None, debug_path: Path | None = None) -> None:
+        self.sources_path = sources_path; self.catalog_path = catalog_path; self.manual_videos_path = manual_videos_path; self.debug_path = debug_path or catalog_path.with_name("media_import_debug.json"); self.scheduler = MediaImportScheduler()
+        if youtube_provider is None:
+            from app.services.providers.youtube_api_provider import YouTubeApiProvider
+            youtube_provider = YouTubeApiProvider()
+        self.youtube_provider = youtube_provider
     def load_sources(self) -> list[MediaSource]:
         try: payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
         except FileNotFoundError: return []
@@ -316,6 +322,8 @@ class MediaImportEngine:
         for source in sources:
             processed += 1
             provider = self.resolve_provider(source.provider)
+            if hasattr(provider, "set_latest_imported_at"):
+                getattr(provider, "set_latest_imported_at")(source.id, self._latest_published_at(existing, source.id))
             source_log: dict[str, Any] = {
                 "source_id": source.id,
                 "source": source.name,
@@ -327,12 +335,15 @@ class MediaImportEngine:
                 "imported_count": 0,
                 "error": None,
                 "parser_diagnostic": None,
+                "quota_used": None,
+                "channel_id": source.channel_id,
+                "channel_title": source.feed_title,
             }
             try:
                 run_log["steps"].append(f"Processing source {source.name}")
-                run_log["steps"].append("Fetching RSS...")
+                run_log["steps"].append("Fetching provider data...")
                 logger.info("Processing source %s", source.name)
-                logger.info("Fetching RSS...")
+                logger.info("Fetching provider data...")
                 result = provider.fetch_latest(source)
                 run_log["steps"].append(f"HTTP {result.response_status if result.response_status is not None else result.request_status}")
                 run_log["steps"].append("Parsing...")
@@ -346,6 +357,9 @@ class MediaImportEngine:
                     "imported_count": len(result.items),
                     "error": result.error,
                     "parser_diagnostic": result.parser_diagnostic,
+                    "quota_used": result.quota_used,
+                    "channel_id": result.source.channel_id,
+                    "channel_title": result.channel_title or result.source.feed_title,
                 })
                 if result.error:
                     failed += 1
@@ -355,7 +369,7 @@ class MediaImportEngine:
                     continue
 
                 fetched.extend(item.payload() for item in result.items)
-                updated_sources.append(replace(result.source, videos_count=result.videos_found, last_import=now, last_success=now, last_error=None, rss_url=result.source.rss_url or result.source.feed_url))
+                updated_sources.append(replace(result.source, videos_count=result.videos_found, last_import=now, last_success=now, last_error=None, rss_url=result.source.rss_url or result.source.feed_url, feed_title=result.channel_title or result.source.feed_title))
                 run_log["steps"].append(f"Imported {len(result.items)}")
                 logger.info("Imported %s", len(result.items))
                 logger.info("media_import_source_ok source_id=%s rss_url=%s http_status=%s entries=%s imported=%s", source.id, source_log["rss_url"], result.response_status, result.videos_found, len(result.items))
@@ -399,9 +413,16 @@ class MediaImportEngine:
         rows=[]
         for source in self.load_sources():
             provider = self.resolve_provider(source.provider)
-            resolved = provider.resolve_rss(source) if isinstance(provider, YouTubeRssProvider) else {"provider": provider.provider_name, "error":"provider_not_implemented"}
+            if hasattr(provider, "resolve_source"):
+                resolved = getattr(provider, "resolve_source")(source)
+            elif isinstance(provider, YouTubeRssProvider):
+                resolved = provider.resolve_rss(source)
+            else:
+                resolved = {"provider": provider.provider_name, "error":"provider_not_implemented"}
             channel_id = resolved.get("channel_id") or source.channel_id
-            blocking_reason = "Нужен YouTube channel_id для RSS-импорта" if source.provider == "youtube" and not channel_id else None
+            blocking_reason = None
+            if source.provider == "youtube" and resolved.get("error"):
+                blocking_reason = str(resolved.get("error"))
             matching_logs = [row for row in last_run.get("sources", []) if row.get("source_id") == source.id]
             last_source_run = matching_logs[-1] if matching_logs else {}
             rows.append({
@@ -409,6 +430,7 @@ class MediaImportEngine:
                 "source_id": source.id,
                 "channel_url": source.channel_url,
                 "provider": resolved.get("provider", source.provider),
+                "quota_used": last_source_run.get("quota_used"),
                 "rss_url": resolved.get("rss_url") or source.rss_url,
                 "channel_id": channel_id,
                 "can_import": blocking_reason is None,
@@ -419,6 +441,7 @@ class MediaImportEngine:
                 "last_error": source.last_error,
                 "resolved_from": source.resolved_from or resolved.get("resolved_from"),
                 "rss_validation_status": source.rss_validation_status,
+                "channel_title": resolved.get("channel_title") or source.feed_title,
                 "feed_title": source.feed_title,
                 "entry_count": source.entry_count,
                 "last_resolve_error": source.last_resolve_error,
@@ -430,6 +453,12 @@ class MediaImportEngine:
                     "imported_count": last_source_run.get("imported_count"),
                     "error": last_source_run.get("error"),
                     "parser_diagnostic": last_source_run.get("parser_diagnostic"),
+                    "quota_used": last_source_run.get("quota_used"),
+                    "channel_id": last_source_run.get("channel_id"),
+                    "channel_title": last_source_run.get("channel_title"),
+                    "videos_found": last_source_run.get("entries_found"),
+                    "imported": last_source_run.get("imported_count"),
+                    "errors": [last_source_run.get("error")] if last_source_run.get("error") else [],
                 },
             })
         return {"last_import_run": last_run, "sources": rows}
@@ -446,6 +475,8 @@ class MediaImportEngine:
     def resolve_source_url(self, provider: str, channel_url: str) -> dict[str, Any]:
         if provider.lower() != "youtube":
             raise MediaConfigError("only youtube source resolving is supported")
+        if hasattr(self.youtube_provider, "resolve"):
+            return getattr(self.youtube_provider, "resolve")(channel_url)
         return self.youtube_provider.resolver.resolve(channel_url, validate_rss=True)
 
     def add_source(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -473,7 +504,7 @@ class MediaImportEngine:
             "priority": int(payload.get("priority") or 1), "categories": [str(v).strip() for v in categories if str(v).strip()],
             "enabled": bool(payload.get("enabled", True)), "channel_id": channel_id, "rss_url": resolved.get("rss_url"),
             "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"),
-            "feed_title": resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0),
+            "feed_title": resolved.get("channel_title") or resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0),
             "last_resolve_error": resolved.get("last_resolve_error"),
         }
         existing_raw.append(item)
@@ -496,7 +527,7 @@ class MediaImportEngine:
                     row.update({"ok": False, "error": f"duplicate youtube channel_id during resolve-all: {channel_id}"})
                 else:
                     seen_channels.add(channel_id)
-                    item.update({"channel_id": channel_id, "rss_url": resolved.get("rss_url"), "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"), "feed_title": resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0), "last_resolve_error": resolved.get("last_resolve_error")})
+                    item.update({"channel_id": channel_id, "rss_url": resolved.get("rss_url"), "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"), "feed_title": resolved.get("channel_title") or resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0), "last_resolve_error": resolved.get("last_resolve_error")})
                     item.pop("last_error", None); item.pop("status", None)
             else:
                 item.update({"last_resolve_error": resolved.get("error"), "rss_validation_status": "error", "last_error": resolved.get("error"), "status": "error"})
@@ -505,6 +536,11 @@ class MediaImportEngine:
         return {"success": all(r.get("ok") for r in results), "results": results}
 
     def resolve_provider(self, provider: str) -> MediaProvider: return self.youtube_provider if provider == "youtube" else EmptyProvider(provider)
+
+    @staticmethod
+    def _latest_published_at(catalog: list[dict[str, Any]], source_id: str) -> str | None:
+        values = [str(item.get("published_at") or "") for item in catalog if item.get("source_id") == source_id and item.get("published_at")]
+        return max(values) if values else None
     def _save_sources(self, updates: list[MediaSource]) -> None:
         by_id = {s.id: s for s in updates}; raw = self._read_json_list(self.sources_path); catalog = self.load_catalog()
         for item in raw:

--- a/app/services/providers/youtube_api_provider.py
+++ b/app/services/providers/youtube_api_provider.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.request import Request, urlopen
+
+from app.services.media_import_engine import ImportSourceResult, MediaImportError, MediaItem, MediaSource, detect_symbol
+
+YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
+CHANNEL_ID_RE = re.compile(r"UC[A-Za-z0-9_-]{4,30}")
+
+
+class YouTubeApiError(RuntimeError):
+    pass
+
+
+class YouTubeQuotaExceededError(YouTubeApiError):
+    pass
+
+
+class YouTubeApiProvider:
+    """Official YouTube Data API v3 media provider.
+
+    Keeps the provider-independent MediaProvider contract: resolve a configured
+    MediaSource, fetch latest videos, and normalize them into MediaItem objects.
+    """
+
+    provider_name = "youtube"
+
+    def __init__(self, api_key: str | None = None, requester: Callable[[str, dict[str, Any]], dict[str, Any]] | None = None, page_size: int = 25) -> None:
+        self.api_key = api_key if api_key is not None else os.getenv("YOUTUBE_API_KEY")
+        self.requester = requester or self._request
+        self.page_size = max(1, min(int(page_size or 25), 50))
+        self.quota_used = 0
+        self._latest_imported_at_by_source: dict[str, str | None] = {}
+
+    def set_latest_imported_at(self, source_id: str, published_at: str | None) -> None:
+        self._latest_imported_at_by_source[source_id] = published_at
+
+    def fetch_latest(self, source: MediaSource) -> ImportSourceResult:
+        try:
+            resolved = self.resolve_source(source)
+            if not resolved.get("ok"):
+                return ImportSourceResult(source, [], "config_error", None, 0, str(resolved.get("error")), quota_used=self.quota_used)
+            channel_id = str(resolved["channel_id"])
+            channel_title = str(resolved.get("channel_title") or source.name)
+            latest_imported_at = self._latest_imported_at_by_source.get(source.id)
+            videos = self._fetch_channel_videos(channel_id, latest_imported_at)
+            seen: set[str] = set()
+            items: list[MediaItem] = []
+            for video in videos:
+                video_id = str(video.get("id") or "")
+                if not video_id or video_id in seen:
+                    continue
+                seen.add(video_id)
+                item = self._video_to_item(video, source, channel_title)
+                if item:
+                    items.append(item)
+            resolved_source = replace(
+                source,
+                channel_id=channel_id,
+                rss_url=None,
+                resolved_from=resolved.get("resolved_from") or source.resolved_from,
+                feed_title=channel_title,
+                entry_count=len(videos),
+                last_resolve_error=None,
+                rss_validation_status="api_ok",
+            )
+            return ImportSourceResult(resolved_source, items, "ok", 200, len(videos), channel_title=channel_title, quota_used=self.quota_used)
+        except YouTubeQuotaExceededError as exc:
+            return ImportSourceResult(source, [], "quota_exceeded", 403, 0, str(exc), quota_used=self.quota_used)
+        except YouTubeApiError as exc:
+            return ImportSourceResult(source, [], "api_error", None, 0, str(exc), quota_used=self.quota_used)
+
+    def resolve_source(self, source: MediaSource) -> dict[str, Any]:
+        return self.resolve(source.channel_url, source.channel_id)
+
+    def resolve(self, channel_url: str, channel_id: str | None = None) -> dict[str, Any]:
+        if not self.api_key:
+            return {"ok": False, "provider": self.provider_name, "error": "YOUTUBE_API_KEY is required for YouTube Data API import", "channel_id": channel_id}
+        normalized = self.normalize_url(channel_url)
+        found_id = channel_id or self._extract_channel_id_from_url(normalized)
+        resolved_from = "saved_channel_id" if channel_id else ("url_channel_path" if found_id else None)
+        if not found_id:
+            parsed = urlparse(normalized)
+            path = parsed.path.strip("/")
+            if path.startswith("@"):
+                handle = path.split("/", 1)[0]
+                data = self._api_get("channels", {"part": "id,snippet", "forHandle": handle})
+                found_id, title = self._first_channel(data)
+                resolved_from = "api_forHandle"
+                if found_id:
+                    return self._resolved(found_id, title, resolved_from)
+                query = handle.lstrip("@")
+            elif path.startswith("user/"):
+                username = path.split("/", 2)[1]
+                data = self._api_get("channels", {"part": "id,snippet", "forUsername": username})
+                found_id, title = self._first_channel(data)
+                resolved_from = "api_forUsername"
+                if found_id:
+                    return self._resolved(found_id, title, resolved_from)
+                query = username
+            else:
+                query = path.split("/", 1)[-1] if path else normalized
+            data = self._api_get("search", {"part": "snippet", "q": query, "type": "channel", "maxResults": 1})
+            item = next(iter(data.get("items") or []), {})
+            found_id = ((item.get("id") or {}).get("channelId"))
+            title = ((item.get("snippet") or {}).get("channelTitle")) or ((item.get("snippet") or {}).get("title"))
+            resolved_from = resolved_from or "api_channel_search"
+            if found_id:
+                return self._resolved(found_id, title, resolved_from)
+            return {"ok": False, "provider": self.provider_name, "error": "Unable to resolve YouTube channel_id with YouTube Data API", "channel_id": None, "normalized_url": normalized}
+        data = self._api_get("channels", {"part": "snippet", "id": found_id})
+        checked_id, title = self._first_channel(data)
+        if not checked_id:
+            return {"ok": False, "provider": self.provider_name, "error": f"YouTube channel not found: {found_id}", "channel_id": found_id, "normalized_url": normalized}
+        return self._resolved(checked_id, title, resolved_from or "api_channels_id")
+
+    def _fetch_channel_videos(self, channel_id: str, published_after: str | None) -> list[dict[str, Any]]:
+        found: list[dict[str, Any]] = []
+        page_token: str | None = None
+        stop = False
+        while not stop:
+            params: dict[str, Any] = {"part": "snippet", "channelId": channel_id, "type": "video", "order": "date", "maxResults": self.page_size}
+            if page_token:
+                params["pageToken"] = page_token
+            if published_after:
+                params["publishedAfter"] = self._as_rfc3339(published_after)
+            data = self._api_get("search", params)
+            ids: list[str] = []
+            snippets: dict[str, Any] = {}
+            for item in data.get("items") or []:
+                video_id = (item.get("id") or {}).get("videoId")
+                if video_id:
+                    ids.append(video_id); snippets[video_id] = item.get("snippet") or {}
+            if ids:
+                details = self._api_get("videos", {"part": "snippet,contentDetails", "id": ",".join(ids)})
+                for item in details.get("items") or []:
+                    vid = str(item.get("id") or "")
+                    snippet = item.get("snippet") or snippets.get(vid) or {}
+                    found.append({"id": vid, "snippet": snippet, "contentDetails": item.get("contentDetails") or {}})
+            page_token = data.get("nextPageToken")
+            stop = not page_token or bool(published_after)
+        return found
+
+    def _api_get(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise YouTubeApiError("YOUTUBE_API_KEY is required for YouTube Data API import")
+        payload = self.requester(endpoint, {**params, "key": self.api_key})
+        units = 100 if endpoint == "search" else 1
+        self.quota_used += units
+        if isinstance(payload, dict) and payload.get("error"):
+            error = payload["error"]
+            reason = self._error_reason(error)
+            message = error.get("message") if isinstance(error, dict) else str(error)
+            if reason in {"quotaExceeded", "dailyLimitExceeded"}:
+                raise YouTubeQuotaExceededError(f"YouTube API quota exceeded: {message or reason}")
+            raise YouTubeApiError(f"YouTube API error: {message or reason or 'unknown'}")
+        return payload
+
+    def _request(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
+        url = f"{YOUTUBE_API_BASE}/{endpoint}?{urlencode(params)}"
+        try:
+            req = Request(url, headers={"Accept": "application/json"})
+            with urlopen(req, timeout=15) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else ""
+            try:
+                return json.loads(body)
+            except Exception as parse_exc:
+                raise YouTubeApiError(f"YouTube API HTTP {exc.code}: {body or exc}") from parse_exc
+        except (URLError, TimeoutError, OSError) as exc:
+            raise YouTubeApiError(f"YouTube API request failed: {exc}") from exc
+
+    @staticmethod
+    def _video_to_item(video: dict[str, Any], source: MediaSource, channel_title: str) -> MediaItem | None:
+        video_id = str(video.get("id") or "")
+        if not video_id:
+            return None
+        snippet = video.get("snippet") or {}
+        title = str(snippet.get("title") or "Без названия").strip()
+        description = str(snippet.get("description") or "").strip()
+        symbol = detect_symbol(f"{title} {description}")
+        thumbnails = snippet.get("thumbnails") or {}
+        thumb = YouTubeApiProvider._best_thumbnail(thumbnails, video_id)
+        return MediaItem(
+            id=f"youtube:{video_id}", provider="youtube", source_id=source.id, title=title, author=str(snippet.get("channelTitle") or channel_title or source.name),
+            youtube_id=video_id, url=f"https://www.youtube.com/watch?v={video_id}", thumbnail=thumb, published_at=str(snippet.get("publishedAt") or "")[:10] or None,
+            duration=(video.get("contentDetails") or {}).get("duration"), category=source.categories[0] if source.categories else "Market Analysis", symbol=symbol,
+            language=source.language, description=description, tags=[*source.categories, symbol], imported_at=datetime.now(timezone.utc).isoformat()
+        )
+
+    @staticmethod
+    def _best_thumbnail(thumbnails: dict[str, Any], video_id: str) -> str:
+        for key in ("maxres", "standard", "high", "medium", "default"):
+            url = (thumbnails.get(key) or {}).get("url")
+            if url:
+                return str(url)
+        return f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
+
+    @staticmethod
+    def normalize_url(channel_url: str) -> str:
+        value = str(channel_url or "").strip()
+        if not value:
+            raise YouTubeApiError("channel_url is required")
+        if not re.match(r"^https?://", value, re.I):
+            value = "https://" + value
+        parsed = urlparse(value)
+        if "youtube.com" not in parsed.netloc.lower():
+            raise YouTubeApiError("Only youtube.com channel URLs are supported")
+        return parsed._replace(scheme="https", netloc=parsed.netloc.lower().replace("m.youtube.com", "www.youtube.com"), fragment="").geturl().rstrip("/")
+
+    @staticmethod
+    def _extract_channel_id_from_url(url: str) -> str | None:
+        parsed = urlparse(url)
+        qs_id = parse_qs(parsed.query).get("channel_id", [None])[0]
+        if qs_id and CHANNEL_ID_RE.fullmatch(qs_id):
+            return qs_id
+        match = re.search(r"/channel/(UC[A-Za-z0-9_-]{4,30})(?:/|$)", parsed.path)
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _first_channel(data: dict[str, Any]) -> tuple[str | None, str | None]:
+        item = next(iter(data.get("items") or []), None)
+        if not item:
+            return None, None
+        return item.get("id"), (item.get("snippet") or {}).get("title")
+
+    @staticmethod
+    def _resolved(channel_id: str, title: str | None, resolved_from: str | None) -> dict[str, Any]:
+        return {"ok": True, "provider": "youtube", "channel_id": channel_id, "channel_title": title, "feed_title": title, "resolved_from": resolved_from, "rss_url": None, "rss_validation_status": "api_ok", "error": None}
+
+    @staticmethod
+    def _error_reason(error: Any) -> str | None:
+        if not isinstance(error, dict):
+            return None
+        errors = error.get("errors") or []
+        first = errors[0] if errors else {}
+        return first.get("reason") if isinstance(first, dict) else None
+
+    @staticmethod
+    def _as_rfc3339(value: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return text
+        if len(text) == 10:
+            return f"{text}T00:00:00Z"
+        if text.endswith("+00:00"):
+            return text.replace("+00:00", "Z")
+        return text

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -184,7 +184,7 @@ def test_youtube_source_with_channel_id_uses_channel_rss(tmp_path: Path):
     assert requested == ["https://www.youtube.com/feeds/videos.xml?channel_id=UCexplicit"]
 
 
-def test_youtube_source_without_channel_id_returns_needs_channel_id(tmp_path: Path):
+def test_youtube_source_without_api_key_returns_config_error(tmp_path: Path):
     sources_path = tmp_path / "media_sources.json"
     catalog_path = tmp_path / "media_catalog.json"
     sources_path.write_text(json.dumps([
@@ -194,11 +194,11 @@ def test_youtube_source_without_channel_id_returns_needs_channel_id(tmp_path: Pa
     result = MediaImportEngine(sources_path, catalog_path).import_latest()
     source = json.loads(sources_path.read_text(encoding="utf-8"))[0]
     assert result["failed"] == 1
-    assert source["status"] == "needs_channel_id"
-    assert source["last_error"] == "YouTube RSS requires channel_id"
+    assert source["status"] == "error"
+    assert "YOUTUBE_API_KEY" in source["last_error"]
 
 
-def test_debug_sources_exposes_blocking_reason_for_missing_channel_id(tmp_path: Path):
+def test_debug_sources_exposes_api_key_blocking_reason(tmp_path: Path):
     sources_path = tmp_path / "media_sources.json"
     catalog_path = tmp_path / "media_catalog.json"
     sources_path.write_text(json.dumps([
@@ -207,7 +207,7 @@ def test_debug_sources_exposes_blocking_reason_for_missing_channel_id(tmp_path: 
     catalog_path.write_text("[]", encoding="utf-8")
     row = MediaImportEngine(sources_path, catalog_path).debug_sources()["sources"][0]
     assert row["can_import"] is False
-    assert row["blocking_reason"] == "Нужен YouTube channel_id для RSS-импорта"
+    assert "YOUTUBE_API_KEY" in row["blocking_reason"]
 
 
 def test_rss_test_returns_headers_preview_feed_title_and_entry_count(tmp_path: Path):

--- a/tests/test_youtube_api_provider.py
+++ b/tests/test_youtube_api_provider.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+from app.services.media_import_engine import MediaImportEngine, MediaSource
+from app.services.providers.youtube_api_provider import YouTubeApiProvider
+
+
+def source(url="https://youtube.com/@demo", channel_id=None):
+    return MediaSource("demo", "Demo", "youtube", url, "ru", 1, ["Forex"], True, channel_id=channel_id)
+
+
+def test_channel_resolving_handle_with_official_api():
+    calls = []
+    def requester(endpoint, params):
+        calls.append((endpoint, params))
+        assert params["key"] == "key"
+        return {"items": [{"id": "UCdemo12345", "snippet": {"title": "Demo Channel"}}]}
+    provider = YouTubeApiProvider(api_key="key", requester=requester)
+    resolved = provider.resolve("https://youtube.com/@demo")
+    assert resolved["ok"] is True
+    assert resolved["channel_id"] == "UCdemo12345"
+    assert resolved["channel_title"] == "Demo Channel"
+    assert calls[0][0] == "channels"
+    assert calls[0][1]["forHandle"] == "@demo"
+
+
+def test_missing_api_key_returns_clear_error():
+    provider = YouTubeApiProvider(api_key="")
+    result = provider.fetch_latest(source())
+    assert result.request_status == "config_error"
+    assert "YOUTUBE_API_KEY" in result.error
+
+
+def test_api_errors_are_reported():
+    provider = YouTubeApiProvider(api_key="key", requester=lambda *_: {"error": {"message": "bad request", "errors": [{"reason": "badRequest"}]}})
+    result = provider.fetch_latest(source(channel_id="UCdemo12345"))
+    assert result.request_status == "api_error"
+    assert "bad request" in result.error
+
+
+def test_quota_exceeded_is_reported():
+    provider = YouTubeApiProvider(api_key="key", requester=lambda *_: {"error": {"message": "quota", "errors": [{"reason": "quotaExceeded"}]}})
+    result = provider.fetch_latest(source(channel_id="UCdemo12345"))
+    assert result.request_status == "quota_exceeded"
+    assert result.response_status == 403
+    assert "quota exceeded" in result.error.lower()
+
+
+def test_empty_channel_returns_no_items():
+    def requester(endpoint, params):
+        if endpoint == "channels":
+            return {"items": [{"id": "UCdemo12345", "snippet": {"title": "Demo"}}]}
+        return {"items": []}
+    result = YouTubeApiProvider(api_key="key", requester=requester).fetch_latest(source(channel_id="UCdemo12345"))
+    assert result.error is None
+    assert result.videos_found == 0
+    assert result.items == []
+
+
+def test_duplicate_videos_are_removed_by_video_id():
+    def requester(endpoint, params):
+        if endpoint == "channels":
+            return {"items": [{"id": "UCdemo12345", "snippet": {"title": "Demo"}}]}
+        if endpoint == "search":
+            return {"items": [
+                {"id": {"videoId": "v1"}, "snippet": {"title": "EURUSD", "publishedAt": "2026-07-06T00:00:00Z", "channelTitle": "Demo"}},
+                {"id": {"videoId": "v1"}, "snippet": {"title": "EURUSD duplicate", "publishedAt": "2026-07-06T00:00:00Z", "channelTitle": "Demo"}},
+            ]}
+        return {"items": [
+            {"id": "v1", "snippet": {"title": "EURUSD", "publishedAt": "2026-07-06T00:00:00Z", "channelTitle": "Demo"}, "contentDetails": {"duration": "PT5M"}},
+            {"id": "v1", "snippet": {"title": "EURUSD duplicate", "publishedAt": "2026-07-06T00:00:00Z", "channelTitle": "Demo"}, "contentDetails": {"duration": "PT5M"}},
+        ]}
+    result = YouTubeApiProvider(api_key="key", requester=requester).fetch_latest(source(channel_id="UCdemo12345"))
+    assert [item.youtube_id for item in result.items] == ["v1"]
+
+
+def test_incremental_import_uses_latest_catalog_date(tmp_path: Path):
+    calls = []
+    def requester(endpoint, params):
+        calls.append((endpoint, params))
+        if endpoint == "channels":
+            return {"items": [{"id": "UCdemo12345", "snippet": {"title": "Demo"}}]}
+        if endpoint == "search":
+            assert params["publishedAfter"] == "2026-07-06T00:00:00Z"
+            return {"items": [{"id": {"videoId": "v2"}, "snippet": {"title": "XAUUSD", "publishedAt": "2026-07-07T00:00:00Z", "channelTitle": "Demo"}}]}
+        return {"items": [{"id": "v2", "snippet": {"title": "XAUUSD", "publishedAt": "2026-07-07T00:00:00Z", "channelTitle": "Demo"}, "contentDetails": {"duration": "PT6M"}}]}
+    sources_path = tmp_path / "sources.json"
+    catalog_path = tmp_path / "catalog.json"
+    sources_path.write_text(json.dumps([{"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://youtube.com/channel/UCdemo12345","channel_id":"UCdemo12345","language":"ru","priority":1,"categories":["Forex"],"enabled":True}]), encoding="utf-8")
+    catalog_path.write_text(json.dumps([{"id":"youtube:v1","provider":"youtube","source_id":"demo","youtube_id":"v1","published_at":"2026-07-06"}]), encoding="utf-8")
+    engine = MediaImportEngine(sources_path, catalog_path, youtube_provider=YouTubeApiProvider(api_key="key", requester=requester))
+    result = engine.import_latest()
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    assert result["imported"] == 1
+    assert any(item.get("youtube_id") == "v2" for item in catalog)


### PR DESCRIPTION
### Motivation
- Заменить ненадёжный YouTube RSS-импорт на официальный YouTube Data API v3 для стабильного автоматического подтягивания реальных видео. 
- Сохранить существующую «provider‑independent» архитектуру и не менять Media Engine, TV UI или админ‑контракты. 
- Обеспечить корректное разрешение каналов, дедупликацию, инкрементный синк и понятную диагностику ошибок/квоты.

### Description
- Добавлен провайдер `YouTubeApiProvider` в `app/services/providers/youtube_api_provider.py`, который использует официальный YouTube Data API v3, поддерживает разрешение каналов, пагинацию, получение `duration` и детализации видео и нормализует результаты в существующую модель `MediaItem`.
- Media Import Engine (`app/services/media_import_engine.py`) теперь по‑умолчанию использует новый провайдер при отсутствии явной подмены, передаёт провайдеру дату последнего импорта для инкрементного `publishedAfter` запроса и сохраняет/передаёт в debug‑логи `quota_used`, `channel_id`, `channel_title`, `videos_found` и ошибки провайдера.
- Провайдер читает ключ из окружения `YOUTUBE_API_KEY` и возвращает явную ошибку, если ключ отсутствует; поддерживаются URL форматы `https://youtube.com/@...`, `/channel/UC...`, `/c/...` и `/user/...` с разрешением через API (handles, forUsername, search).
- Дедупликация выполняется по `videoId`, импорт скачивает только ролики новее последнего `published_at`, и исходные Admin UI кнопки `Resolve`, `Import`, `Resolve All` остаются неизменными и теперь используют API‑путь в backend.
- Добавлены тесты `tests/test_youtube_api_provider.py` и обновлены медиа‑тесты для отражения поведения API‑провайдера; обновлён `README.md` с инструкцией по созданию Google Cloud project и настройке `YOUTUBE_API_KEY`.

### Testing
- Выполнена компиляция: `python -m py_compile app/services/media_import_engine.py app/services/providers/youtube_api_provider.py` — успешно.
- Запуск модульных тестов: `pytest -q tests/test_youtube_api_provider.py tests/test_media_import_engine.py tests/test_youtube_source_resolver.py` — успешно (все тесты прошли).
- Полный запуск тестового набора `pytest -q` — успешно; итог: `29 passed` (с предупреждениями), нет регрессий в связанных media‑функциях.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c95195dd08331bcfab48f958b0fe5)