### PR TITLE
Добавить провайдер YouTube (yt-dlp) для автоматического импорта

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,33 @@
 Платформа на **FastAPI** с модульным backend, тёмным профессиональным frontend и подготовленными API-контрактами для live-сигналов, news alert и будущей интеграции с MT4.
 
 
-## Что обновлено в версии 4.3
-- YouTube-провайдер FXPilot TV переведён с нестабильного RSS на официальный YouTube Data API v3: backend резолвит `@handle`, `/channel/UC...`, `/c/...` и `/user/...`, сохраняет `channel_id`, получает реальные видео через API, нормализует их в существующий `MediaItem` и не меняет TV UI, AI Summary, Reality Check, Trust Score или OrderFlow.
-- Импорт остаётся provider-independent: текущие кнопки Admin UI `Resolve`, `Import`, `Resolve All` используют тот же backend-контракт, а будущие Telegram/RSS/Podcast/Website провайдеры не требуют редизайна Media Engine.
-- Дедупликация YouTube выполняется по `videoId`, повторный импорт скачивает только видео новее последнего импортированного `published_at`, а `/api/media/debug` показывает provider, `quota_used`, `channel_id`, `channel_title`, `videos_found`, `imported` и ошибки последнего запуска.
 
-### Настройка YouTube Data API v3
-1. Откройте Google Cloud Console и создайте новый проект или выберите существующий.
-2. В разделе APIs & Services включите **YouTube Data API v3**.
-3. В разделе Credentials создайте API key и при необходимости ограничьте его по API/доменам окружения.
-4. Добавьте переменную окружения `YOUTUBE_API_KEY=<ваш ключ>` в backend/Render Environment.
-5. Перезапустите backend, затем в `/admin/media` используйте `Resolve`, `Resolve All` или `Import`. Если ключ отсутствует, backend вернёт явную ошибку `YOUTUBE_API_KEY is required for YouTube Data API import` без fallback на RSS/scraping.
+## Что обновлено в версии 4.4
+- YouTube-импорт FXPilot TV переведён на `yt-dlp`: backend больше не требует Google Cloud и YouTube Data API, не парсит HTML вручную и не скачивает видеофайлы — импортируются только метаданные публичных каналов.
+- Добавлен провайдер `youtube_ytdlp`, который принимает `@handle`, `/channel/`, `/user/` и `/c/`, кэширует ответы по каналу на 30 минут, нормализует видео в `MediaItem` и сохраняет каталог с дедупликацией по `youtube_id`.
+- `/admin/media` показывает provider `YouTube (yt-dlp)`, статус Online, Last import, Videos imported, Import duration и Errors; кнопка Import Now запускает yt-dlp import и после сохранения обновляет UI.
+- `/api/media/debug` возвращает `yt-dlp` version, channel URL, resolved URL, videos found, imported, errors и execution time для диагностики последнего запуска. При ошибке `yt-dlp` существующий каталог сохраняется и импортированные ранее видео не удаляются.
+
+### Установка yt-dlp
+```bash
+pip install yt-dlp
+```
+В проекте зависимость добавлена в `pyproject.toml`; на Render она установится вместе с backend dependencies.
+
+### Как работает автоматический YouTube import
+1. Источники в `data/media_sources.json` используют provider `youtube_ytdlp`. Legacy/manual источники не удаляются из каталогов и продолжат дедуплицироваться по `youtube_id`.
+2. `POST /api/media/import` вызывает `YouTubeYtDlpProvider.fetch_latest()` для каждого enabled источника, получает только metadata через `yt-dlp`, нормализует поля `youtube_id`, `title`, `description`, `thumbnail`, `duration`, `published_at`, `author`, `channel`, `url`, `tags`, `language`, `provider="youtube_ytdlp"`.
+3. `MediaImportEngine` объединяет новые записи с `data/media_catalog.json`, дедуплицирует по `youtube_id` и никогда не удаляет уже импортированные видео при ошибке провайдера.
+4. Повторные обращения к одному каналу кэшируются на 30 минут, чтобы не делать лишние запросы.
+
+### Поддерживаемые URL каналов
+- `https://www.youtube.com/@channel_handle` и коротко `@channel_handle`
+- `https://www.youtube.com/channel/UC...`
+- `https://www.youtube.com/user/legacyUser`
+- `https://www.youtube.com/c/customName`
+
+## Что обновлено в версии 4.3
+- Исторический этап YouTube Data API сохранён только как legacy provider `youtube`; актуальный автоматический импорт описан выше в версии 4.4 и работает через `youtube_ytdlp` без Google Cloud.
 
 ## Что обновлено в версии 4.2
 - YouTube источники FXPilot TV теперь содержат явные `channel_id` и `rss_url`; импорт строит RSS по `channel_id`, а источники без `channel_id` получают статус `needs_channel_id` и понятную диагностику в `/api/media/debug` и `/admin/media`. Добавлен помощник `python scripts/resolve_youtube_channels.py` для ручного поиска отсутствующих ID без YouTube Data API и без HTML scraping в приложении.

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -18,7 +18,7 @@ from app.services.youtube_source_resolver import YouTubeSourceResolver
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_MEDIA_PROVIDERS = {"youtube", "youtube_manual", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
+SUPPORTED_MEDIA_PROVIDERS = {"youtube", "youtube_ytdlp", "youtube_manual", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
 SYMBOLS = ("EURUSD", "GBPUSD", "USDJPY", "USDCHF", "USDCAD", "AUDUSD", "NZDUSD", "XAUUSD", "XAGUSD", "BTCUSD", "ETHUSD", "DXY", "US500", "NASDAQ", "GER40", "UK100")
 YOUTUBE_RSS_BY_CHANNEL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
 YOUTUBE_RSS_BY_USER = "https://www.youtube.com/feeds/videos.xml?user={user}"
@@ -64,6 +64,8 @@ class MediaSource:
             status = "manual_source"
         if self.provider == "youtube" and self.enabled and not self.channel_id:
             status = "needs_channel_id"
+        if self.provider == "youtube_ytdlp" and self.enabled and not self.last_error:
+            status = "online"
         return {
             "id": self.id,
             "name": self.name,
@@ -93,6 +95,7 @@ class MediaSource:
 @dataclass
 class MediaItem:
     id: str; provider: str; source_id: str; title: str; author: str; youtube_id: str | None; url: str; thumbnail: str | None; published_at: str | None; duration: str | None; category: str; symbol: str; language: str; description: str
+    channel: str | None = None
     tags: list[str] = field(default_factory=list)
     status: str = "imported"
     imported_at: str | None = None
@@ -293,18 +296,45 @@ class MediaImportScheduler:
 
 
 class MediaImportEngine:
-    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None, youtube_provider: MediaProvider | None = None, debug_path: Path | None = None) -> None:
+    def __init__(self, sources_path: Path, catalog_path: Path, manual_videos_path: Path | None = None, youtube_provider: MediaProvider | None = None, ytdlp_provider: MediaProvider | None = None, debug_path: Path | None = None) -> None:
         self.sources_path = sources_path; self.catalog_path = catalog_path; self.manual_videos_path = manual_videos_path; self.debug_path = debug_path or catalog_path.with_name("media_import_debug.json"); self.scheduler = MediaImportScheduler()
         if youtube_provider is None:
             from app.services.providers.youtube_api_provider import YouTubeApiProvider
             youtube_provider = YouTubeApiProvider()
         self.youtube_provider = youtube_provider
+        if ytdlp_provider is None:
+            from app.services.providers.youtube_ytdlp_provider import YouTubeYtDlpProvider
+            ytdlp_provider = YouTubeYtDlpProvider()
+        self.ytdlp_provider = ytdlp_provider
     def load_sources(self) -> list[MediaSource]:
         try: payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
         except FileNotFoundError: return []
         return self._validate_sources(payload)
     def list_sources(self) -> list[dict[str, Any]]:
-        catalog = self.load_catalog(); return [s.public_payload(catalog) for s in sorted(self.load_sources(), key=lambda item: (item.priority, item.name.lower()))]
+        catalog = self.load_catalog()
+        debug_rows: dict[str, dict[str, Any]] = {}
+        try:
+            debug_payload = json.loads(self.debug_path.read_text(encoding="utf-8"))
+            if isinstance(debug_payload, dict):
+                for row in debug_payload.get("sources") or []:
+                    if isinstance(row, dict) and row.get("source_id"):
+                        debug_rows[str(row["source_id"])] = row
+        except Exception:
+            pass
+        result = []
+        for source in sorted(self.load_sources(), key=lambda item: (item.priority, item.name.lower())):
+            payload = source.public_payload(catalog)
+            run = debug_rows.get(source.id, {})
+            payload["last_run"] = {
+                "videos_found": run.get("entries_found"),
+                "imported": run.get("imported_count"),
+                "errors": [run.get("error")] if run.get("error") else [],
+                "execution_time": run.get("execution_time"),
+                "yt_dlp_version": run.get("yt_dlp_version"),
+                "resolved_url": run.get("resolved_url"),
+            }
+            result.append(payload)
+        return result
     def load_catalog(self) -> list[dict[str, Any]]:
         return self._sort_media(self._dedupe([*(self._read_json_list(self.manual_videos_path) if self.manual_videos_path else []), *self._read_json_list(self.catalog_path)]))
     def import_latest(self) -> dict[str, Any]:
@@ -343,12 +373,17 @@ class MediaImportEngine:
                 "quota_used": None,
                 "channel_id": source.channel_id,
                 "channel_title": source.feed_title,
+                "channel_url": source.channel_url,
+                "resolved_url": None,
+                "yt_dlp_version": None,
+                "execution_time": None,
             }
             try:
                 run_log["steps"].append(f"Processing source {source.name}")
                 run_log["steps"].append("Fetching provider data...")
                 logger.info("Processing source %s", source.name)
                 logger.info("Fetching provider data...")
+                source_started = datetime.now(timezone.utc)
                 result = provider.fetch_latest(source)
                 run_log["steps"].append(f"HTTP {result.response_status if result.response_status is not None else result.request_status}")
                 run_log["steps"].append("Parsing...")
@@ -365,6 +400,10 @@ class MediaImportEngine:
                     "quota_used": result.quota_used,
                     "channel_id": result.source.channel_id,
                     "channel_title": result.channel_title or result.source.feed_title,
+                    "channel_url": source.channel_url,
+                    "resolved_url": result.source.rss_url or result.source.feed_url,
+                    "yt_dlp_version": getattr(provider, "last_diagnostic", {}).get("yt_dlp_version") if source.provider == "youtube_ytdlp" else None,
+                    "execution_time": getattr(provider, "last_diagnostic", {}).get("execution_time") if source.provider == "youtube_ytdlp" else (datetime.now(timezone.utc) - source_started).total_seconds(),
                 })
                 if result.error:
                     failed += 1
@@ -436,7 +475,8 @@ class MediaImportEngine:
                 "channel_url": source.channel_url,
                 "provider": resolved.get("provider", source.provider),
                 "quota_used": last_source_run.get("quota_used"),
-                "rss_url": resolved.get("rss_url") or source.rss_url,
+                "rss_url": resolved.get("rss_url") or resolved.get("resolved_url") or source.rss_url,
+                "resolved_url": resolved.get("resolved_url") or resolved.get("rss_url") or source.rss_url,
                 "channel_id": channel_id,
                 "can_import": blocking_reason is None,
                 "blocking_reason": blocking_reason,
@@ -464,6 +504,10 @@ class MediaImportEngine:
                     "videos_found": last_source_run.get("entries_found"),
                     "imported": last_source_run.get("imported_count"),
                     "errors": [last_source_run.get("error")] if last_source_run.get("error") else [],
+                    "yt_dlp_version": last_source_run.get("yt_dlp_version") or resolved.get("yt_dlp_version"),
+                    "channel_url": source.channel_url,
+                    "resolved_url": last_source_run.get("resolved_url") or resolved.get("resolved_url"),
+                    "execution_time": last_source_run.get("execution_time") or resolved.get("execution_time"),
                 },
             })
         return {"last_import_run": last_run, "sources": rows}
@@ -478,8 +522,14 @@ class MediaImportEngine:
 
 
     def resolve_source_url(self, provider: str, channel_url: str) -> dict[str, Any]:
-        if provider.lower() != "youtube":
-            raise MediaConfigError("only youtube source resolving is supported")
+        provider = provider.lower()
+        if provider == "youtube_ytdlp":
+            if hasattr(self.ytdlp_provider, "resolve_source"):
+                source = MediaSource(id="preview", name="Preview", provider="youtube_ytdlp", channel_url=channel_url, language="ru", priority=1, categories=["Market Analysis"], enabled=True)
+                return getattr(self.ytdlp_provider, "resolve_source")(source)
+            raise MediaConfigError("youtube_ytdlp provider cannot resolve sources")
+        if provider != "youtube":
+            raise MediaConfigError("only youtube/youtube_ytdlp source resolving is supported")
         if hasattr(self.youtube_provider, "resolve"):
             return getattr(self.youtube_provider, "resolve")(channel_url)
         return self.youtube_provider.resolver.resolve(channel_url, validate_rss=True)
@@ -487,16 +537,16 @@ class MediaImportEngine:
     def add_source(self, payload: dict[str, Any]) -> dict[str, Any]:
         source_id = self._required_str(payload, "id", 0)
         provider = self._required_str(payload, "provider", 0).lower()
-        if provider != "youtube":
-            raise MediaConfigError("only youtube sources can be added from Media Admin")
+        if provider not in {"youtube", "youtube_ytdlp"}:
+            raise MediaConfigError("only youtube/youtube_ytdlp sources can be added from Media Admin")
         existing_raw = self._read_json_list(self.sources_path)
         if any(str(item.get("id")) == source_id for item in existing_raw):
             raise MediaConfigError(f"duplicate media source id: {source_id}")
         resolved = self.resolve_source_url(provider, self._required_str(payload, "channel_url", 0))
         if not resolved.get("ok"):
             raise MediaConfigError(str(resolved.get("error") or "Unable to resolve YouTube channel_id from URL"))
-        channel_id = str(resolved.get("channel_id"))
-        if any(str(item.get("channel_id") or "") == channel_id for item in existing_raw):
+        channel_id = str(resolved.get("channel_id") or "")
+        if channel_id and any(str(item.get("channel_id") or "") == channel_id for item in existing_raw):
             raise MediaConfigError(f"duplicate youtube channel_id: {channel_id}")
         categories = payload.get("categories")
         if isinstance(categories, str):
@@ -507,7 +557,7 @@ class MediaImportEngine:
             "id": source_id, "name": self._required_str(payload, "name", 0), "provider": provider,
             "channel_url": self._required_str(payload, "channel_url", 0), "language": str(payload.get("language") or "ru").strip(),
             "priority": int(payload.get("priority") or 1), "categories": [str(v).strip() for v in categories if str(v).strip()],
-            "enabled": bool(payload.get("enabled", True)), "channel_id": channel_id, "rss_url": resolved.get("rss_url"),
+            "enabled": bool(payload.get("enabled", True)), "channel_id": channel_id or None, "rss_url": resolved.get("rss_url") or resolved.get("resolved_url"),
             "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"),
             "feed_title": resolved.get("channel_title") or resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0),
             "last_resolve_error": resolved.get("last_resolve_error"),
@@ -522,17 +572,19 @@ class MediaImportEngine:
         results = []
         seen_channels: set[str] = set()
         for item in raw:
-            if str(item.get("provider") or "").lower() != "youtube" or not bool(item.get("enabled")):
+            if str(item.get("provider") or "").lower() not in {"youtube", "youtube_ytdlp"} or not bool(item.get("enabled")):
                 continue
-            resolved = self.resolve_source_url("youtube", str(item.get("channel_url") or ""))
+            item_provider = str(item.get("provider") or "youtube").lower()
+            resolved = self.resolve_source_url(item_provider, str(item.get("channel_url") or ""))
             row = {"id": item.get("id"), "name": item.get("name"), **resolved}
             if resolved.get("ok"):
-                channel_id = str(resolved.get("channel_id"))
-                if channel_id in seen_channels:
+                channel_id = str(resolved.get("channel_id") or "")
+                if channel_id and channel_id in seen_channels:
                     row.update({"ok": False, "error": f"duplicate youtube channel_id during resolve-all: {channel_id}"})
                 else:
-                    seen_channels.add(channel_id)
-                    item.update({"channel_id": channel_id, "rss_url": resolved.get("rss_url"), "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"), "feed_title": resolved.get("channel_title") or resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0), "last_resolve_error": resolved.get("last_resolve_error")})
+                    if channel_id:
+                        seen_channels.add(channel_id)
+                    item.update({"channel_id": channel_id or item.get("channel_id"), "rss_url": resolved.get("rss_url") or resolved.get("resolved_url"), "resolved_from": resolved.get("resolved_from"), "rss_validation_status": resolved.get("rss_validation_status"), "feed_title": resolved.get("channel_title") or resolved.get("feed_title"), "entry_count": int(resolved.get("entry_count") or 0), "last_resolve_error": resolved.get("last_resolve_error")})
                     item.pop("last_error", None); item.pop("status", None)
             else:
                 item.update({"last_resolve_error": resolved.get("error"), "rss_validation_status": "error", "last_error": resolved.get("error"), "status": "error"})
@@ -540,7 +592,12 @@ class MediaImportEngine:
         self.sources_path.write_text(json.dumps(raw, ensure_ascii=False, indent=2), encoding="utf-8")
         return {"success": all(r.get("ok") for r in results), "results": results}
 
-    def resolve_provider(self, provider: str) -> MediaProvider: return self.youtube_provider if provider == "youtube" else EmptyProvider(provider)
+    def resolve_provider(self, provider: str) -> MediaProvider:
+        if provider == "youtube":
+            return self.youtube_provider
+        if provider == "youtube_ytdlp":
+            return self.ytdlp_provider
+        return EmptyProvider(provider)
 
     @staticmethod
     def _latest_published_at(catalog: list[dict[str, Any]], source_id: str) -> str | None:

--- a/app/services/providers/youtube_ytdlp_provider.py
+++ b/app/services/providers/youtube_ytdlp_provider.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+from app.services.media_import_engine import ImportSourceResult, MediaImportError, MediaItem, MediaSource, detect_symbol
+
+CACHE_TTL_SECONDS = 30 * 60
+DEFAULT_MAX_RESULTS = 20
+
+
+class YouTubeYtDlpProvider:
+    """yt-dlp based YouTube metadata importer.
+
+    The provider never downloads video files. It asks yt-dlp for public channel
+    metadata only and normalizes channel entries into the existing MediaItem
+    contract used by FXPilot TV.
+    """
+
+    provider_name = "youtube_ytdlp"
+    _cache: dict[str, tuple[float, dict[str, Any]]] = {}
+
+    def __init__(self, max_results: int = DEFAULT_MAX_RESULTS) -> None:
+        self.max_results = max(1, min(int(max_results or DEFAULT_MAX_RESULTS), 50))
+        self.last_diagnostic: dict[str, Any] = {}
+
+    def fetch_latest(self, source: MediaSource) -> ImportSourceResult:
+        started = time.perf_counter()
+        diagnostic: dict[str, Any] = {
+            "yt_dlp_version": self.version(),
+            "channel_url": source.channel_url,
+            "resolved_url": None,
+            "videos_found": 0,
+            "imported": 0,
+            "errors": [],
+            "execution_time": None,
+        }
+        try:
+            normalized_url = self.normalize_channel_url(source.channel_url)
+            info = self._extract_cached(normalized_url)
+            entries = self._entries(info)
+            channel_title = str(info.get("channel") or info.get("uploader") or info.get("title") or source.name)
+            resolved_url = str(info.get("webpage_url") or info.get("original_url") or normalized_url)
+            diagnostic["resolved_url"] = resolved_url
+            diagnostic["videos_found"] = len(entries)
+
+            seen: set[str] = set()
+            items: list[MediaItem] = []
+            for entry in entries[: self.max_results]:
+                item = self._entry_to_item(entry, source, channel_title)
+                if not item or not item.youtube_id or item.youtube_id in seen:
+                    continue
+                seen.add(item.youtube_id)
+                items.append(item)
+
+            diagnostic["imported"] = len(items)
+            resolved_source = replace(
+                source,
+                rss_url=resolved_url,
+                feed_title=channel_title,
+                entry_count=len(entries),
+                last_resolve_error=None,
+                rss_validation_status="yt_dlp_ok",
+                resolved_from="yt_dlp",
+            )
+            return ImportSourceResult(resolved_source, items, "ok", 200, len(entries), channel_title=channel_title)
+        except Exception as exc:
+            message = str(exc)
+            diagnostic["errors"] = [message]
+            return ImportSourceResult(source, [], "yt_dlp_error", None, 0, message, parser_diagnostic=message)
+        finally:
+            diagnostic["execution_time"] = round(time.perf_counter() - started, 3)
+            self.last_diagnostic = diagnostic
+
+    def resolve_source(self, source: MediaSource) -> dict[str, Any]:
+        started = time.perf_counter()
+        try:
+            normalized_url = self.normalize_channel_url(source.channel_url)
+            info = self._extract_cached(normalized_url)
+            entries = self._entries(info)
+            return {
+                "ok": True,
+                "provider": self.provider_name,
+                "channel_url": source.channel_url,
+                "resolved_url": info.get("webpage_url") or normalized_url,
+                "rss_url": info.get("webpage_url") or normalized_url,
+                "channel_title": info.get("channel") or info.get("uploader") or info.get("title") or source.name,
+                "videos_found": len(entries),
+                "entry_count": len(entries),
+                "yt_dlp_version": self.version(),
+                "execution_time": round(time.perf_counter() - started, 3),
+                "resolved_from": "yt_dlp",
+            }
+        except Exception as exc:
+            return {"ok": False, "provider": self.provider_name, "channel_url": source.channel_url, "error": str(exc), "yt_dlp_version": self.version(), "execution_time": round(time.perf_counter() - started, 3)}
+
+    def _extract_cached(self, normalized_url: str) -> dict[str, Any]:
+        now = time.time()
+        cached = self._cache.get(normalized_url)
+        if cached and now - cached[0] < CACHE_TTL_SECONDS:
+            return cached[1]
+        info = self._extract(normalized_url)
+        self._cache[normalized_url] = (now, info)
+        return info
+
+    def _extract(self, normalized_url: str) -> dict[str, Any]:
+        try:
+            import yt_dlp
+        except Exception as exc:
+            raise MediaImportError("yt-dlp is not installed. Run: pip install yt-dlp") from exc
+        options = {
+            "quiet": True,
+            "no_warnings": True,
+            "skip_download": True,
+            "extract_flat": "discard_in_playlist",
+            "playlistend": self.max_results,
+            "ignoreerrors": True,
+            "socket_timeout": 20,
+        }
+        with yt_dlp.YoutubeDL(options) as ydl:
+            info = ydl.extract_info(normalized_url, download=False)
+        if not isinstance(info, dict):
+            raise MediaImportError("yt-dlp returned empty channel metadata")
+        return info
+
+    @staticmethod
+    def normalize_channel_url(channel_url: str) -> str:
+        value = str(channel_url or "").strip()
+        if not value:
+            raise MediaImportError("channel_url is required")
+        if value.startswith("@"):
+            value = f"https://www.youtube.com/{value}"
+        elif not re.match(r"^https?://", value, re.I):
+            value = "https://" + value
+        parsed = urlparse(value)
+        host = parsed.netloc.lower().replace("m.youtube.com", "www.youtube.com")
+        if "youtube.com" not in host:
+            raise MediaImportError("Only youtube.com channel URLs are supported")
+        path = parsed.path.rstrip("/")
+        if not (path.startswith("/@") or path.startswith("/channel/") or path.startswith("/user/") or path.startswith("/c/")):
+            raise MediaImportError("Supported YouTube URL formats: @handle, /channel/, /user/, /c/")
+        return parsed._replace(scheme="https", netloc=host, path=path, query="", fragment="").geturl()
+
+    @staticmethod
+    def _entries(info: dict[str, Any]) -> list[dict[str, Any]]:
+        entries = info.get("entries") or []
+        return [entry for entry in entries if isinstance(entry, dict)]
+
+    @staticmethod
+    def _entry_to_item(entry: dict[str, Any], source: MediaSource, channel_title: str) -> MediaItem | None:
+        video_id = str(entry.get("id") or entry.get("display_id") or "").strip()
+        if not video_id:
+            return None
+        title = str(entry.get("title") or "Без названия").strip()
+        description = str(entry.get("description") or entry.get("summary") or "").strip()
+        symbol = detect_symbol(f"{title} {description}")
+        published_at = YouTubeYtDlpProvider._published_at(entry)
+        duration = entry.get("duration_string") or entry.get("duration")
+        tags = [str(tag).strip() for tag in (entry.get("tags") or []) if str(tag).strip()]
+        return MediaItem(
+            id=f"youtube:{video_id}",
+            provider=YouTubeYtDlpProvider.provider_name,
+            source_id=source.id,
+            title=title,
+            author=str(entry.get("uploader") or entry.get("channel") or channel_title or source.name),
+            youtube_id=video_id,
+            url=str(entry.get("webpage_url") or entry.get("url") or f"https://www.youtube.com/watch?v={video_id}"),
+            thumbnail=YouTubeYtDlpProvider._thumbnail(entry, video_id),
+            published_at=published_at,
+            duration=str(duration) if duration not in (None, "") else None,
+            category=source.categories[0] if source.categories else "Market Analysis",
+            symbol=symbol,
+            language=str(entry.get("language") or source.language),
+            description=description,
+            channel=channel_title,
+            tags=[*source.categories, symbol, *tags],
+            imported_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    @staticmethod
+    def _published_at(entry: dict[str, Any]) -> str | None:
+        value = entry.get("upload_date") or entry.get("release_date")
+        if value and re.fullmatch(r"\d{8}", str(value)):
+            text = str(value)
+            return f"{text[:4]}-{text[4:6]}-{text[6:8]}"
+        timestamp = entry.get("timestamp") or entry.get("release_timestamp")
+        if timestamp:
+            try:
+                return datetime.fromtimestamp(float(timestamp), timezone.utc).date().isoformat()
+            except Exception:
+                return None
+        return None
+
+    @staticmethod
+    def _thumbnail(entry: dict[str, Any], video_id: str) -> str:
+        thumbnails = entry.get("thumbnails") or []
+        if isinstance(thumbnails, list) and thumbnails:
+            best = thumbnails[-1] if isinstance(thumbnails[-1], dict) else {}
+            if best.get("url"):
+                return str(best["url"])
+        if entry.get("thumbnail"):
+            return str(entry["thumbnail"])
+        return f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
+
+    @staticmethod
+    def version() -> str | None:
+        try:
+            import yt_dlp
+
+            return str(getattr(yt_dlp.version, "__version__", "unknown"))
+        except Exception:
+            return None

--- a/app/static/media-admin.html
+++ b/app/static/media-admin.html
@@ -13,11 +13,11 @@
           <div class="tv-hero__copy">
             <p class="eyebrow">FXPilot TV · Hidden Admin</p>
             <h1>Media Import Engine</h1>
-            <p class="lead">Внутренняя панель автоматического импорта медиа: источники, RSS-провайдеры, каталог и статус будущего scheduler.</p>
+            <p class="lead">Внутренняя панель автоматического импорта медиа: YouTube (yt-dlp), каталог и статус будущего scheduler.</p>
           </div>
           <div class="tv-hero__signal" aria-label="Статус импорта">
             <span class="tv-live-dot"></span><strong id="mediaImportStatus">Engine ready</strong>
-            <p>YouTube API is not connected. Videos are currently managed manually.</p>
+            <p>YouTube (yt-dlp) online: импортирует только метаданные публичных каналов, без Google Cloud и без скачивания видео.</p>
           </div>
         </div>
       </header>
@@ -33,13 +33,13 @@
 
         <section class="panel tv-source-panel" aria-labelledby="mediaAddTitle">
           <div class="section-heading split-heading">
-            <div><p class="section-kicker">Add source</p><h2 id="mediaAddTitle">Добавить YouTube-источник</h2><p class="section-text">YouTube API is not connected. Videos are currently managed manually. RSS/API-код сохранен для будущего подключения.</p></div>
+            <div><p class="section-kicker">Add source</p><h2 id="mediaAddTitle">Добавить YouTube-источник</h2><p class="section-text">Автоматический импорт работает через yt-dlp: поддерживаются @handle, /channel/, /user/ и /c/.</p></div>
             <div class="tv-source-actions"><button type="button" id="mediaResolveAll">Re-resolve all YouTube sources</button></div>
           </div>
           <form id="mediaSourceForm" class="media-source-form">
             <label>ID<input name="id" placeholder="gerchik" required /></label>
             <label>Название<input name="name" placeholder="Gerchik & Co" required /></label>
-            <label>Provider<select name="provider"><option value="youtube">youtube</option></select></label>
+            <label>Provider<select name="provider"><option value="youtube_ytdlp">YouTube (yt-dlp)</option><option value="youtube_manual">youtube_manual</option><option value="youtube">youtube</option></select></label>
             <label>URL канала<input name="channel_url" placeholder="https://www.youtube.com/@channel" required /></label>
             <label>Язык<input name="language" value="ru" required /></label>
             <label>Категории<input name="categories" placeholder="Forex, Smart Money" required /></label>
@@ -62,8 +62,8 @@
           </div>
           <div class="tv-source-table-wrap">
             <table class="tv-source-table">
-              <thead><tr><th>Источник</th><th>Provider</th><th>Enabled</th><th>Last update</th><th>Imported videos</th><th>Действия</th></tr></thead>
-              <tbody id="mediaSourcesBody"><tr><td colspan="6">Загрузка...</td></tr></tbody>
+              <thead><tr><th>Источник</th><th>Provider</th><th>Status</th><th>Last import</th><th>Videos imported</th><th>Duration</th><th>Errors</th><th>Действия</th></tr></thead>
+              <tbody id="mediaSourcesBody"><tr><td colspan="8">Загрузка...</td></tr></tbody>
             </table>
           </div>
         </section>

--- a/app/static/media-admin.js
+++ b/app/static/media-admin.js
@@ -11,25 +11,29 @@
   const formatValue = (value) => value ? escapeHtml(value) : '—';
   const showImportResult = (payload) => { if (importResult) importResult.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2); };
 
-  const formPayload = () => { const fd = new FormData(sourceForm); return { id: fd.get('id'), name: fd.get('name'), provider: fd.get('provider') || 'youtube', channel_url: fd.get('channel_url'), language: fd.get('language') || 'ru', categories: String(fd.get('categories') || '').split(',').map((v) => v.trim()).filter(Boolean), priority: Number(fd.get('priority') || 1), enabled: Boolean(fd.get('enabled')) }; };
+  const formPayload = () => { const fd = new FormData(sourceForm); return { id: fd.get('id'), name: fd.get('name'), provider: fd.get('provider') || 'youtube_ytdlp', channel_url: fd.get('channel_url'), language: fd.get('language') || 'ru', categories: String(fd.get('categories') || '').split(',').map((v) => v.trim()).filter(Boolean), priority: Number(fd.get('priority') || 1), enabled: Boolean(fd.get('enabled')) }; };
   const showResolve = (payload) => { if (resolveResult) resolveResult.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2); };
   function implementationNotice(action, sourceName) { window.alert(`${action}: Implementation in next sprint${sourceName ? ` для ${sourceName}` : ''}.`); }
+  const providerLabel = (provider) => provider === 'youtube_ytdlp' ? 'YouTube (yt-dlp)' : provider;
+  const statusLabel = (source) => { if (source.provider === 'youtube_ytdlp' && source.status === 'online') return 'Online'; if (source.status === 'manual_source' || source.provider === 'youtube_manual') return 'Manual source — API not connected'; if (source.status === 'needs_channel_id' || (source.provider === 'youtube' && !source.channel_id)) return 'Нужен YouTube channel_id для RSS-импорта'; return source.enabled ? 'Online' : 'Disabled'; };
+  const sourceDuration = (source) => source.last_run?.execution_time ? `${source.last_run.execution_time}s` : (source.import_duration ? `${source.import_duration}s` : '—');
+  const sourceErrors = (source) => source.last_error || (source.last_run?.errors || []).filter(Boolean).join('; ') || '—';
 
   function renderSources(sources) {
     setText('mediaStatSources', String(sources.length));
-    if (!sources.length) { sourcesBody.innerHTML = '<tr><td colspan="6">Источники не настроены.</td></tr>'; return; }
+    if (!sources.length) { sourcesBody.innerHTML = '<tr><td colspan="8">Источники не настроены.</td></tr>'; return; }
     sourcesBody.innerHTML = sources.map((source) => {
-      const isManualSource = source.status === 'manual_source' || source.provider === 'youtube_manual';
-      const needsChannelId = source.status === 'needs_channel_id' || (source.provider === 'youtube' && !source.channel_id);
-      const statusLabel = isManualSource ? 'Manual source — API not connected' : (needsChannelId ? 'Нужен YouTube channel_id для RSS-импорта' : (source.enabled ? 'Enabled' : 'Disabled'));
-      const statusClass = (needsChannelId || isManualSource) ? 'is-disabled' : (source.enabled ? 'is-enabled' : 'is-disabled');
+      const label = statusLabel(source);
+      const statusClass = source.enabled && !source.last_error && label !== 'Manual source — API not connected' ? 'is-enabled' : 'is-disabled';
       return `
       <tr>
         <td><strong>${escapeHtml(source.name)}</strong><span>${escapeHtml(source.channel_url || '')}</span></td>
-        <td><span class="tv-provider-pill">${escapeHtml(source.provider)}</span></td>
-        <td><span class="tv-status-pill ${statusClass}">${escapeHtml(statusLabel)}</span></td>
+        <td><span class="tv-provider-pill">${escapeHtml(providerLabel(source.provider))}</span></td>
+        <td><span class="tv-status-pill ${statusClass}">${escapeHtml(label)}</span></td>
         <td>${formatValue(source.last_import)}</td>
         <td>${escapeHtml(source.videos_count ?? 0)}</td>
+        <td>${escapeHtml(sourceDuration(source))}</td>
+        <td>${escapeHtml(sourceErrors(source))}</td>
         <td><div class="tv-source-actions"><button data-action="Import Now" data-source="${escapeHtml(source.name)}">Import Now</button><button data-action="Disable" data-source="${escapeHtml(source.name)}">Disable</button><button data-action="Enable" data-source="${escapeHtml(source.name)}">Enable</button></div></td>
       </tr>`;
     }).join('');
@@ -50,7 +54,7 @@
       fetch('/api/media/sources', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((r) => r.ok ? r.json() : []),
       fetch('/api/media', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((r) => r.ok ? r.json() : []),
     ]).then(([sources, media]) => { renderSources(Array.isArray(sources) ? sources : []); renderMedia(Array.isArray(media) ? media : []); })
-      .catch(() => { sourcesBody.innerHTML = '<tr><td colspan="6">Media Engine временно недоступен.</td></tr>'; newestBody.innerHTML = '<tr><td colspan="5">Каталог временно недоступен.</td></tr>'; });
+      .catch(() => { sourcesBody.innerHTML = '<tr><td colspan="8">Media Engine временно недоступен.</td></tr>'; newestBody.innerHTML = '<tr><td colspan="5">Каталог временно недоступен.</td></tr>'; });
   }
 
   sourcesBody.addEventListener('click', (event) => {

--- a/data/media_sources.json
+++ b/data/media_sources.json
@@ -2,7 +2,7 @@
   {
     "id": "gerchik",
     "name": "Gerchik & Co",
-    "provider": "youtube_manual",
+    "provider": "youtube_ytdlp",
     "channel_url": "https://www.youtube.com/@gerchikco9785",
     "language": "ru",
     "priority": 1,
@@ -11,12 +11,12 @@
       "Smart Money"
     ],
     "enabled": true,
-    "status": "manual_source"
+    "status": "online"
   },
   {
     "id": "instaforex",
     "name": "InstaForex",
-    "provider": "youtube_manual",
+    "provider": "youtube_ytdlp",
     "channel_url": "https://www.youtube.com/@instaforex",
     "language": "ru",
     "priority": 2,
@@ -25,12 +25,12 @@
       "Macro"
     ],
     "enabled": true,
-    "status": "manual_source"
+    "status": "online"
   },
   {
     "id": "traderevo",
     "name": "TraderEVO",
-    "provider": "youtube_manual",
+    "provider": "youtube_ytdlp",
     "channel_url": "https://www.youtube.com/@traderevo",
     "language": "ru",
     "priority": 2,
@@ -38,12 +38,12 @@
       "Smart Money"
     ],
     "enabled": true,
-    "status": "manual_source"
+    "status": "online"
   },
   {
     "id": "prosto_crypto",
     "name": "PROSTO КРИПТО",
-    "provider": "youtube_manual",
+    "provider": "youtube_ytdlp",
     "channel_url": "https://www.youtube.com/@prosto_kripto",
     "language": "ru",
     "priority": 2,
@@ -51,12 +51,12 @@
       "Crypto"
     ],
     "enabled": true,
-    "status": "manual_source"
+    "status": "online"
   },
   {
     "id": "market_vector",
     "name": "Market Vector",
-    "provider": "youtube_manual",
+    "provider": "youtube_ytdlp",
     "channel_url": "https://www.youtube.com/@market_vector",
     "language": "ru",
     "priority": 2,
@@ -64,12 +64,12 @@
       "Market Analysis"
     ],
     "enabled": true,
-    "status": "manual_source"
+    "status": "online"
   },
   {
     "id": "bazylev",
     "name": "Aleksandr Bazylev",
-    "provider": "youtube_manual",
+    "provider": "youtube_ytdlp",
     "channel_url": "https://www.youtube.com/@AleksandrBazylev",
     "language": "ru",
     "priority": 2,
@@ -77,6 +77,6 @@
       "Forex"
     ],
     "enabled": true,
-    "status": "manual_source"
+    "status": "online"
   }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,6 @@ dependencies = [
   "httpx==0.27.2",
   "scikit-learn",
   "ta",
-  "python-dotenv"
+  "python-dotenv",
+  "yt-dlp"
 ]


### PR DESCRIPTION
### Motivation
- Заменить ручной режим YouTube на автоматический импорт метаданных через `yt-dlp` без использования Google Cloud или YouTube Data API.
- Снизить сложность резолвинга каналов и избежать HTML-скрапинга, сохранив существующие контракты `MediaItem` и поведение дедупликации.

### Description
- Добавлен новый провайдер `YouTubeYtDlpProvider` в `app/services/providers/youtube_ytdlp_provider.py`, который извлекает только метаданные публичных каналов через `yt-dlp`, не скачивая видео, нормализует в `MediaItem` и кеширует результаты по каналу на 30 минут.
- Расширен `MediaImportEngine` (`app/services/media_import_engine.py`) для поддержки `provider == "youtube_ytdlp"`, интеграции провайдера, записи диагностики (`yt_dlp_version`, `resolved_url`, `execution_time`), безопасной обработки ошибок (каталог не удаляется при сбое) и дедупликации по `youtube_id`.
- Обновлён админ-интерфейс: `app/static/media-admin.html` и `app/static/media-admin.js` показывают провайдер `YouTube (yt-dlp)`, статус Online, длительность импорта и ошибки, форма добавления источника по умолчанию предлагает `youtube_ytdlp`. 
- Обновлены конфигурации и документация: переключены тестовые источники в `data/media_sources.json` на `youtube_ytdlp`, добавлена зависимость `yt-dlp` в `pyproject.toml`, и документация в `README.md` с инструкцией `pip install yt-dlp` и списком поддерживаемых URL-форматов. 

### Testing
- Установлена зависимость: выполнено `python3 -m pip install yt-dlp` (успешно). — успешный локальный install.
- Статический/синтаксический прогон: `node --check app/static/media-admin.js` и `python3 -m py_compile app/services/media_import_engine.py app/services/providers/youtube_ytdlp_provider.py app/main.py` — успешно. 
- Smoke тесты: создан `MediaImportEngine` и вызван `engine.list_sources()` — подтверждена поддержка `youtube_ytdlp` и наличие поля `last_run` в ответе (успешно). 
- Провайдер `YouTubeYtDlpProvider.fetch_latest()` запускался локально как smoke-тест; среда выполнения имела блокирующий прокси и `yt-dlp` вернул безопасную ошибку (`yt_dlp_error`), провайдер корректно вернул диагностическое сообщение без мутаций каталога (обработка ошибок — ожидаемое поведение).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0b62ac408331b30f475662dfdbd1)