### PR TITLE
Исправление извлечения YouTube ID в yt-dlp провайдере и диагностики пропусков

### DIFF
--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -404,6 +404,7 @@ class MediaImportEngine:
                 "valid_items": 0,
                 "skipped_invalid": 0,
                 "skipped_reasons": {},
+                "skipped_items": [],
                 "saved_catalog_items": 0,
             }
             try:
@@ -436,6 +437,7 @@ class MediaImportEngine:
                     "valid_items": getattr(provider, "last_diagnostic", {}).get("valid_items", len(result.items)) if source.provider == "youtube_ytdlp" else len(result.items),
                     "skipped_invalid": getattr(provider, "last_diagnostic", {}).get("skipped_invalid", 0) if source.provider == "youtube_ytdlp" else 0,
                     "skipped_reasons": getattr(provider, "last_diagnostic", {}).get("skipped_reasons", {}) if source.provider == "youtube_ytdlp" else {},
+                    "skipped_items": getattr(provider, "last_diagnostic", {}).get("skipped_items", [])[:20] if source.provider == "youtube_ytdlp" else [],
                     "updated_count": 0,
                 })
                 if result.error:
@@ -485,6 +487,12 @@ class MediaImportEngine:
             for reason, count in (row.get("skipped_reasons") or {}).items():
                 skipped_reasons[str(reason)] = skipped_reasons.get(str(reason), 0) + int(count or 0)
         run_log["skipped_reasons"] = skipped_reasons
+        skipped_items: list[dict[str, Any]] = []
+        for row in run_log["sources"]:
+            skipped_items.extend((row.get("skipped_items") or [])[: max(0, 20 - len(skipped_items))])
+            if len(skipped_items) >= 20:
+                break
+        run_log["skipped_items"] = skipped_items
         run_log["saved_catalog_items"] = len(merged)
         run_log["videos_by_source"] = self._videos_by_source(merged)
         run_log["catalog_items"] = len(merged)
@@ -508,8 +516,12 @@ class MediaImportEngine:
             "valid_items": run_log["valid_items"],
             "skipped_invalid": run_log["skipped_invalid"],
             "skipped_reasons": run_log["skipped_reasons"],
+            "skipped_items": run_log["skipped_items"],
             "saved_catalog_items": run_log["saved_catalog_items"],
             "videos_by_source": run_log["videos_by_source"],
+            "sources_with_videos": len(run_log["videos_by_source"]),
+            "real_videos": len([item for item in merged if is_valid_youtube_id(item.get("youtube_id")) and item.get("status") != "manual_demo"]),
+            "manual_demo": len([item for item in merged if item.get("status") == "manual_demo" or item.get("provider") in {"youtube_manual", "youtube-manual"}]),
         }
 
     def _persist_debug_run(self, run_log: dict[str, Any]) -> None:
@@ -565,6 +577,7 @@ class MediaImportEngine:
                 "valid_items": last_source_run.get("valid_items"),
                 "skipped_invalid": last_source_run.get("skipped_invalid"),
                 "skipped_reasons": last_source_run.get("skipped_reasons"),
+                "skipped_items": (last_source_run.get("skipped_items") or [])[:20],
                 "fetched_raw_count": last_source_run.get("fetched_raw_count"),
                 "saved_catalog_items": last_source_run.get("saved_catalog_items"),
                 "imported_count": last_source_run.get("imported_count"),

--- a/app/services/providers/youtube_ytdlp_provider.py
+++ b/app/services/providers/youtube_ytdlp_provider.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from app.services.media_import_engine import ImportSourceResult, MediaImportError, MediaItem, MediaSource, detect_symbol, is_valid_youtube_id, max_media_per_source
 
@@ -41,6 +41,7 @@ class YouTubeYtDlpProvider:
             "fetched_raw_count": 0,
             "skipped_invalid": 0,
             "skipped_reasons": {},
+            "skipped_items": [],
             "imported_count": 0,
             "errors": [],
             "execution_time": None,
@@ -119,9 +120,21 @@ class YouTubeYtDlpProvider:
         diagnostic["skipped_invalid"] = int(diagnostic.get("skipped_invalid") or 0) + 1
         skipped_reasons = diagnostic.setdefault("skipped_reasons", {})
         skipped_reasons[reason] = int(skipped_reasons.get(reason) or 0) + 1
-        raw_id = entry_id or entry.get("id") or entry.get("display_id") or entry.get("url") or entry.get("webpage_url")
-        logger.warning("youtube_ytdlp_skip_entry source_id=%s reason=%s entry_id=%s", source_id, reason, raw_id)
-        diagnostic.setdefault("errors", []).append({"entry_id": raw_id, "reason": reason})
+        raw_id = entry_id or entry.get("id") or entry.get("display_id")
+        raw_url = entry.get("url")
+        webpage_url = entry.get("webpage_url")
+        skipped_item = {
+            "source_id": source_id,
+            "title": str(entry.get("title") or ""),
+            "raw_id": str(raw_id or ""),
+            "raw_url": str(raw_url or ""),
+            "webpage_url": str(webpage_url or ""),
+            "reason": reason,
+        }
+        logger.warning("youtube_ytdlp_skip_entry source_id=%s reason=%s entry_id=%s raw_url=%s webpage_url=%s", source_id, reason, raw_id, raw_url, webpage_url)
+        if len(diagnostic.setdefault("skipped_items", [])) < 20:
+            diagnostic["skipped_items"].append(skipped_item)
+        diagnostic.setdefault("errors", []).append(skipped_item)
 
     def _extract_cached(self, normalized_url: str) -> dict[str, Any]:
         now = time.time()
@@ -216,16 +229,46 @@ class YouTubeYtDlpProvider:
 
     @staticmethod
     def _candidate_video_id(entry: dict[str, Any]) -> str:
-        for key in ("youtube_id", "id", "display_id"):
-            value = str(entry.get(key) or "").strip()
-            if is_valid_youtube_id(value):
-                return value
-        for key in ("url", "webpage_url"):
-            value = str(entry.get(key) or "").strip()
-            match = re.search(r"(?:v=|youtu\.be/|/embed/|/shorts/)([A-Za-z0-9_-]{11})", value)
+        for key in ("id", "url", "webpage_url", "original_url"):
+            candidate = YouTubeYtDlpProvider._extract_video_id(entry.get(key))
+            if candidate:
+                return candidate
+        ie_key = str(entry.get("ie_key") or "").strip().lower()
+        if ie_key == "youtube":
+            for key in ("id", "url", "webpage_url", "original_url"):
+                value = str(entry.get(key) or "").strip()
+                if value:
+                    candidate = YouTubeYtDlpProvider._extract_video_id(f"https://www.youtube.com/watch?v={value}")
+                    if candidate:
+                        return candidate
+        for key in ("youtube_id", "display_id"):
+            candidate = YouTubeYtDlpProvider._extract_video_id(entry.get(key))
+            if candidate:
+                return candidate
+        return str(entry.get("id") or entry.get("url") or entry.get("webpage_url") or entry.get("display_id") or "").strip()
+
+    @staticmethod
+    def _extract_video_id(value: Any) -> str | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        if is_valid_youtube_id(text):
+            return text
+        parsed = urlparse(text if re.match(r"^https?://", text, re.I) else f"https://www.youtube.com{text if text.startswith('/') else '/' + text}")
+        query_id = parse_qs(parsed.query).get("v", [None])[0]
+        if is_valid_youtube_id(query_id):
+            return str(query_id)
+        patterns = (
+            r"(?:^|/)watch/?$",  # query already handled above
+            r"(?:^|/)shorts/([A-Za-z0-9_-]{11})(?:[/?#]|$)",
+            r"(?:^|/)embed/([A-Za-z0-9_-]{11})(?:[/?#]|$)",
+            r"youtu\.be/([A-Za-z0-9_-]{11})(?:[/?#]|$)",
+        )
+        for pattern in patterns[1:]:
+            match = re.search(pattern, text)
             if match and is_valid_youtube_id(match.group(1)):
                 return match.group(1)
-        return str(entry.get("id") or entry.get("display_id") or "").strip()
+        return None
 
     @staticmethod
     def _published_at(entry: dict[str, Any]) -> str | None:

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -157,6 +157,40 @@ def test_ytdlp_invalid_video_id_skipped(monkeypatch):
     assert provider.last_diagnostic["skipped_invalid"] == 2
 
 
+def test_ytdlp_extracts_video_id_from_supported_fields(monkeypatch):
+    provider = YouTubeYtDlpProvider(max_results=10)
+    source = _source("https://www.youtube.com/@demo")
+    source = source.__class__(source.id, source.name, "youtube_ytdlp", source.channel_url, source.language, source.priority, source.categories, source.enabled)
+    monkeypatch.setattr(provider, "_extract_cached", lambda url: {
+        "title": "Demo Channel",
+        "entries": [
+            {"id": "Flat0000001", "title": "Flat id"},
+            {"id": "playlist-entry-1", "url": "https://www.youtube.com/watch?v=Url00000001", "title": "URL watch"},
+            {"id": "playlist-entry-2", "webpage_url": "https://www.youtube.com/watch?v=Web00000001", "title": "Webpage watch"},
+            {"id": "playlist-entry-3", "webpage_url": "https://www.youtube.com/shorts/Sho00000001?feature=share", "title": "Shorts"},
+            {"id": "bad", "title": "Invalid id"},
+        ],
+    })
+
+    result = provider.fetch_latest(source)
+
+    assert [item.youtube_id for item in result.items] == ["Flat0000001", "Url00000001", "Web00000001", "Sho00000001"]
+    assert provider.last_diagnostic["skipped_invalid"] == 1
+    assert provider.last_diagnostic["skipped_items"] == [{
+        "source_id": "demo",
+        "title": "Invalid id",
+        "raw_id": "bad",
+        "raw_url": "",
+        "webpage_url": "",
+        "reason": "invalid_youtube_id",
+    }]
+
+
+def test_ytdlp_extract_video_id_from_relative_watch_original_and_youtube_ie_key():
+    assert YouTubeYtDlpProvider._candidate_video_id({"url": "/watch?v=Rel00000001"}) == "Rel00000001"
+    assert YouTubeYtDlpProvider._candidate_video_id({"original_url": "https://youtu.be/Org00000001?t=10"}) == "Org00000001"
+    assert YouTubeYtDlpProvider._candidate_video_id({"ie_key": "Youtube", "url": "Iek00000001"}) == "Iek00000001"
+
 def test_catalog_merge_by_youtube_id_and_save_load(tmp_path: Path):
     sources_path = tmp_path / "media_sources.json"
     catalog_path = tmp_path / "media_catalog.json"


### PR DESCRIPTION
### Motivation
- Исправить пропуск валидных видео от разных источников из-за некорректного извлечения/валидации `youtube_id` в `YouTubeYtDlpProvider`.
- Добавить понятную диагностику пропущенных записей, чтобы не терять валидные элементы при наличии некорректных записей.

### Description
- Обновлён алгоритм извлечения ID: теперь проверяются поля в порядке `id`, `url`, `webpage_url`, `original_url`, затем fallback для `ie_key="Youtube"`, и дополнительно `youtube_id`/`display_id`, при этом парсятся URL-формы `watch?v=`, `youtu.be/`, `/shorts/`, `/embed/` и относительные `/watch?v=` и query-параметр `v=` (файл `app/services/providers/youtube_ytdlp_provider.py`).
- Добавлена вспомогательная функция `_extract_video_id` для аккуратного парсинга и проверки по `is_valid_youtube_id` (11 символов, regex и не начинается с `DEMO`).
- Добавлена структурированная диагностика пропусков `skipped_items` с полями `source_id`, `title`, `raw_id`, `raw_url`, `webpage_url`, `reason` и ограничением первых 20 записей, и логирование этих элементов при импорте (файлы `app/services/providers/youtube_ytdlp_provider.py` и `app/services/media_import_engine.py`).
- Не выбрасывается весь источник при наличии некорректных записей — все валидные элементы сохраняются и лимит применяется к валидным записям; диагностика `skipped_items` проброшена в результат импорта и `GET /api/media/debug`, также добавлены счётчики `sources_with_videos`, `real_videos` и `manual_demo` в ответ импортера (файл `app/services/media_import_engine.py`).
- Добавлены/обновлены тесты для покрытия случаев: flat playlist `id`, `entry.url` с `watch?v=`, `entry.webpage_url` с `watch?v=`, shorts URL, относительный `/watch?v=`, `original_url`, `ie_key` fallback и некорректный ID (файл `tests/test_media_import_engine.py`).

### Testing
- Выполнена компиляция модифицированных модулей: `python -m py_compile app/services/providers/youtube_ytdlp_provider.py app/services/media_import_engine.py` — успешно.
- Запущены модульные тесты `pytest -q tests/test_media_import_engine.py -q` и связанные yt-dlp проверки — все тесты прошли успешно.
- Полный прогон с `pytest -q tests/test_media_import_engine.py tests/test_youtube_api_provider.py -q` выявил существующий, не связанный с этими изменениями, разрыв в тесте `test_incremental_import_uses_latest_catalog_date` в API-провайдере YouTube; это поведение тестовой фикстуры (`publishedAfter` отсутствует) не касалось правок yt-dlp и требует отдельного расследования.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dd3ef33ac8331b3eb0ec4103688d4)