### PR TITLE
Добавить yt-dlp в requirements.txt для деплоя на Render

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ ta==0.11.0
 python-dotenv==1.0.1
 websocket-client==1.8.0
 feedparser==6.0.11
+yt-dlp


### PR DESCRIPTION
### Motivation
- Обеспечить автоматическую установку `yt-dlp` при деплое на Render через существующий Build Command `pip install -r requirements.txt`.

### Description
- Добавлена строка `yt-dlp` в `requirements.txt`; другие исходные файлы и код не менялись, а `render.yaml` оставлен с `buildCommand: pip install -r requirements.txt`.

### Testing
- Выполнен `python -m pip install -r requirements.txt --dry-run` и проверка наличия `yt-dlp` в `requirements.txt` и `buildCommand` в `render.yaml` через автоматический скрипт, все проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d1ba70b0883318bf4f1637740b431)