### PR TITLE
FXPilot TV: добавить фактический Review и API /api/media/review

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -510,21 +510,148 @@ def _load_tv_video_catalog() -> list[dict[str, Any]]:
         logger.warning("media_catalog_unavailable error=%s", exc)
         return []
 
-def _build_tv_review_payload(video: dict[str, Any]) -> dict[str, Any]:
+def _normalize_review_symbol(value: Any) -> str:
+    return "".join(ch for ch in str(value or "").upper() if ch.isalnum())
+
+
+def _first_review_value(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _review_ideas(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    ideas: list[dict[str, Any]] = []
+    for key in ("ideas", "signals", "active", "archive"):
+        values = payload.get(key)
+        if isinstance(values, list):
+            ideas.extend(item for item in values if isinstance(item, dict))
+    return ideas
+
+
+def _find_review_market_idea(market_payload: dict[str, Any], symbol: str) -> dict[str, Any] | None:
+    wanted = _normalize_review_symbol(symbol)
+    if not wanted:
+        return None
+    for idea in _review_ideas(market_payload):
+        candidate = _normalize_review_symbol(_first_review_value(idea.get("symbol"), idea.get("pair"), idea.get("instrument"), idea.get("ticker")))
+        if candidate == wanted:
+            return idea
+    return None
+
+
+def _review_direction(idea: dict[str, Any] | None) -> str | None:
+    if not idea:
+        return None
+    raw = str(_first_review_value(idea.get("action"), idea.get("direction"), idea.get("signal"), idea.get("final_signal"), idea.get("recommendation"), idea.get("bias"), "") or "").strip().upper()
+    if raw in {"BUY", "LONG", "BULLISH", "ПОКУПКА", "БЫЧИЙ"}:
+        return "BUY"
+    if raw in {"SELL", "SHORT", "BEARISH", "ПРОДАЖА", "МЕДВЕЖИЙ"}:
+        return "SELL"
+    return raw or None
+
+
+def _review_number(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 1:
+        number *= 100
+    return max(0.0, min(100.0, number))
+
+
+def _review_available(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None or value == "":
+        return False
+    return str(value).strip().lower() not in {"false", "0", "none", "null", "unavailable", "недоступно"}
+
+
+def _review_news_support(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return True
+    negative = ("high", "risk", "negative", "bearish", "conflict", "blocked", "красн", "риск", "негатив", "конфликт")
+    return not any(token in text for token in negative)
+
+
+def _build_review_market_model(video: dict[str, Any], idea: dict[str, Any] | None) -> dict[str, Any]:
+    levels = idea.get("levels", {}) if isinstance(idea, dict) and isinstance(idea.get("levels"), dict) else {}
+    setup = idea.get("setup", {}) if isinstance(idea, dict) and isinstance(idea.get("setup"), dict) else {}
+    orderflow = idea.get("orderflow", {}) if isinstance(idea, dict) and isinstance(idea.get("orderflow"), dict) else {}
+    options = idea.get("options", {}) if isinstance(idea, dict) and isinstance(idea.get("options"), dict) else {}
+    news = idea.get("news", {}) if isinstance(idea, dict) and isinstance(idea.get("news"), dict) else {}
+    context = idea.get("market_context", {}) if isinstance(idea, dict) and isinstance(idea.get("market_context"), dict) else {}
+    idea = idea or {}
+    confidence = _first_review_value(idea.get("confidence"), idea.get("score"), idea.get("confidence_score"), idea.get("prop_score"), idea.get("total_score"), idea.get("confluence"))
+    return {
+        "symbol": _first_review_value(idea.get("symbol"), idea.get("pair"), idea.get("instrument"), video.get("symbol")),
+        "direction": _review_direction(idea),
+        "entry": _first_review_value(idea.get("entry"), idea.get("entry_price"), idea.get("entryPrice"), levels.get("entry"), setup.get("entry")),
+        "sl": _first_review_value(idea.get("sl"), idea.get("stop_loss"), idea.get("stopLoss"), levels.get("sl"), levels.get("stop_loss")),
+        "tp": _first_review_value(idea.get("tp"), idea.get("take_profit"), idea.get("takeProfit"), levels.get("tp"), levels.get("take_profit")),
+        "confidence": _review_number(confidence),
+        "orderflow_status": "available" if _review_available(_first_review_value(idea.get("orderflow_available"), idea.get("order_flow_available"), orderflow.get("available"), idea.get("orderflow_bias"), orderflow.get("bias"))) else "unavailable",
+        "orderflow_bias": _first_review_value(idea.get("orderflow_bias"), idea.get("orderFlowBias"), orderflow.get("bias")),
+        "options_status": "available" if _review_available(_first_review_value(idea.get("options_available"), idea.get("optionsAvailable"), options.get("available"), idea.get("options_bias"), options.get("bias"))) else "unavailable",
+        "options_bias": _first_review_value(idea.get("options_bias"), idea.get("optionsBias"), idea.get("external_options_bias"), options.get("bias")),
+        "news_status": _first_review_value(idea.get("news_risk"), idea.get("newsRisk"), news.get("risk"), idea.get("news_status"), "neutral"),
+        "institutional_narrative": _first_review_value(idea.get("institutional_narrative"), idea.get("narrative"), context.get("institutional_narrative")),
+        "raw_idea": idea or None,
+    }
+
+
+def _review_confluence_score(video: dict[str, Any], model: dict[str, Any], has_idea: bool) -> int:
+    score = 0
+    if has_idea and _normalize_review_symbol(video.get("symbol")) == _normalize_review_symbol(model.get("symbol")):
+        score += 20
+    if model.get("direction") in {"BUY", "SELL"}:
+        score += 15
+    if model.get("orderflow_status") == "available":
+        score += 15
+    if model.get("options_status") == "available":
+        score += 15
+    if _review_news_support(model.get("news_status")):
+        score += 10
+    score += round((model.get("confidence") or 0) * 0.25)
+    return max(0, min(100, int(score)))
+
+
+def _review_verdict(model: dict[str, Any], score: int, has_idea: bool) -> str:
+    if not has_idea or score < 35:
+        return "FXPilot has insufficient data."
+    if score < 65:
+        return "FXPilot warns that confirmation is weak."
+    return "FXPilot currently supports this market context."
+
+
+def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    market_payload = market_payload if isinstance(market_payload, dict) else ideas_market()
+    idea = _find_review_market_idea(market_payload, str(video.get("symbol") or ""))
+    model = _build_review_market_model(video, idea)
+    score = _review_confluence_score(video, model, idea is not None)
     return {
         "video": video,
-        "review": {
-            "ai_summary": "Премиальный шаблон FXPilot Review уже готов: выбранный видеообзор отображается рядом с рыночным контекстом платформы. Реальная AI-расшифровка и анализ тезисов автора пока не выполняются.",
-            "fxpilot_opinion": "Текущий взгляд FXPilot берется из существующего /api/ideas/market на стороне страницы review. Торговая логика, скоринг и OrderFlow Engine не изменяются.",
-            "agreement_score": 72,
-            "main_conclusions": [
-                "Будущий AI-модуль будет извлекать тезисы автора, уровни, риск и условия отмены сценария.",
-                "Сценарии видео будут сопоставляться с текущим FXPilot-контекстом по тому же инструменту.",
-                "Reality Check и Trust Score подготовлены как интерфейсные блоки без реального рейтинга автора.",
-            ],
-            "reality_check": {"status": "coming_soon", "label": "Coming Soon"},
-            "trust_score": {"status": "coming_soon", "label": "Coming Soon"},
+        "author_source": {
+            "author": video.get("author"),
+            "provider": video.get("provider"),
+            "source_id": video.get("source_id"),
+            "youtube_id": video.get("youtube_id"),
         },
+        "detected_symbol": video.get("symbol"),
+        "current_fxpilot_idea": model,
+        "comparison": {
+            "video_says": "No transcript yet. AI summary will appear later.",
+            "fxpilot_says": model,
+        },
+        "confluence_score": score,
+        "preliminary_verdict": _review_verdict(model, score, idea is not None),
+        "source_endpoints": {"media": "/api/media", "market": "/api/ideas/market"},
     }
 
 
@@ -649,12 +776,21 @@ def api_tv_sources_stats() -> dict[str, Any]:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
-@app.get("/api/tv/review/{video_id}")
-def api_tv_review(video_id: str) -> dict[str, Any]:
+def _get_media_review(video_id: str) -> dict[str, Any]:
     for video in _load_tv_video_catalog():
         if video.get("id") == video_id:
             return _build_tv_review_payload(video)
     raise HTTPException(status_code=404, detail="TV video not found")
+
+
+@app.get("/api/media/review/{video_id}")
+def api_media_review(video_id: str) -> dict[str, Any]:
+    return _get_media_review(video_id)
+
+
+@app.get("/api/tv/review/{video_id}")
+def api_tv_review(video_id: str) -> dict[str, Any]:
+    return _get_media_review(video_id)
 
 
 @app.get("/news", include_in_schema=False)

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3539,3 +3539,20 @@ body[data-page="tv-sources"] {
   font-size: 0.82rem;
 }
 .media-source-form{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:12px;margin-top:14px}.media-source-form label{display:grid;gap:6px;color:#90a4c3;font-size:.82rem;text-transform:uppercase;letter-spacing:.06em}.media-source-form input,.media-source-form select{border:1px solid rgba(104,143,191,.24);background:rgba(8,18,30,.9);color:#e8eef8;border-radius:12px;padding:11px}.media-source-form .media-check{display:flex;align-items:center;gap:10px;text-transform:none;letter-spacing:0}.media-source-form .tv-source-actions{align-items:end}
+
+.tv-comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.tv-review-wide-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 820px) {
+  .tv-comparison-grid,
+  .tv-review-wide-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -3,190 +3,88 @@
   if (!root || !window.FXPilotTv) return;
 
   const { escapeHtml, formatDate, thumbnailUrl, CategoryBadges, ReviewSection } = window.FXPilotTv;
-
   const getVideoId = () => {
     const parts = window.location.pathname.split('/').filter(Boolean);
     return parts[0] === 'tv' && parts[1] === 'review' ? decodeURIComponent(parts[2] || '') : '';
   };
+  const value = (input, fallback = '—') => (input === undefined || input === null || input === '' ? fallback : input);
+  const percent = (input) => input === undefined || input === null || input === '' ? '—' : `${Math.round(Number(input))}%`;
+  const statusRu = (status) => status === 'available' ? 'Доступен' : 'Недоступен';
+  const directionRu = (direction) => direction === 'BUY' ? 'Покупка' : direction === 'SELL' ? 'Продажа' : value(direction, 'Нет направления');
+  const verdictRu = (verdict) => ({
+    'FXPilot currently supports this market context.': 'FXPilot сейчас поддерживает этот рыночный контекст.',
+    'FXPilot has insufficient data.': 'У FXPilot недостаточно данных.',
+    'FXPilot warns that confirmation is weak.': 'FXPilot предупреждает: подтверждение слабое.',
+  }[verdict] || verdict || 'Вердикт недоступен.');
 
-  const asArray = (value) => Array.isArray(value) ? value : [];
-  const firstDefined = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
-  const normalizeSymbol = (value) => String(value || '').replace(/[^A-Z0-9]/gi, '').toUpperCase();
-  const normalizeText = (value) => String(value || '').trim();
-  const formatValue = (value) => firstDefined(value, '—');
-  const toNumber = (value) => {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  };
-  const percent = (value) => {
-    const number = toNumber(value);
-    if (number === null) return '—';
-    return `${Math.max(0, Math.min(100, Math.round(number)))}%`;
-  };
-
-  function flattenIdeas(payload) {
-    if (!payload || typeof payload !== 'object') return [];
-    return [...asArray(payload.ideas), ...asArray(payload.signals), ...asArray(payload.active), ...asArray(payload.archive)]
-      .filter((item) => item && typeof item === 'object');
-  }
-
-  function findMarketContext(payload, symbol) {
-    const wanted = normalizeSymbol(symbol);
-    if (!wanted) return null;
-    return flattenIdeas(payload).find((idea) => normalizeSymbol(firstDefined(idea.symbol, idea.pair, idea.instrument, idea.ticker)) === wanted) || null;
-  }
-
-  function directionOf(idea) {
-    const raw = normalizeText(firstDefined(idea?.action, idea?.direction, idea?.signal, idea?.final_signal, idea?.recommendation, idea?.bias, 'WAIT'));
-    const upper = raw.toUpperCase();
-    if (['BUY', 'ПОКУПКА', 'LONG', 'BULLISH', 'БЫЧИЙ'].includes(upper)) return 'BUY';
-    if (['SELL', 'ПРОДАЖА', 'SHORT', 'BEARISH', 'МЕДВЕЖИЙ'].includes(upper)) return 'SELL';
-    return upper || 'WAIT';
-  }
-
-  function marketModel(idea, symbol) {
-    const entry = firstDefined(idea?.entry, idea?.entry_price, idea?.entryPrice, idea?.levels?.entry, idea?.setup?.entry);
-    const sl = firstDefined(idea?.sl, idea?.stop_loss, idea?.stopLoss, idea?.levels?.sl, idea?.levels?.stop_loss);
-    const tp = firstDefined(idea?.tp, idea?.take_profit, idea?.takeProfit, idea?.levels?.tp, idea?.levels?.take_profit);
-    const confidence = firstDefined(idea?.confidence, idea?.score, idea?.confidence_score, idea?.prop_score, idea?.total_score, idea?.confluence);
-    return {
-      symbol: firstDefined(idea?.symbol, idea?.pair, idea?.instrument, symbol, '—'),
-      price: firstDefined(idea?.current_price, idea?.price, idea?.market_price, idea?.market_data?.price, idea?.snapshot?.price),
-      direction: idea ? directionOf(idea) : 'WAIT',
-      entry,
-      sl,
-      tp,
-      confidence,
-      grade: firstDefined(idea?.grade, idea?.rating, idea?.quality_grade, idea?.prop_grade),
-      mode: firstDefined(idea?.mode, idea?.signal_mode, idea?.data_mode, idea?.market_data?.mode, idea?.data_source_label),
-      updatedAt: firstDefined(idea?.updated_at, idea?.timestamp, idea?.created_at, idea?.market_data?.updated_at),
-      trend: firstDefined(idea?.trend, idea?.trend_regime, idea?.regime, idea?.market_regime, idea?.market_context?.trend),
-      structure: firstDefined(idea?.market_structure, idea?.structure, idea?.smc?.market_structure, idea?.market_context?.structure),
-      newsRisk: firstDefined(idea?.news_risk, idea?.newsRisk, idea?.news?.risk, idea?.news_context?.risk),
-      orderflowAvailable: firstDefined(idea?.orderflow_available, idea?.order_flow_available, idea?.orderflow?.available),
-      orderflowBias: firstDefined(idea?.orderflow_bias, idea?.orderFlowBias, idea?.orderflow?.bias),
-      optionsAvailable: firstDefined(idea?.options_available, idea?.optionsAvailable, idea?.options?.available),
-      optionsBias: firstDefined(idea?.options_bias, idea?.optionsBias, idea?.external_options_bias, idea?.options?.bias),
-      institutional: firstDefined(idea?.institutional_narrative, idea?.narrative, idea?.market_context?.institutional_narrative),
-      sourceQuality: firstDefined(idea?.data_source_quality, idea?.source_quality, idea?.market_data?.data_source_quality),
-    };
-  }
-
-  function statusFrom(value, direction) {
-    const text = normalizeText(value).toUpperCase();
-    if (!text) return 'neutral';
-    if (direction && text.includes(direction)) return 'agree';
-    if (['BUY', 'SELL'].includes(text) && text !== direction) return 'conflict';
-    if (text.includes('BEAR') && direction === 'BUY') return 'conflict';
-    if (text.includes('BULL') && direction === 'SELL') return 'conflict';
-    if (text.includes('RISK') || text.includes('CONFLICT')) return 'conflict';
-    if (text.includes('NEUTRAL') || text.includes('WAIT') || text.includes('ОЖИД')) return 'neutral';
-    return 'agree';
-  }
-
-  function intelligenceCards(model) {
-    const direction = model.direction;
-    return [
-      { icon: '◇', title: 'Smart Money', status: statusFrom(model.structure, direction), summary: model.structure ? `Структура рынка: ${model.structure}` : 'SMC-контекст не найден в текущем payload FXPilot.', confidence: model.confidence },
-      { icon: '⇄', title: 'OrderFlow', status: model.orderflowAvailable ? statusFrom(model.orderflowBias || direction, direction) : 'neutral', summary: model.orderflowAvailable ? `OrderFlow bias: ${formatValue(model.orderflowBias || direction)}` : 'OrderFlow недоступен или отключён; подтверждение не подменяется proxy-значением.', confidence: model.orderflowAvailable ? model.confidence : null },
-      { icon: '🏛', title: 'Institutional Narrative', status: statusFrom(model.institutional || direction, direction), summary: model.institutional || `Институциональный сценарий следует текущему направлению FXPilot: ${direction}.`, confidence: model.confidence },
-      { icon: '⌁', title: 'Options', status: model.optionsAvailable ? statusFrom(model.optionsBias, direction) : 'neutral', summary: model.optionsAvailable ? `Options bias: ${formatValue(model.optionsBias)}. Метрики помечены как доступные из текущего FXPilot.` : 'Опционные данные недоступны; proxy metrics не используются.', confidence: model.optionsAvailable ? model.confidence : null },
-      { icon: '📰', title: 'News', status: statusFrom(model.newsRisk, direction), summary: model.newsRisk ? `Новостной риск: ${model.newsRisk}` : 'Новостной фон не содержит явного конфликта в текущем payload.', confidence: model.confidence },
-      { icon: '▣', title: 'Market Structure', status: statusFrom(model.structure, direction), summary: model.structure ? `Текущая структура: ${model.structure}` : 'Структурный слой пока не вернул детализированное состояние.', confidence: model.confidence },
-      { icon: '↗', title: 'Trend', status: statusFrom(model.trend || direction, direction), summary: model.trend ? `Трендовый режим: ${model.trend}` : `Тренд читается через направление текущего сигнала: ${direction}.`, confidence: model.confidence },
-      { icon: '⚖', title: 'Risk / Reward', status: model.entry && model.sl && model.tp ? 'agree' : 'neutral', summary: model.entry && model.sl && model.tp ? `План уровней: вход ${model.entry}, SL ${model.sl}, TP ${model.tp}.` : 'Полный набор Entry / SL / TP не найден, оценка R/R нейтральная.', confidence: model.confidence },
-    ];
-  }
-
-  const statusLabel = (status) => ({ agree: 'Agree', neutral: 'Neutral', conflict: 'Conflict' }[status] || 'Neutral');
-
-  function renderVideoSection(video) {
+  function renderVideoInfo(video) {
     const thumb = thumbnailUrl(video);
-    return ReviewSection({ id: 'videoIntel', className: 'tv-review-section--summary', title: 'Видео', content: `
+    return ReviewSection({ id: 'videoInfo', className: 'tv-review-section--summary', title: 'Video info', content: `
       <div class="tv-intel-video">
         <div class="tv-intel-thumb" style="${thumb ? `background-image:url('${escapeHtml(thumb)}')` : ''}" aria-label="Thumbnail"></div>
         <div class="tv-intel-video__body">
-          <div class="tv-detail-top"><div>${CategoryBadges(video)}<span class="tv-duration-badge">${escapeHtml(formatValue(video.duration))}</span></div><time datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time></div>
+          <div class="tv-detail-top"><div>${CategoryBadges(video)}</div><time datetime="${escapeHtml(video.published_at)}">${escapeHtml(formatDate(video.published_at))}</time></div>
           <h2>${escapeHtml(video.title || 'Видеообзор FXPilot TV')}</h2>
+          <p>${escapeHtml(video.description || 'Описание недоступно.')}</p>
           <div class="tv-player-meta-grid tv-review-meta-grid">
-            ${[['Автор', video.author], ['Дата публикации', formatDate(video.published_at)], ['Длительность', video.duration], ['Категория', video.category], ['Символ', video.symbol], ['Таймфрейм', video.timeframe]].map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(formatValue(value))}</strong></div>`).join('')}
+            ${[['Длительность', video.duration], ['Категория', video.category], ['Таймфрейм', video.timeframe], ['YouTube ID', video.youtube_id]].map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}
           </div>
         </div>
       </div>` });
   }
 
-  function renderAuthorThesis() {
-    return ReviewSection({ id: 'authorThesis', className: 'tv-review-section--summary tv-author-thesis', title: 'Тезис автора', content: '<div class="tv-premium-placeholder"><strong>No transcript available.</strong><p>AI Summary will appear after transcript analysis.</p></div>' });
+  function renderSource(review) {
+    const source = review.author_source || {};
+    return ReviewSection({ id: 'authorSource', className: 'tv-review-section--summary', title: 'Author/source', content: `
+      <div class="tv-snapshot-grid">
+        ${[['Автор', source.author], ['Provider', source.provider], ['Source ID', source.source_id], ['Detected symbol', review.detected_symbol]].map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}
+      </div>` });
   }
 
-  function renderFxPilotAnalysis(cards) {
-    return ReviewSection({ id: 'fxpilotAnalysis', className: 'tv-review-section--summary', title: 'FXPilot Analysis', content: `<div class="tv-intel-card-grid">${cards.map((card) => `<article class="tv-intel-card is-${escapeHtml(card.status)}"><div class="tv-intel-card__icon">${escapeHtml(card.icon)}</div><div><span>${escapeHtml(statusLabel(card.status))}</span><h3>${escapeHtml(card.title)}</h3><p>${escapeHtml(card.summary)}</p><small>Confidence: ${escapeHtml(percent(card.confidence))}</small></div></article>`).join('')}</div>` });
-  }
-
-  function renderSnapshot(model) {
-    const rows = [['Current price', model.price], ['Direction', model.direction], ['Entry', model.entry], ['SL', model.sl], ['TP', model.tp], ['Confidence', percent(model.confidence)], ['Grade', model.grade], ['Mode', model.mode], ['Update time', model.updatedAt]];
-    return ReviewSection({ id: 'marketSnapshot', className: 'tv-review-section--summary', title: 'Market Snapshot', content: `<div class="tv-snapshot-grid">${rows.map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(formatValue(value))}</strong></div>`).join('')}</div><p class="tv-context-note">Снимок построен из /api/ideas/market и не является анализом transcript.</p>` });
-  }
-
-  function confluence(model) {
-    const direction = model.direction;
-    const items = [
-      ['Direction', ['BUY', 'SELL'].includes(direction) ? 'agree' : 'neutral'],
-      ['Entry zone', model.entry ? 'agree' : 'neutral'],
-      ['Trend', statusFrom(model.trend || direction, direction)],
-      ['Structure', statusFrom(model.structure, direction)],
-      ['News', statusFrom(model.newsRisk, direction)],
-      ['OrderFlow', model.orderflowAvailable ? statusFrom(model.orderflowBias || direction, direction) : 'neutral'],
+  function renderIdea(review) {
+    const idea = review.current_fxpilot_idea || {};
+    const rows = [
+      ['Detected symbol', review.detected_symbol],
+      ['Current FXPilot idea for that symbol', idea.symbol],
+      ['Direction', directionRu(idea.direction)],
+      ['Entry', idea.entry],
+      ['SL', idea.sl],
+      ['TP', idea.tp],
+      ['Confidence', percent(idea.confidence)],
+      ['OrderFlow status', `${statusRu(idea.orderflow_status)}${idea.orderflow_bias ? ` · ${idea.orderflow_bias}` : ''}`],
+      ['Options status', `${statusRu(idea.options_status)}${idea.options_bias ? ` · ${idea.options_bias}` : ''}`],
+      ['News status', idea.news_status || 'neutral'],
+      ['Institutional Narrative', idea.institutional_narrative],
     ];
-    const score = Math.round(items.reduce((sum, [, status]) => sum + (status === 'agree' ? 100 : status === 'neutral' ? 50 : 0), 0) / items.length);
-    return { items, score };
+    return ReviewSection({ id: 'fxpilotIdea', className: 'tv-review-section--summary', title: 'Current FXPilot idea', content: `<div class="tv-snapshot-grid tv-review-wide-grid">${rows.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div><p class="tv-context-note">Контекст построен фактически из /api/ideas/market. Transcript и LLM не используются.</p>` });
   }
 
-  function renderConfluence(result) {
-    return ReviewSection({ id: 'confluence', className: 'tv-review-section--summary', title: 'Confluence', content: `<div class="tv-confluence-score"><strong>${result.score}</strong><span>Agreement Score</span></div><div class="tv-confluence-list">${result.items.map(([label, status]) => `<div class="is-${escapeHtml(status)}"><span>${escapeHtml(label)}</span><strong>${escapeHtml(statusLabel(status))}</strong></div>`).join('')}</div>` });
+  function renderComparison(review) {
+    const idea = review.current_fxpilot_idea || {};
+    return ReviewSection({ id: 'comparison', className: 'tv-review-section--summary', title: 'Comparison', content: `
+      <div class="tv-comparison-grid">
+        <article class="tv-premium-placeholder"><strong>Что говорит видео</strong><p>${escapeHtml(review.comparison?.video_says || 'No transcript yet. AI summary will appear later.')}</p></article>
+        <article class="tv-premium-placeholder"><strong>Что говорит FXPilot</strong><p>${escapeHtml(`Символ: ${value(idea.symbol)} · направление: ${directionRu(idea.direction)} · вход: ${value(idea.entry)} · SL: ${value(idea.sl)} · TP: ${value(idea.tp)} · confidence: ${percent(idea.confidence)}`)}</p></article>
+      </div>` });
   }
 
-  function renderVerdict(model, confluenceResult) {
-    const directionText = model.direction === 'BUY' ? 'BUY' : model.direction === 'SELL' ? 'SELL' : 'WAIT';
-    const orderflow = confluenceResult.items.find(([label]) => label === 'OrderFlow')?.[1];
-    const news = confluenceResult.items.find(([label]) => label === 'News')?.[1];
-    const tone = confluenceResult.score >= 70 ? 'поддерживает текущий сценарий' : confluenceResult.score >= 45 ? 'даёт смешанную картину' : 'конфликтует с текущим сценарием';
-    const lines = [
-      `FXPilot сейчас ${tone} по ${model.symbol}: направление ${directionText}.`,
-      `OrderFlow: ${statusLabel(orderflow)}.`,
-      `News: ${statusLabel(news)}.`,
-      model.institutional ? `Institutional Narrative: ${model.institutional}.` : `Institutional Narrative поддерживает ${directionText}, если текущий сигнал не WAIT.`,
-    ];
-    return ReviewSection({ id: 'preliminaryVerdict', className: 'tv-review-section--summary tv-verdict-section', title: 'Preliminary Verdict', content: `<div class="tv-verdict"><strong>${confluenceResult.score >= 70 ? 'Scenario Supported' : confluenceResult.score >= 45 ? 'Needs Confirmation' : 'Scenario Conflict'}</strong>${lines.map((line) => `<p>${escapeHtml(line)}</p>`).join('')}</div>` });
+  function renderScore(review) {
+    return ReviewSection({ id: 'confluenceScore', className: 'tv-review-section--summary tv-verdict-section', title: 'Confluence Score', content: `<div class="tv-confluence-score"><strong>${escapeHtml(value(review.confluence_score, 0))}</strong><span>0-100</span></div><p class="tv-context-note">Скоринг: совпадение символа, наличие направления, OrderFlow, options, нейтральный/позитивный news-фон и confidence.</p>` });
   }
 
-  function renderComingSoon() {
-    const modules = ['Reality Check', 'Trust Score', 'AI Summary', 'Transcript', 'Historical Similarity'];
-    return ReviewSection({ id: 'comingSoon', className: 'tv-review-section--summary', title: 'Coming Soon', content: `<div class="tv-coming-grid">${modules.map((item) => `<div class="tv-premium-placeholder"><strong>${escapeHtml(item)}</strong><p>Будущий AI-модуль подключится к этому reusable блоку без редизайна страницы.</p></div>`).join('')}</div>` });
+  function renderVerdict(review) {
+    return ReviewSection({ id: 'preliminaryVerdict', className: 'tv-review-section--summary tv-verdict-section', title: 'Preliminary verdict', content: `<div class="tv-verdict"><strong>${escapeHtml(verdictRu(review.preliminary_verdict))}</strong><p>Это предварительная проверка рыночного контекста, а не анализ тезисов автора видео.</p></div>` });
   }
 
-  function ReviewPage(payload, marketPayload) {
-    const video = payload.video || {};
-    const marketIdea = findMarketContext(marketPayload, video.symbol);
-    const model = marketModel(marketIdea, video.symbol);
-    const cards = intelligenceCards(model);
-    const confluenceResult = confluence(model);
-    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">AI Review Engine v1: текущая разведка FXPilot без LLM, transcript parsing и YouTube API.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoSection(video)}${renderAuthorThesis()}${renderFxPilotAnalysis(cards)}${renderSnapshot(model)}${renderConfluence(confluenceResult)}${renderVerdict(model, confluenceResult)}${renderComingSoon()}</div>`;
+  function ReviewPage(review) {
+    const video = review.video || {};
+    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, transcript parsing и изменения import pipeline.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
   }
 
   async function loadReview() {
-    const videoId = getVideoId();
-    const reviewResponse = await fetch(`/api/tv/review/${encodeURIComponent(videoId)}`, { headers: { Accept: 'application/json' }, cache: 'no-store' });
-    if (!reviewResponse.ok) throw new Error('review_not_found');
-    const reviewPayload = await reviewResponse.json();
-    let marketPayload = null;
-    try {
-      const marketResponse = await fetch('/api/ideas/market', { headers: { Accept: 'application/json' }, cache: 'no-store' });
-      if (marketResponse.ok) marketPayload = await marketResponse.json();
-    } catch (error) {
-      marketPayload = null;
-    }
-    root.innerHTML = ReviewPage(reviewPayload, marketPayload);
+    const response = await fetch(`/api/media/review/${encodeURIComponent(getVideoId())}`, { headers: { Accept: 'application/json' }, cache: 'no-store' });
+    if (!response.ok) throw new Error('review_not_found');
+    root.innerHTML = ReviewPage(await response.json());
   }
 
   loadReview().catch(() => {

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+import app.main as main
 from app.main import app
 from app.services.media_import_engine import FetchResult, ImportSourceResult, MediaImportEngine, MediaItem, YouTubeRssProvider, detect_symbol
 from app.services.providers.youtube_ytdlp_provider import YouTubeYtDlpProvider
@@ -461,3 +462,46 @@ def test_ytdlp_published_at_normalization_and_fallback(monkeypatch):
     assert result.items[0].published_at == "2026-07-06"
     assert result.items[1].published_at == "2026-07-07T00:00:00+00:00"
     assert result.items[2].published_at == result.items[2].imported_at
+
+
+def test_media_review_endpoint_returns_fxpilot_context(monkeypatch):
+    video = {
+        "id": "video-eurusd",
+        "title": "EURUSD обзор",
+        "author": "Desk",
+        "symbol": "EURUSD",
+        "youtube_id": "dQw4w9WgXcQ",
+        "provider": "youtube_rss",
+        "source_id": "desk",
+    }
+    market_payload = {
+        "ideas": [{
+            "symbol": "EURUSD",
+            "direction": "BUY",
+            "entry": 1.1000,
+            "sl": 1.0950,
+            "tp": 1.1120,
+            "confidence": 80,
+            "orderflow_available": True,
+            "options_available": True,
+            "news_risk": "neutral",
+            "institutional_narrative": "Долларовый контекст поддерживает EURUSD.",
+        }]
+    }
+
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [video])
+    monkeypatch.setattr(main, "ideas_market", lambda: market_payload)
+
+    response = TestClient(app).get("/api/media/review/video-eurusd")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["video"]["id"] == "video-eurusd"
+    assert payload["detected_symbol"] == "EURUSD"
+    assert payload["current_fxpilot_idea"]["direction"] == "BUY"
+    assert payload["current_fxpilot_idea"]["entry"] == 1.1
+    assert payload["current_fxpilot_idea"]["orderflow_status"] == "available"
+    assert payload["current_fxpilot_idea"]["options_status"] == "available"
+    assert payload["comparison"]["video_says"] == "No transcript yet. AI summary will appear later."
+    assert payload["confluence_score"] == 95
+    assert payload["preliminary_verdict"] == "FXPilot currently supports this market context."


### PR DESCRIPTION
### Motivation
- Сделать кнопку «Проверить обзор» полезной для импортированных видео, показывая текущий фактический контекст FXPilot для обнаруженного символа без LLM и без парсинга транскриптов.

### Description
- Добавлены вспомогательные функции и сборка review-пayload в `app/main.py` для поиска идеи по символу в текущем `/api/ideas/market`, нормализации направления, извлечения Entry/SL/TP, confidence и статусов (OrderFlow, Options, News, Institutional Narrative) и вычисления Confluence Score и предварительного вердикта.
- Реализован новый endpoint `GET /api/media/review/{video_id}` и сохранён совместимый alias `GET /api/tv/review/{video_id}` через `_get_media_review` (использует существующий импортированный каталог медиа и `/api/ideas/market`).
- Обновлён фронтенд `app/static/tv-review.js` чтобы загружать новый API и отрисовывать секции: Video info, Author/source, Detected symbol, Current FXPilot idea (Direction, Entry, SL, TP, Confidence, OrderFlow/Options/News/Institutional Narrative), блок сравнения («Что говорит видео» — плейсхолдер, «Что говорит FXPilot»), Confluence Score и Preliminary verdict.
- Добавлены стили для responsive comparison/review grid в `app/static/styles.css` и добавлен тест в `tests/test_media_import_engine.py` (`test_media_review_endpoint_returns_fxpilot_context`) с моками каталога медиа и market payload.

### Testing
- Выполнена проверка синтаксиса `python -m py_compile app/main.py`, успешно.
- Прогнаны модульные тесты командой `pytest tests/test_media_import_engine.py -q`, все тесты прошли (включая новый тест), итог `27 passed`.
- Локально проверено, что новый endpoint возвращает ожидаемую структуру review и что фронтенд запрашивает `/api/media/review/{video_id}` (см. изменения `app/static/tv-review.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e47603cb0833181f5d4a8dff423d6)