### PR TITLE
Балансировка каталога FXPilot TV: лимит на источник, даты и статистика

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,14 @@ Admin endpoints:
 - `POST /api/media/sources` — resolve, validate, duplicate-check, and save a source.
 - `POST /api/media/resolve-all` — re-resolve enabled YouTube sources and refresh stored RSS metadata.
 
+
+## FXPilot TV media catalog balancing
+
+- Automatic media import now keeps source diversity by limiting each enabled source to `FXPILOT_MEDIA_MAX_PER_SOURCE` newest valid videos; default is `5`.
+- Rebuilt `data/media_catalog.json` is sorted newest-first by `published_at`, falling back to `imported_at`, and `/api/media/stats` exposes `sources_with_videos` plus `videos_by_source` for catalog health checks.
+- yt-dlp metadata dates are normalized from `upload_date` (`YYYY-MM-DD`) or `timestamp` (UTC ISO datetime); when no published date is available, `imported_at` is used.
+- The `/tv` catalog list renders all videos returned by `/api/media` so visible videos are not restricted to one source group.
+
 ## FXPilot TV yt-dlp catalog migration
 
 - `/api/media` and `/tv` now read the video catalog from `data/media_catalog.json` only; `data/manual_youtube_videos.json` is excluded by default and can be enabled only for local development with `FXPILOT_DEV_MANUAL_MEDIA=1`.

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -24,6 +24,15 @@ SYMBOLS = ("EURUSD", "GBPUSD", "USDJPY", "USDCHF", "USDCAD", "AUDUSD", "NZDUSD",
 YOUTUBE_RSS_BY_CHANNEL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
 YOUTUBE_RSS_BY_USER = "https://www.youtube.com/feeds/videos.xml?user={user}"
 YOUTUBE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+DEFAULT_MAX_MEDIA_PER_SOURCE = 5
+
+
+def max_media_per_source() -> int:
+    try:
+        value = int(str(os.getenv("FXPILOT_MEDIA_MAX_PER_SOURCE") or DEFAULT_MAX_MEDIA_PER_SOURCE).strip())
+    except (TypeError, ValueError):
+        value = DEFAULT_MAX_MEDIA_PER_SOURCE
+    return max(1, value)
 
 
 def is_valid_youtube_id(value: Any) -> bool:
@@ -447,7 +456,7 @@ class MediaImportEngine:
 
         valid_existing = [item for item in existing if self._is_catalog_item_importable(item)]
         valid_fetched = [item for item in fetched if self._is_catalog_item_importable(item)]
-        merged = self._sort_media(self._dedupe([*valid_existing, *valid_fetched]))
+        merged = self._balance_by_source(self._dedupe([*valid_existing, *valid_fetched]))
         raw_count = len(valid_existing) + len(valid_fetched)
         duplicates_removed = max(0, raw_count - len(merged))
         before = {str(i.get("youtube_id")) for i in valid_existing if is_valid_youtube_id(i.get("youtube_id"))}
@@ -556,11 +565,18 @@ class MediaImportEngine:
         except Exception:
             pass
         manual_demo = len([item for item in catalog if item.get("status") == "manual_demo" or item.get("provider") in {"youtube_manual", "youtube-manual"}])
-        real_videos = len([item for item in catalog if is_valid_youtube_id(item.get("youtube_id")) and item.get("status") != "manual_demo"])
+        real_items = [item for item in catalog if is_valid_youtube_id(item.get("youtube_id")) and item.get("status") != "manual_demo"]
+        real_videos = len(real_items)
+        videos_by_source: dict[str, int] = {}
+        for item in real_items:
+            source_id = str(item.get("source_id") or "unknown")
+            videos_by_source[source_id] = videos_by_source.get(source_id, 0) + 1
         return {
             "catalog_items": len(catalog),
             "real_videos": real_videos,
             "manual_demo": manual_demo,
+            "sources_with_videos": len(videos_by_source),
+            "videos_by_source": dict(sorted(videos_by_source.items())),
             "duplicates_removed": int(last_run.get("duplicates_removed") or 0),
             "last_import": last_run.get("finished_at") or last_run.get("started_at"),
         }
@@ -741,6 +757,19 @@ class MediaImportEngine:
             seen[youtube_id] = normalized
         return list(seen.values())
 
+    def _balance_by_source(self, items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        limit = max_media_per_source()
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        enabled_sources = {source.id for source in self.load_sources() if source.enabled}
+        for item in self._sort_media(items):
+            source_id = str(item.get("source_id") or "unknown")
+            if enabled_sources and source_id not in enabled_sources:
+                continue
+            grouped.setdefault(source_id, [])
+            if len(grouped[source_id]) < limit:
+                grouped[source_id].append(item)
+        return self._sort_media([item for bucket in grouped.values() for item in bucket])
+
     @staticmethod
     def _sort_media(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return sorted(items, key=lambda item: str(item.get("published_at") or ""), reverse=True)
+        return sorted(items, key=lambda item: str(item.get("published_at") or item.get("imported_at") or ""), reverse=True)

--- a/app/services/providers/youtube_ytdlp_provider.py
+++ b/app/services/providers/youtube_ytdlp_provider.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlparse
 
-from app.services.media_import_engine import ImportSourceResult, MediaImportError, MediaItem, MediaSource, detect_symbol, is_valid_youtube_id
+from app.services.media_import_engine import ImportSourceResult, MediaImportError, MediaItem, MediaSource, detect_symbol, is_valid_youtube_id, max_media_per_source
 
 logger = logging.getLogger(__name__)
 CACHE_TTL_SECONDS = 30 * 60
@@ -26,8 +26,8 @@ class YouTubeYtDlpProvider:
     provider_name = "youtube_ytdlp"
     _cache: dict[str, tuple[float, dict[str, Any]]] = {}
 
-    def __init__(self, max_results: int = DEFAULT_MAX_RESULTS) -> None:
-        self.max_results = max(1, min(int(max_results or DEFAULT_MAX_RESULTS), 50))
+    def __init__(self, max_results: int | None = None) -> None:
+        self.max_results = max(1, min(int(max_results or max_media_per_source()), 50))
         self.last_diagnostic: dict[str, Any] = {}
 
     def fetch_latest(self, source: MediaSource) -> ImportSourceResult:
@@ -54,7 +54,7 @@ class YouTubeYtDlpProvider:
 
             seen: set[str] = set()
             items: list[MediaItem] = []
-            for entry in entries[: self.max_results]:
+            for entry in entries[: max_media_per_source()]:
                 item = self._entry_to_item(entry, source, channel_title)
                 if not item or not item.youtube_id:
                     diagnostic["skipped_invalid"] += 1
@@ -134,7 +134,7 @@ class YouTubeYtDlpProvider:
             "no_warnings": True,
             "skip_download": True,
             "extract_flat": "discard_in_playlist",
-            "playlistend": self.max_results,
+            "playlistend": max_media_per_source(),
             "ignoreerrors": True,
             "socket_timeout": 20,
         }
@@ -179,7 +179,8 @@ class YouTubeYtDlpProvider:
         title = str(entry.get("title") or "Без названия").strip()
         description = str(entry.get("description") or entry.get("summary") or "").strip()
         symbol = detect_symbol(f"{title} {description}")
-        published_at = YouTubeYtDlpProvider._published_at(entry)
+        imported_at = datetime.now(timezone.utc).isoformat()
+        published_at = YouTubeYtDlpProvider._published_at(entry) or imported_at
         duration = entry.get("duration_string") or entry.get("duration")
         entry_categories = entry.get("categories") if isinstance(entry.get("categories"), list) else []
         tags = [str(tag).strip() for tag in [*source.categories, *entry_categories, *((entry.get("tags") or []) if isinstance(entry.get("tags"), list) else [])] if str(tag).strip()]
@@ -202,7 +203,7 @@ class YouTubeYtDlpProvider:
             description=description,
             channel=str(entry.get("channel") or channel_title or source.name),
             tags=tags,
-            imported_at=datetime.now(timezone.utc).isoformat(),
+            imported_at=imported_at,
         )
 
     @staticmethod
@@ -227,7 +228,7 @@ class YouTubeYtDlpProvider:
         timestamp = entry.get("timestamp") or entry.get("release_timestamp")
         if timestamp:
             try:
-                return datetime.fromtimestamp(float(timestamp), timezone.utc).date().isoformat()
+                return datetime.fromtimestamp(float(timestamp), timezone.utc).isoformat()
             except Exception:
                 return None
         return None

--- a/app/static/tv.js
+++ b/app/static/tv.js
@@ -121,15 +121,9 @@
       listEl.innerHTML = '<div class="tv-player-empty"><strong>Каталог пока пуст.</strong><span>Запустите Import Now.</span></div>';
       return;
     }
-    listEl.innerHTML = playlistGroups.map((group) => {
-      const items = filteredVideos.filter(group.match);
-      if (!items.length) return '';
+    const renderItems = (items) => items.map((video) => {
+      const progress = watchHistory[video.id]?.progress || 0;
       return `
-      <section class="tv-video-group" aria-label="${escapeHtml(group.title)}">
-        <h4>${escapeHtml(group.title)}</h4>
-        ${items.map((video) => {
-          const progress = watchHistory[video.id]?.progress || 0;
-          return `
           <button class="tv-video-item ${video.id === selectedId ? 'is-active' : ''}" type="button" data-video-id="${escapeHtml(video.id)}" aria-pressed="${video.id === selectedId ? 'true' : 'false'}">
             <span class="tv-video-item__meta">${CategoryBadges(video)}<span class="tv-duration-badge">${escapeHtml(video.duration || '—')}</span></span>
             <strong>${escapeHtml(video.title)}</strong>
@@ -137,9 +131,12 @@
             <span class="tv-mini-progress"><i style="width:${Math.max(0, Math.min(100, progress))}%"></i></span>
             <small>${progress >= 100 ? '✓ Watched' : progress ? `Просмотрено ${progress}%` : `${escapeHtml(video.author)} · не просмотрено`}</small>
           </button>`;
-        }).join('')}
-      </section>`;
     }).join('');
+    listEl.innerHTML = `
+      <section class="tv-video-group" aria-label="Все видео">
+        <h4>Все видео</h4>
+        ${renderItems(filteredVideos)}
+      </section>`;
   }
 
   function selectVideo(id) {

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -371,3 +371,59 @@ def test_rss_test_includes_exception_traceback(tmp_path: Path):
     assert payload["exception"]["type"] == "RuntimeError"
     assert "Traceback" in payload["traceback"]
     assert "upstream exploded" in payload["traceback"]
+
+
+def test_import_rebuild_balances_catalog_by_source_and_stats(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FXPILOT_MEDIA_MAX_PER_SOURCE", "2")
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([
+        {"id":"alpha","name":"Alpha","provider":"youtube_ytdlp","channel_url":"https://www.youtube.com/@alpha","language":"ru","priority":1,"categories":["Forex"],"enabled":True},
+        {"id":"beta","name":"Beta","provider":"youtube_ytdlp","channel_url":"https://www.youtube.com/@beta","language":"ru","priority":2,"categories":["Macro"],"enabled":True},
+    ]), encoding="utf-8")
+    catalog_path.write_text(json.dumps([
+        {"id":"youtube:Alpha000001","provider":"youtube_ytdlp","source_id":"alpha","youtube_id":"Alpha000001","title":"A1","author":"Alpha","url":"https://www.youtube.com/watch?v=Alpha000001","published_at":"2026-07-01","status":"imported"},
+        {"id":"youtube:Alpha000002","provider":"youtube_ytdlp","source_id":"alpha","youtube_id":"Alpha000002","title":"A2","author":"Alpha","url":"https://www.youtube.com/watch?v=Alpha000002","published_at":"2026-07-02","status":"imported"},
+        {"id":"youtube:Alpha000003","provider":"youtube_ytdlp","source_id":"alpha","youtube_id":"Alpha000003","title":"A3","author":"Alpha","url":"https://www.youtube.com/watch?v=Alpha000003","published_at":"2026-07-03","status":"imported"},
+    ]), encoding="utf-8")
+
+    class Provider:
+        provider_name = "youtube_ytdlp"
+        last_diagnostic = {"yt_dlp_version": "test", "execution_time": 0.01, "valid_items": 2, "skipped_invalid": 0}
+        def fetch_latest(self, source):
+            if source.id == "alpha":
+                items = [MediaItem(f"youtube:Alpha00000{i}", "youtube_ytdlp", "alpha", f"A{i}", "Alpha", f"Alpha00000{i}", f"https://www.youtube.com/watch?v=Alpha00000{i}", None, f"2026-07-0{i}", None, "Forex", "MARKET", "ru", "") for i in range(4, 7)]
+            else:
+                items = [MediaItem(f"youtube:Beta000000{i}", "youtube_ytdlp", "beta", f"B{i}", "Beta", f"Beta000000{i}", f"https://www.youtube.com/watch?v=Beta000000{i}", None, f"2026-07-0{i}", None, "Macro", "MARKET", "ru", "") for i in range(4, 6)]
+            return ImportSourceResult(source, items, "ok", 200, len(items))
+
+    engine = MediaImportEngine(sources_path, catalog_path, ytdlp_provider=Provider())
+    engine.import_latest()
+    catalog = engine.load_catalog()
+    stats = engine.stats()
+
+    assert len([item for item in catalog if item["source_id"] == "alpha"]) == 2
+    assert len([item for item in catalog if item["source_id"] == "beta"]) == 2
+    assert [item["published_at"] for item in catalog] == sorted([item["published_at"] for item in catalog], reverse=True)
+    assert stats["sources_with_videos"] == 2
+    assert stats["videos_by_source"] == {"alpha": 2, "beta": 2}
+
+
+def test_ytdlp_published_at_normalization_and_fallback(monkeypatch):
+    provider = YouTubeYtDlpProvider()
+    source = _source("https://www.youtube.com/@demo")
+    source = source.__class__(source.id, source.name, "youtube_ytdlp", source.channel_url, source.language, source.priority, source.categories, source.enabled)
+    monkeypatch.setattr(provider, "_extract_cached", lambda url: {
+        "title": "Demo Channel",
+        "entries": [
+            {"id": "Date0000001", "title": "Upload date", "upload_date": "20260706"},
+            {"id": "Time0000001", "title": "Timestamp", "timestamp": 1783382400},
+            {"id": "None0000001", "title": "No date"},
+        ],
+    })
+
+    result = provider.fetch_latest(source)
+
+    assert result.items[0].published_at == "2026-07-06"
+    assert result.items[1].published_at == "2026-07-07T00:00:00+00:00"
+    assert result.items[2].published_at == result.items[2].imported_at


### PR DESCRIPTION
### Motivation
- Исправить доминирование одного источника в каталоге после импорта через `yt-dlp`, чтобы на странице `/tv` было видно видео от нескольких авторов.  
- Стабильность сортировки и корректное отображение дат публикации для видео из `yt-dlp`.  
- Дать операторам контроль над количеством импортируемых видео с каждого источника и улучшить метрики каталога.

### Description
- Добавлен конфиг/функция `max_media_per_source()` и переменная окружения `FXPILOT_MEDIA_MAX_PER_SOURCE` с дефолтом `5`, используемая при импорте и для ограничения `playlistend` в `yt-dlp`. (изменён `app/services/media_import_engine.py` и `app/services/providers/youtube_ytdlp_provider.py`).
- При перестроении каталога теперь берутся до N (по источнику) новейших валидных видео от каждого включённого источника через метод `_balance_by_source`, а итоговый список сортируется по `published_at` по убыванию, при отсутствии — по `imported_at`. (изменён `app/services/media_import_engine.py`).
- Нормализация дат в `youtube_ytdlp` провайдере: `upload_date` преобразуется в ISO дату (`YYYY-MM-DD`), `timestamp` преобразуется в UTC ISO datetime, а при отсутствии даты используется `imported_at`. Также ограничен объём выборки per-source. (изменён `app/services/providers/youtube_ytdlp_provider.py`).
- TV UI теперь рендерит все видео, возвращаемые `GET /api/media`, вместо «показа лишь первых групп», чтобы `/tv` показывал видео из разных авторов; пересобран рендеринг списка. (изменён `app/static/tv.js`).
- Расширены статистики `GET /api/media/stats` новыми полями `sources_with_videos` и `videos_by_source`, и добавлен краткий раздел в `README.md` с описанием поведения. (изменён `app/services/media_import_engine.py`, `README.md`).
- Добавлены/обновлены регрессионные тесты для балансировки по источнику и нормализации дат. (изменён `tests/test_media_import_engine.py`).

### Testing
- Запущены `pytest tests/test_media_import_engine.py -q`, тесты прошли успешно.  
- Запущены `pytest tests/test_media_import_engine.py tests/test_tv_source_manager.py -q`, тесты прошли успешно.  
- Полный прогон `pytest -q -x` завершился с одним падением в уже существующем не связанном тесте `tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, который относится к логике идей/нарратива и не затрагивается этими изменениями.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d3dd4a35083318586d99f57314d90)