### PR TITLE
Завершить миграцию FXPilot TV на автоматический импорт YouTube через yt-dlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,3 +512,9 @@ Admin endpoints:
 - `POST /api/media/resolve-source` — resolve and validate one YouTube channel URL.
 - `POST /api/media/sources` — resolve, validate, duplicate-check, and save a source.
 - `POST /api/media/resolve-all` — re-resolve enabled YouTube sources and refresh stored RSS metadata.
+
+## FXPilot TV yt-dlp catalog migration
+
+- `/api/media` and `/tv` now read the video catalog from `data/media_catalog.json` only; `data/manual_youtube_videos.json` is excluded by default and can be enabled only for local development with `FXPILOT_DEV_MANUAL_MEDIA=1`.
+- `POST /api/media/import` rebuilds and saves `media_catalog.json` immediately after provider import, filters out records without a valid 11-character `youtube_id`, deduplicates by `youtube_id`, and records `duplicates_removed` in the import debug log.
+- Added `GET /api/media/stats` for catalog health (`catalog_items`, `real_videos`, `manual_demo`, `duplicates_removed`, `last_import`); the TV player shows `No videos imported` when the automatic catalog is empty and always uses `https://www.youtube.com/embed/{youtube_id}` for playback.

--- a/app/main.py
+++ b/app/main.py
@@ -142,7 +142,8 @@ MEDIA_MANUAL_YOUTUBE_PATH = BASE_DIR.parent / "data" / "manual_youtube_videos.js
 MEDIA_DEBUG_PATH = BASE_DIR.parent / "data" / "media_import_debug.json"
 
 def create_media_import_engine() -> MediaImportEngine:
-    return MediaImportEngine(MEDIA_SOURCES_PATH, MEDIA_CATALOG_PATH, MEDIA_TV_VIDEOS_PATH, debug_path=MEDIA_DEBUG_PATH)
+    manual_path = MEDIA_MANUAL_YOUTUBE_PATH if os.getenv("FXPILOT_DEV_MANUAL_MEDIA", "").strip().lower() in {"1", "true", "yes", "on", "dev"} else None
+    return MediaImportEngine(MEDIA_SOURCES_PATH, MEDIA_CATALOG_PATH, manual_path, debug_path=MEDIA_DEBUG_PATH)
 
 media_import_engine = create_media_import_engine()
 
@@ -504,24 +505,10 @@ def media_admin_page():
 
 def _load_tv_video_catalog() -> list[dict[str, Any]]:
     try:
-        return MediaImportEngine(
-            MEDIA_SOURCES_PATH,
-            MEDIA_CATALOG_PATH,
-            MEDIA_MANUAL_YOUTUBE_PATH,
-            debug_path=MEDIA_DEBUG_PATH,
-        )._sort_media(
-            MediaImportEngine._dedupe(
-                [
-                    *MediaImportEngine._read_json_list(MEDIA_MANUAL_YOUTUBE_PATH),
-                    *MediaImportEngine._read_json_list(MEDIA_TV_VIDEOS_PATH),
-                    *MediaImportEngine._read_json_list(MEDIA_CATALOG_PATH),
-                ]
-            )
-        )
+        return create_media_import_engine().load_catalog()
     except Exception as exc:
         logger.warning("media_catalog_unavailable error=%s", exc)
         return []
-
 
 def _build_tv_review_payload(video: dict[str, Any]) -> dict[str, Any]:
     return {
@@ -596,6 +583,14 @@ def api_media_import() -> dict[str, Any]:
     except Exception as exc:
         logger.exception("media_import_failed_before_completion")
         raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
+
+
+@app.get("/api/media/stats")
+def api_media_stats() -> dict[str, Any]:
+    try:
+        return create_media_import_engine().stats()
+    except MediaConfigError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @app.get("/api/media/debug")

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import traceback
 from dataclasses import asdict, dataclass, field, replace
@@ -22,6 +23,11 @@ SUPPORTED_MEDIA_PROVIDERS = {"youtube", "youtube_ytdlp", "youtube_manual", "tele
 SYMBOLS = ("EURUSD", "GBPUSD", "USDJPY", "USDCHF", "USDCAD", "AUDUSD", "NZDUSD", "XAUUSD", "XAGUSD", "BTCUSD", "ETHUSD", "DXY", "US500", "NASDAQ", "GER40", "UK100")
 YOUTUBE_RSS_BY_CHANNEL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
 YOUTUBE_RSS_BY_USER = "https://www.youtube.com/feeds/videos.xml?user={user}"
+YOUTUBE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+
+def is_valid_youtube_id(value: Any) -> bool:
+    return bool(YOUTUBE_ID_RE.fullmatch(str(value or "").strip()))
 
 
 class MediaConfigError(ValueError):
@@ -211,7 +217,7 @@ class YouTubeRssProvider:
 
     def _entry_to_item(self, entry: Any, source: MediaSource) -> MediaItem | None:
         youtube_id = self._entry_video_id(entry)
-        if not youtube_id: return None
+        if not is_valid_youtube_id(youtube_id): return None
         title = str(entry.get("title") or "Без названия").strip(); description = str(entry.get("summary") or entry.get("description") or "").strip(); symbol = detect_symbol(f"{title} {description}")
         return MediaItem(id=f"youtube:{youtube_id}", provider=self.provider_name, source_id=source.id, title=title, author=str(entry.get("author") or source.name), youtube_id=youtube_id, url=str(entry.get("link") or f"https://www.youtube.com/watch?v={youtube_id}"), thumbnail=self._thumbnail(entry), published_at=self._published_date(entry), duration=None, category=source.categories[0] if source.categories else "Market Analysis", symbol=symbol, language=source.language, description=description, tags=[*source.categories, symbol], imported_at=datetime.now(timezone.utc).isoformat())
 
@@ -336,7 +342,14 @@ class MediaImportEngine:
             result.append(payload)
         return result
     def load_catalog(self) -> list[dict[str, Any]]:
-        return self._sort_media(self._dedupe([*(self._read_json_list(self.manual_videos_path) if self.manual_videos_path else []), *self._read_json_list(self.catalog_path)]))
+        items = self._read_json_list(self.catalog_path)
+        if self._manual_dev_mode_enabled() and self.manual_videos_path:
+            items = [*self._read_json_list(self.manual_videos_path), *items]
+        return self._sort_media(self._dedupe(items, allow_manual=self._manual_dev_mode_enabled()))
+
+    @staticmethod
+    def _manual_dev_mode_enabled() -> bool:
+        return str(os.getenv("FXPILOT_DEV_MANUAL_MEDIA") or "").strip().lower() in {"1", "true", "yes", "on", "dev"}
     def import_latest(self) -> dict[str, Any]:
         now = datetime.now(timezone.utc).isoformat()
         run_log: dict[str, Any] = {"started_at": now, "finished_at": None, "sources": [], "steps": ["ENTER import_latest()"]}
@@ -428,19 +441,25 @@ class MediaImportEngine:
             finally:
                 run_log["sources"].append(source_log)
 
-        merged = self._sort_media(self._dedupe([*existing, *fetched]))
-        before = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in existing}
-        after = {(str(i.get("provider")), str(i.get("youtube_id") or i.get("id") or i.get("url"))) for i in merged}
+        valid_existing = [item for item in existing if self._is_catalog_item_importable(item)]
+        valid_fetched = [item for item in fetched if self._is_catalog_item_importable(item)]
+        merged = self._sort_media(self._dedupe([*valid_existing, *valid_fetched]))
+        raw_count = len(valid_existing) + len(valid_fetched)
+        duplicates_removed = max(0, raw_count - len(merged))
+        before = {str(i.get("youtube_id")) for i in valid_existing if is_valid_youtube_id(i.get("youtube_id"))}
+        after = {str(i.get("youtube_id")) for i in merged if is_valid_youtube_id(i.get("youtube_id"))}
         run_log["steps"].append("Saving catalog...")
         logger.info("Saving catalog...")
         self.catalog_path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
         self._save_sources(updated_sources)
+        run_log["duplicates_removed"] = duplicates_removed
+        run_log["catalog_items"] = len(merged)
         run_log["finished_at"] = datetime.now(timezone.utc).isoformat()
         run_log["steps"].append("DONE")
         logger.info("DONE")
         self._persist_debug_run(run_log)
         imported = len(after - before)
-        return {"success": failed == 0, "processed": processed, "imported": imported, "updated": max(0, len(fetched) - imported), "failed": failed, "errors": errors, "catalog_size": len(merged), "sources": len(sources), "new_items": imported}
+        return {"success": failed == 0, "processed": processed, "imported": imported, "updated": max(0, len(valid_fetched) - imported), "failed": failed, "errors": errors, "catalog_size": len(merged), "sources": len(sources), "new_items": imported, "duplicates_removed": duplicates_removed}
 
     def _persist_debug_run(self, run_log: dict[str, Any]) -> None:
         self.debug_path.parent.mkdir(parents=True, exist_ok=True)
@@ -511,6 +530,25 @@ class MediaImportEngine:
                 },
             })
         return {"last_import_run": last_run, "sources": rows}
+    def stats(self) -> dict[str, Any]:
+        catalog = self.load_catalog()
+        last_run = {}
+        try:
+            payload = json.loads(self.debug_path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                last_run = payload
+        except Exception:
+            pass
+        manual_demo = len([item for item in catalog if item.get("status") == "manual_demo" or item.get("provider") in {"youtube_manual", "youtube-manual"}])
+        real_videos = len([item for item in catalog if is_valid_youtube_id(item.get("youtube_id")) and item.get("status") != "manual_demo"])
+        return {
+            "catalog_items": len(catalog),
+            "real_videos": real_videos,
+            "manual_demo": manual_demo,
+            "duplicates_removed": int(last_run.get("duplicates_removed") or 0),
+            "last_import": last_run.get("finished_at") or last_run.get("started_at"),
+        }
+
     def rss_test(self, source_id: str) -> dict[str, Any]:
         source = next((s for s in self.load_sources() if s.id == source_id), None)
         if not source:
@@ -604,7 +642,7 @@ class MediaImportEngine:
         values = [str(item.get("published_at") or "") for item in catalog if item.get("source_id") == source_id and item.get("published_at")]
         return max(values) if values else None
     def _save_sources(self, updates: list[MediaSource]) -> None:
-        by_id = {s.id: s for s in updates}; raw = self._read_json_list(self.sources_path); catalog = self.load_catalog()
+        by_id = {s.id: s for s in updates}; raw = self._read_json_list(self.sources_path); catalog = self._sort_media(self._dedupe(self._read_json_list(self.catalog_path)))
         for item in raw:
             upd = by_id.get(str(item.get("id")))
             if upd:
@@ -653,18 +691,31 @@ class MediaImportEngine:
         return [item for item in payload if isinstance(item, dict)] if isinstance(payload, list) else []
 
     @staticmethod
-    def _dedupe(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        seen: dict[tuple[str, str], dict[str, Any]] = {}
+    def _is_catalog_item_importable(item: dict[str, Any], *, allow_manual: bool = False) -> bool:
+        if not isinstance(item, dict):
+            return False
+        if not allow_manual and (item.get("status") == "manual_demo" or str(item.get("provider") or "") in {"youtube_manual", "youtube-manual"}):
+            return False
+        return is_valid_youtube_id(item.get("youtube_id"))
+
+    @staticmethod
+    def _dedupe(items: list[dict[str, Any]], *, allow_manual: bool = False) -> list[dict[str, Any]]:
+        seen: dict[str, dict[str, Any]] = {}
         for item in items:
-            provider = str(item.get("provider") or ("youtube-manual" if item.get("youtube_id") else "manual"))
-            external_id = str(item.get("youtube_id") or item.get("id") or item.get("url"))
-            dedupe_key = ("youtube_id", external_id) if item.get("youtube_id") else (provider, external_id)
+            if not MediaImportEngine._is_catalog_item_importable(item, allow_manual=allow_manual):
+                continue
+            youtube_id = str(item.get("youtube_id") or "").strip()
             normalized = dict(item)
-            normalized.setdefault("provider", provider); normalized.setdefault("source_id", "manual")
-            normalized.setdefault("status", "manual"); normalized.setdefault("language", "ru")
-            normalized.setdefault("thumbnail", f"https://i.ytimg.com/vi/{normalized.get('youtube_id')}/hqdefault.jpg" if normalized.get("youtube_id") else None)
+            normalized["youtube_id"] = youtube_id
+            normalized.setdefault("id", f"youtube:{youtube_id}")
+            normalized.setdefault("provider", "youtube_ytdlp")
+            normalized.setdefault("source_id", "imported")
+            normalized.setdefault("status", "imported")
+            normalized.setdefault("language", "ru")
+            normalized.setdefault("thumbnail", f"https://i.ytimg.com/vi/{youtube_id}/hqdefault.jpg")
+            normalized.setdefault("url", f"https://www.youtube.com/watch?v={youtube_id}")
             normalized.setdefault("symbol", detect_symbol(f"{normalized.get('title','')} {normalized.get('description','')}"))
-            seen[dedupe_key] = normalized
+            seen[youtube_id] = normalized
         return list(seen.values())
 
     @staticmethod

--- a/app/services/providers/youtube_ytdlp_provider.py
+++ b/app/services/providers/youtube_ytdlp_provider.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlparse
 
-from app.services.media_import_engine import ImportSourceResult, MediaImportError, MediaItem, MediaSource, detect_symbol
+from app.services.media_import_engine import ImportSourceResult, MediaImportError, MediaItem, MediaSource, detect_symbol, is_valid_youtube_id
 
 CACHE_TTL_SECONDS = 30 * 60
 DEFAULT_MAX_RESULTS = 20
@@ -153,7 +153,7 @@ class YouTubeYtDlpProvider:
     @staticmethod
     def _entry_to_item(entry: dict[str, Any], source: MediaSource, channel_title: str) -> MediaItem | None:
         video_id = str(entry.get("id") or entry.get("display_id") or "").strip()
-        if not video_id:
+        if not is_valid_youtube_id(video_id):
             return None
         title = str(entry.get("title") or "Без названия").strip()
         description = str(entry.get("description") or entry.get("summary") or "").strip()

--- a/app/static/tv-components.js
+++ b/app/static/tv-components.js
@@ -10,11 +10,9 @@ window.FXPilotTv = (() => {
     return new Intl.DateTimeFormat('ru-RU', { day: '2-digit', month: 'long', year: 'numeric' }).format(date);
   };
 
-  const embedUrl = (youtubeId, { autoplay = false } = {}) => {
-    const params = new URLSearchParams({ rel: '0', modestbranding: '1', playsinline: '1' });
-    if (autoplay) params.set('autoplay', '1');
-    return `https://www.youtube.com/embed/${encodeURIComponent(youtubeId)}?${params.toString()}`;
-  };
+  const isValidYouTubeId = (youtubeId) => /^[A-Za-z0-9_-]{11}$/.test(String(youtubeId || ''));
+
+  const embedUrl = (youtubeId) => `https://www.youtube.com/embed/${encodeURIComponent(youtubeId)}`;
 
   const PlayerSkeleton = (label = 'Загрузка видео...') => `
     <div class="tv-player-skeleton" aria-live="polite">
@@ -23,7 +21,7 @@ window.FXPilotTv = (() => {
   `;
 
   const VideoPlayer = (video, { autoplay = false, titleFallback = 'FXPilot TV' } = {}) => {
-    if (!video || !video.youtube_id) return '<div class="tv-player-empty">Видео пока недоступно.</div>';
+    if (!video || !isValidYouTubeId(video.youtube_id)) return '<div class="tv-player-empty">No videos imported</div>';
     return `<iframe src="${embedUrl(video.youtube_id, { autoplay })}" title="${escapeHtml(video.title || titleFallback)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"></iframe>`;
   };
 

--- a/app/static/tv.js
+++ b/app/static/tv.js
@@ -118,7 +118,7 @@
     applyFilters();
     if (countEl) countEl.textContent = `${filteredVideos.length} из ${videos.length} видео`;
     if (!filteredVideos.length) {
-      listEl.innerHTML = '<div class="tv-player-empty"><strong>Видео не найдены</strong><span>Измените поиск или категорию. Каталог FXPilot TV будет расширяться без подключения YouTube API.</span></div>';
+      listEl.innerHTML = '<div class="tv-player-empty"><strong>No videos imported</strong><span>Запустите Import Now в Media Admin, чтобы загрузить реальные ролики YouTube.</span></div>';
       return;
     }
     listEl.innerHTML = playlistGroups.map((group) => {
@@ -166,6 +166,7 @@
       renderFilters();
       document.getElementById('tvVideoSearch')?.addEventListener('input', (event) => { query = event.target.value; renderList(); });
       document.getElementById('tvCategoryFilter')?.addEventListener('change', (event) => { category = event.target.value; renderList(); selectVideo(filteredVideos[0]?.id); });
+      if (!videos.length) { renderList(); renderPlayer(null); renderDetails(null); return; }
       selectVideo(videos[0] && videos[0].id);
     })
     .catch(() => { videos = []; filteredVideos = []; if (countEl) countEl.textContent = '0 видео'; playerEl.innerHTML = '<div class="tv-player-empty"><strong>Каталог временно недоступен</strong><span>Не удалось загрузить локальный список видео. Попробуйте обновить страницу.</span></div>'; detailsEl.innerHTML = '<p class="section-text">Видеообзоры не загружены. Реальные рыночные данные не подменяются демо-контентом.</p>'; listEl.innerHTML = '<div class="tv-player-empty">Нет доступных видео.</div>'; });

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -27,7 +27,7 @@ def test_symbol_detection_supported_symbols():
     assert detect_symbol("общий рыночный обзор") == "MARKET"
 
 
-def test_media_import_merges_and_deduplicates_manual_catalog(tmp_path: Path):
+def test_media_catalog_ignores_manual_demo_without_dev_mode(tmp_path: Path):
     sources_path = tmp_path / "media_sources.json"
     catalog_path = tmp_path / "media_catalog.json"
     manual_path = tmp_path / "tv_videos.json"
@@ -38,15 +38,11 @@ def test_media_import_merges_and_deduplicates_manual_catalog(tmp_path: Path):
         {"id": "manual", "youtube_id": "abc12345678", "title": "EURUSD manual", "published_at": "2026-07-06"}
     ]), encoding="utf-8")
     catalog_path.write_text(json.dumps([
-        {"id": "duplicate", "provider": "youtube-manual", "youtube_id": "abc12345678", "title": "EURUSD duplicate", "published_at": "2026-07-05"}
+        {"id": "duplicate", "provider": "youtube-manual", "youtube_id": "abc12345678", "title": "EURUSD duplicate", "published_at": "2026-07-05", "status": "manual_demo"}
     ]), encoding="utf-8")
 
     engine = MediaImportEngine(sources_path, catalog_path, manual_path)
-    catalog = engine.load_catalog()
-
-    assert len(catalog) == 1
-    assert catalog[0]["youtube_id"] == "abc12345678"
-    assert catalog[0]["symbol"] == "EURUSD"
+    assert engine.load_catalog() == []
 
 
 
@@ -105,6 +101,14 @@ def test_media_debug_endpoint_contract():
     payload = response.json()
     assert {"started_at", "finished_at", "sources"}.issubset(payload["last_import_run"].keys())
     assert {"provider", "rss_url", "channel_id", "can_import", "last_run", "last_error"}.issubset(payload["sources"][0].keys())
+
+
+def test_media_stats_endpoint_contract():
+    response = TestClient(app).get("/api/media/stats")
+    assert response.status_code == 200
+    payload = response.json()
+    assert {"catalog_items", "real_videos", "manual_demo", "duplicates_removed", "last_import"}.issubset(payload.keys())
+    assert payload["manual_demo"] == 0
 
 
 


### PR DESCRIPTION
### Motivation
- Исключить по умолчанию устаревший `manual_youtube_videos.json` и перевести `/api/media`/`/tv` на единый автоматически формируемый каталог `data/media_catalog.json`.
- Гарантировать, что после `POST /api/media/import` каталог перестраивается, сохраняется и отражает только реальные ролики с валидными YouTube ID (без DEMOxxxx).
- Устранить проблемы с недоступными iframe и дублями, а также добавить диагностический исчерпывающий статус каталога.

### Description
- Параметр запуска `FXPILOT_DEV_MANUAL_MEDIA` управляет подключением `manual_youtube_videos.json`, а по умолчанию `create_media_import_engine()` не подключает manual-источник; `load_catalog()` теперь читает только `data/media_catalog.json` (DEV only when flag set). (`app/main.py`, `app/services/media_import_engine.py`).
- Добавлена строгая валидация YouTube ID (регэксп 11 символов) через `is_valid_youtube_id()` и провайдеры пропускают записи без валидного `youtube_id` (обновлён `youtube_ytdlp` provider и RSS provider). (`app/services/media_import_engine.py`, `app/services/providers/youtube_ytdlp_provider.py`).
- `import_latest()` фильтрует невалидные записи, объединяет `existing` и `fetched` только после проверки, дедуплицирует по `youtube_id`, записывает пересобранный `media_catalog.json`, и логирует `duplicates_removed` и `catalog_items`. (`app/services/media_import_engine.py`).
- Добавлен endpoint `GET /api/media/stats` возвращающий `catalog_items`, `real_videos`, `manual_demo`, `duplicates_removed` и `last_import`. (`app/main.py`, `app/services/media_import_engine.py`).
- TV frontend/компоненты изменены: iframe строится только как `https://www.youtube.com/embed/{youtube_id}`, и при пустом автоматическом каталоге показывается сообщение о `No videos imported` и плейсхолдеры не используются. (`app/static/tv-components.js`, `app/static/tv.js`).
- Тесты и документация обновлены: добавлены проверки на исключение manual demo по умолчанию и контракт `/api/media/stats`, а README описывает новый DEV-флаг и поведение импорта. (`tests/test_media_import_engine.py`, `README.md`).

### Testing
- Собрал файлы под модульную проверку с `python -m compileall app/services/media_import_engine.py app/services/providers/youtube_ytdlp_provider.py app/main.py` (успешно). 
- Запустил модульные тесты `pytest -q tests/test_media_import_engine.py`, все тесты в этом наборе прошли успешно. 
- Выполнил простую проверку API через `TestClient` на `/api/media` и `GET /api/media/stats`, оба эндпойнта вернули `200` и корректную структуру. 
- Полный прогон тестов показал единичный падёж в тестах, не связанных с media pipeline: `tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, который является существующей несвязанной ошибкой и не блокирует принятые изменения в pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d1fa71c1c8331bf80a7206ac980fa)