### PR TITLE
Исправить импорт FXPilot TV (yt-dlp) и восстановить Import Now

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -572,11 +572,27 @@ def api_media_resolve_all() -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+def _run_media_import() -> dict[str, Any]:
+    engine = create_media_import_engine()
+    return engine.import_latest()
+
+
 @app.post("/api/media/import")
 def api_media_import() -> dict[str, Any]:
     try:
-        engine = create_media_import_engine()
-        return engine.import_latest()
+        return _run_media_import()
+    except MediaConfigError as exc:
+        logger.exception("media_import_config_failed")
+        raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
+    except Exception as exc:
+        logger.exception("media_import_failed_before_completion")
+        raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
+
+
+@app.get("/api/media/import-now")
+def api_media_import_now() -> dict[str, Any]:
+    try:
+        return _run_media_import()
     except MediaConfigError as exc:
         logger.exception("media_import_config_failed")
         raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -400,6 +400,11 @@ class MediaImportEngine:
                 "resolved_url": None,
                 "yt_dlp_version": None,
                 "execution_time": None,
+                "fetched_raw_count": 0,
+                "valid_items": 0,
+                "skipped_invalid": 0,
+                "skipped_reasons": {},
+                "saved_catalog_items": 0,
             }
             try:
                 run_log["steps"].append(f"Processing source {source.name}")
@@ -427,8 +432,10 @@ class MediaImportEngine:
                     "resolved_url": result.source.rss_url or result.source.feed_url,
                     "yt_dlp_version": getattr(provider, "last_diagnostic", {}).get("yt_dlp_version") if source.provider == "youtube_ytdlp" else None,
                     "execution_time": getattr(provider, "last_diagnostic", {}).get("execution_time") if source.provider == "youtube_ytdlp" else (datetime.now(timezone.utc) - source_started).total_seconds(),
+                    "fetched_raw_count": getattr(provider, "last_diagnostic", {}).get("fetched_raw_count", result.videos_found) if source.provider == "youtube_ytdlp" else result.videos_found,
                     "valid_items": getattr(provider, "last_diagnostic", {}).get("valid_items", len(result.items)) if source.provider == "youtube_ytdlp" else len(result.items),
                     "skipped_invalid": getattr(provider, "last_diagnostic", {}).get("skipped_invalid", 0) if source.provider == "youtube_ytdlp" else 0,
+                    "skipped_reasons": getattr(provider, "last_diagnostic", {}).get("skipped_reasons", {}) if source.provider == "youtube_ytdlp" else {},
                     "updated_count": 0,
                 })
                 if result.error:
@@ -454,12 +461,11 @@ class MediaImportEngine:
             finally:
                 run_log["sources"].append(source_log)
 
-        valid_existing = [item for item in existing if self._is_catalog_item_importable(item)]
         valid_fetched = [item for item in fetched if self._is_catalog_item_importable(item)]
-        merged = self._balance_by_source(self._dedupe([*valid_existing, *valid_fetched]))
-        raw_count = len(valid_existing) + len(valid_fetched)
+        merged = self._balance_by_source(self._dedupe(valid_fetched))
+        raw_count = len(valid_fetched)
         duplicates_removed = max(0, raw_count - len(merged))
-        before = {str(i.get("youtube_id")) for i in valid_existing if is_valid_youtube_id(i.get("youtube_id"))}
+        before = {str(i.get("youtube_id")) for i in existing if is_valid_youtube_id(i.get("youtube_id"))}
         after = {str(i.get("youtube_id")) for i in merged if is_valid_youtube_id(i.get("youtube_id"))}
         run_log["steps"].append("Saving catalog...")
         logger.info("Saving catalog...")
@@ -467,16 +473,44 @@ class MediaImportEngine:
         for row in run_log["sources"]:
             if row.get("error"):
                 continue
+            row["saved_catalog_items"] = len([item for item in merged if item.get("source_id") == row.get("source_id")])
             row["updated_count"] = len([item for item in valid_fetched if item.get("source_id") == row.get("source_id") and str(item.get("youtube_id")) in before])
         self._save_sources(updated_sources)
         run_log["duplicates_removed"] = duplicates_removed
+        run_log["fetched_raw_count"] = sum(int(row.get("fetched_raw_count") or row.get("entries_found") or 0) for row in run_log["sources"])
+        run_log["valid_items"] = len(valid_fetched)
+        run_log["skipped_invalid"] = sum(int(row.get("skipped_invalid") or 0) for row in run_log["sources"])
+        skipped_reasons: dict[str, int] = {}
+        for row in run_log["sources"]:
+            for reason, count in (row.get("skipped_reasons") or {}).items():
+                skipped_reasons[str(reason)] = skipped_reasons.get(str(reason), 0) + int(count or 0)
+        run_log["skipped_reasons"] = skipped_reasons
+        run_log["saved_catalog_items"] = len(merged)
+        run_log["videos_by_source"] = self._videos_by_source(merged)
         run_log["catalog_items"] = len(merged)
         run_log["finished_at"] = datetime.now(timezone.utc).isoformat()
         run_log["steps"].append("DONE")
         logger.info("DONE")
         self._persist_debug_run(run_log)
         imported = len(after - before)
-        return {"success": failed == 0, "processed": processed, "imported": imported, "updated": max(0, len(valid_fetched) - imported), "failed": failed, "errors": errors, "catalog_size": len(merged), "sources": len(sources), "new_items": imported, "duplicates_removed": duplicates_removed}
+        return {
+            "success": failed == 0,
+            "processed": processed,
+            "imported": imported,
+            "updated": max(0, len(valid_fetched) - imported),
+            "failed": failed,
+            "errors": errors,
+            "catalog_size": len(merged),
+            "sources": len(sources),
+            "new_items": imported,
+            "duplicates_removed": duplicates_removed,
+            "fetched_raw_count": run_log["fetched_raw_count"],
+            "valid_items": run_log["valid_items"],
+            "skipped_invalid": run_log["skipped_invalid"],
+            "skipped_reasons": run_log["skipped_reasons"],
+            "saved_catalog_items": run_log["saved_catalog_items"],
+            "videos_by_source": run_log["videos_by_source"],
+        }
 
     def _persist_debug_run(self, run_log: dict[str, Any]) -> None:
         self.debug_path.parent.mkdir(parents=True, exist_ok=True)
@@ -530,6 +564,9 @@ class MediaImportEngine:
                 "entries_found": last_source_run.get("entries_found"),
                 "valid_items": last_source_run.get("valid_items"),
                 "skipped_invalid": last_source_run.get("skipped_invalid"),
+                "skipped_reasons": last_source_run.get("skipped_reasons"),
+                "fetched_raw_count": last_source_run.get("fetched_raw_count"),
+                "saved_catalog_items": last_source_run.get("saved_catalog_items"),
                 "imported_count": last_source_run.get("imported_count"),
                 "updated_count": last_source_run.get("updated_count"),
                 "error": last_source_run.get("error"),
@@ -567,10 +604,7 @@ class MediaImportEngine:
         manual_demo = len([item for item in catalog if item.get("status") == "manual_demo" or item.get("provider") in {"youtube_manual", "youtube-manual"}])
         real_items = [item for item in catalog if is_valid_youtube_id(item.get("youtube_id")) and item.get("status") != "manual_demo"]
         real_videos = len(real_items)
-        videos_by_source: dict[str, int] = {}
-        for item in real_items:
-            source_id = str(item.get("source_id") or "unknown")
-            videos_by_source[source_id] = videos_by_source.get(source_id, 0) + 1
+        videos_by_source = self._videos_by_source(real_items)
         return {
             "catalog_items": len(catalog),
             "real_videos": real_videos,
@@ -751,11 +785,22 @@ class MediaImportEngine:
             normalized.setdefault("source_id", "imported")
             normalized.setdefault("status", "imported")
             normalized.setdefault("language", "ru")
+            normalized.setdefault("imported_at", datetime.now(timezone.utc).isoformat())
+            if not normalized.get("published_at"):
+                normalized["published_at"] = normalized.get("imported_at")
             normalized.setdefault("thumbnail", f"https://i.ytimg.com/vi/{youtube_id}/hqdefault.jpg")
             normalized.setdefault("url", f"https://www.youtube.com/watch?v={youtube_id}")
             normalized.setdefault("symbol", detect_symbol(f"{normalized.get('title','')} {normalized.get('description','')}"))
             seen[youtube_id] = normalized
         return list(seen.values())
+
+    @staticmethod
+    def _videos_by_source(items: list[dict[str, Any]]) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for item in items:
+            source_id = str(item.get("source_id") or "unknown")
+            counts[source_id] = counts.get(source_id, 0) + 1
+        return dict(sorted(counts.items()))
 
     def _balance_by_source(self, items: list[dict[str, Any]]) -> list[dict[str, Any]]:
         limit = max_media_per_source()

--- a/app/services/providers/youtube_ytdlp_provider.py
+++ b/app/services/providers/youtube_ytdlp_provider.py
@@ -27,7 +27,7 @@ class YouTubeYtDlpProvider:
     _cache: dict[str, tuple[float, dict[str, Any]]] = {}
 
     def __init__(self, max_results: int | None = None) -> None:
-        self.max_results = max(1, min(int(max_results or max_media_per_source()), 50))
+        self.max_results = max(1, min(int(max_results or DEFAULT_MAX_RESULTS), 50))
         self.last_diagnostic: dict[str, Any] = {}
 
     def fetch_latest(self, source: MediaSource) -> ImportSourceResult:
@@ -38,7 +38,9 @@ class YouTubeYtDlpProvider:
             "resolved_url": None,
             "entries_found": 0,
             "valid_items": 0,
+            "fetched_raw_count": 0,
             "skipped_invalid": 0,
+            "skipped_reasons": {},
             "imported_count": 0,
             "errors": [],
             "execution_time": None,
@@ -51,27 +53,23 @@ class YouTubeYtDlpProvider:
             resolved_url = str(info.get("webpage_url") or info.get("original_url") or normalized_url)
             diagnostic["resolved_url"] = resolved_url
             diagnostic["entries_found"] = len(entries)
+            diagnostic["fetched_raw_count"] = len(entries)
 
             seen: set[str] = set()
             items: list[MediaItem] = []
-            for entry in entries[: max_media_per_source()]:
+            limit = max_media_per_source()
+            for entry in entries:
                 item = self._entry_to_item(entry, source, channel_title)
                 if not item or not item.youtube_id:
-                    diagnostic["skipped_invalid"] += 1
-                    logger_reason = {
-                        "entry_id": entry.get("id") or entry.get("display_id") or entry.get("url"),
-                        "reason": "invalid_youtube_id",
-                    }
-                    logger.warning("youtube_ytdlp_skip_entry source_id=%s reason=%s entry_id=%s", source.id, logger_reason["reason"], logger_reason["entry_id"])
-                    diagnostic["errors"].append(logger_reason)
+                    self._record_skip(diagnostic, source.id, entry, "invalid_youtube_id")
                     continue
                 if item.youtube_id in seen:
-                    diagnostic["skipped_invalid"] += 1
-                    logger.warning("youtube_ytdlp_skip_entry source_id=%s reason=duplicate_youtube_id entry_id=%s", source.id, item.youtube_id)
-                    diagnostic["errors"].append({"entry_id": item.youtube_id, "reason": "duplicate_youtube_id"})
+                    self._record_skip(diagnostic, source.id, entry, "duplicate_youtube_id", item.youtube_id)
                     continue
                 seen.add(item.youtube_id)
                 items.append(item)
+                if len(items) >= limit:
+                    break
 
             diagnostic["valid_items"] = len(items)
             diagnostic["imported_count"] = len(items)
@@ -115,16 +113,26 @@ class YouTubeYtDlpProvider:
         except Exception as exc:
             return {"ok": False, "provider": self.provider_name, "channel_url": source.channel_url, "error": str(exc), "yt_dlp_version": self.version(), "execution_time": round(time.perf_counter() - started, 3)}
 
+
+    @staticmethod
+    def _record_skip(diagnostic: dict[str, Any], source_id: str, entry: dict[str, Any], reason: str, entry_id: str | None = None) -> None:
+        diagnostic["skipped_invalid"] = int(diagnostic.get("skipped_invalid") or 0) + 1
+        skipped_reasons = diagnostic.setdefault("skipped_reasons", {})
+        skipped_reasons[reason] = int(skipped_reasons.get(reason) or 0) + 1
+        raw_id = entry_id or entry.get("id") or entry.get("display_id") or entry.get("url") or entry.get("webpage_url")
+        logger.warning("youtube_ytdlp_skip_entry source_id=%s reason=%s entry_id=%s", source_id, reason, raw_id)
+        diagnostic.setdefault("errors", []).append({"entry_id": raw_id, "reason": reason})
+
     def _extract_cached(self, normalized_url: str) -> dict[str, Any]:
         now = time.time()
         cached = self._cache.get(normalized_url)
         if cached and now - cached[0] < CACHE_TTL_SECONDS:
             return cached[1]
-        info = self._extract(normalized_url)
+        info = self._extract(normalized_url, self.max_results)
         self._cache[normalized_url] = (now, info)
         return info
 
-    def _extract(self, normalized_url: str) -> dict[str, Any]:
+    def _extract(self, normalized_url: str, max_results: int | None = None) -> dict[str, Any]:
         try:
             import yt_dlp
         except Exception as exc:
@@ -134,7 +142,7 @@ class YouTubeYtDlpProvider:
             "no_warnings": True,
             "skip_download": True,
             "extract_flat": "discard_in_playlist",
-            "playlistend": max_media_per_source(),
+            "playlistend": max(1, int(max_results or self.max_results)),
             "ignoreerrors": True,
             "socket_timeout": 20,
         }

--- a/app/static/media-admin.html
+++ b/app/static/media-admin.html
@@ -57,7 +57,7 @@
               <h2 id="mediaSourcesTitle">Настроенные источники</h2>
               <p class="section-text">Кнопки Enable / Disable зарезервированы под следующий спринт. Import Now уже вызывает серверный engine.</p>
             </div>
-            <div class="tv-source-actions"><button type="button" id="mediaImportNow">Import Now</button></div>
+            <div class="tv-source-actions"><button type="button" id="mediaImportNow">Import Now</button><a class="tv-source-button" href="/api/media/import-now" target="_blank" rel="noopener">Import Now (browser)</a></div>
               <pre id="mediaImportResult" class="media-import-result" aria-live="polite">—</pre>
           </div>
           <div class="tv-source-table-wrap">


### PR DESCRIPTION
### Motivation
- Восстановить работоспособность импорта YouTube через `yt-dlp` после регресса, который привёл к пустому каталогу и ошибке в админ/браузерной проверке. 
- Сделать импорт вызываемым из браузера/админки для быстрого ручного тестирования и диагностики. 
- Не терять валидные записи из-за отсутствия `published_at` или из-за некорректной логики фильтраций и валидации ID. 

### Description
- Добавлен общий раннер `def _run_media_import()` и новый endpoint `GET /api/media/import-now`, который вызывает тот же pipeline, что и `POST /api/media/import`, сохраняя POST рабочим (`app/main.py`).
- Провайдер `YouTubeYtDlpProvider` усилил поведение: введён `DEFAULT_MAX_RESULTS`, передача `max_results` в вызовы `yt-dlp`, учёт `fetched_raw_count`, аккуратная фильтрация/логирование с `_record_skip(...)` и ограничение результатов до per-source лимита (`app/services/providers/youtube_ytdlp_provider.py`).
- Исправлен rebuild каталога в `MediaImportEngine`: каталог теперь строится из валидных fetched-элементов каждого включённого `youtube_ytdlp`-источника, дедупликация по `youtube_id`, балансировка по источникам с лимитом `FXPILOT_MEDIA_MAX_PER_SOURCE`, атомарная запись `media_catalog.json`, и при отсутствии `published_at` подставляется `imported_at` (`app/services/media_import_engine.py`).
- Добавлены и агрегируются расширенные debug/health поля: `fetched_raw_count`, `valid_items`, `skipped_invalid`, `skipped_reasons`, `saved_catalog_items`, `videos_by_source` и они возвращаются в результате импорта и записываются в debug-файл (`app/services/media_import_engine.py`).
- UI: в `app/static/media-admin.html` оставлена существующая кнопка POST `Import Now` и добавлена видимая ссылка `Import Now (browser)` на новый `GET /api/media/import-now` для быстрого ручного запуска из браузера.

### Testing
- Сборка/синтаксис проверены командой `python3 -m py_compile app/main.py app/services/media_import_engine.py app/services/providers/youtube_ytdlp_provider.py` и ошибок не выявлено. 
- Запущены модульные тесты `pytest -q tests/test_media_import_engine.py` и все тесты успешно прошли (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dc140d22483318a8d89204be3c2f3)