### PR TITLE
Добавить пайплайн транскриптов (YouTube + кеш, интерфейс провайдера, API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,3 +526,11 @@ Admin endpoints:
 - `/api/media` and `/tv` now read the video catalog from `data/media_catalog.json` only; `data/manual_youtube_videos.json` is excluded by default and can be enabled only for local development with `FXPILOT_DEV_MANUAL_MEDIA=1`.
 - `POST /api/media/import` rebuilds and saves `media_catalog.json` immediately after provider import, filters out records without a valid 11-character `youtube_id`, deduplicates by `youtube_id`, and records `duplicates_removed` in the import debug log.
 - Added `GET /api/media/stats` for catalog health (`catalog_items`, `real_videos`, `manual_demo`, `duplicates_removed`, `last_import`); the TV player shows `No videos imported` when the automatic catalog is empty and always uses `https://www.youtube.com/embed/{youtube_id}` for playback.
+
+## FXPilot AI Transcript Engine v1
+
+- `GET /api/media/transcript/{video_id}` получает YouTube transcript без OpenAI/GPT, нормализует сегменты (`text`, `start`, `duration`, optional `speaker`) и возвращает контракт `status`, `provider`, `language`, `duration`, `segments`, `text`.
+- Pipeline построен вокруг `TranscriptEngine` и provider-интерфейса: текущий provider использует `youtube-transcript-api` для `ru`, `en`, `auto` и переводимого transcript, а `WhisperTranscriptProvider` пока является placeholder и возвращает `WHISPER_REQUIRED`.
+- Локальный кеш хранится в `data/transcripts/{video_id}.json` с `video_id`, `created_at`, `provider`, `language`, `segments`, `full_text`, `duration`; повторный запрос читает файл и не обращается к YouTube повторно.
+- `/api/media/debug` дополнительно показывает `transcripts_cached`, `transcript_requests`, `transcript_errors`, `provider_used`.
+- Страница `/tv/review/{video_id}` показывает секцию Transcript: первые абзацы при `FOUND`, `Transcript unavailable` при недоступности и `Whisper processing required`, если нужен будущий Whisper-процессинг.

--- a/app/main.py
+++ b/app/main.py
@@ -43,6 +43,7 @@ from app.services.ai_runtime_status import get_ai_status, record_ai_request_fail
 from app.services.visitor_counter import get_visit_stats, increment_visit
 from app.services.tv_source_manager import TvSourceConfigError, TvSourceManager
 from app.services.media_import_engine import MediaConfigError, MediaImportEngine
+from app.services.transcript import TranscriptEngine, TranscriptStorage
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -146,6 +147,7 @@ def create_media_import_engine() -> MediaImportEngine:
     return MediaImportEngine(MEDIA_SOURCES_PATH, MEDIA_CATALOG_PATH, manual_path, debug_path=MEDIA_DEBUG_PATH)
 
 media_import_engine = create_media_import_engine()
+transcript_engine = TranscriptEngine(storage=TranscriptStorage(BASE_DIR.parent / "data" / "transcripts"))
 
 class _AnalyticsNewsConnector:
     def _descriptor(self, *, status: str = "unavailable", note_ru: str = "") -> dict[str, str]:
@@ -739,9 +741,27 @@ def api_media_stats() -> dict[str, Any]:
 @app.get("/api/media/debug")
 def api_media_debug() -> dict[str, Any]:
     try:
-        return create_media_import_engine().debug_sources()
+        payload = create_media_import_engine().debug_sources()
+        payload.update(transcript_engine.debug_payload())
+        return payload
     except MediaConfigError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/api/media/transcript/{video_id}")
+def api_media_transcript(video_id: str) -> dict[str, Any]:
+    try:
+        result = transcript_engine.get(video_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "status": result.status.value,
+        "provider": result.source,
+        "language": result.language,
+        "duration": result.duration,
+        "segments": [segment.to_dict() for segment in result.segments],
+        "text": result.transcript,
+    }
 
 
 @app.get("/api/media/rss-test/{source_id}")

--- a/app/services/transcript/__init__.py
+++ b/app/services/transcript/__init__.py
@@ -1,0 +1,5 @@
+from .transcript_engine import TranscriptDiagnostics, TranscriptEngine
+from .transcript_models import TranscriptResult, TranscriptSegment, TranscriptStatus
+from .transcript_storage import TranscriptStorage
+
+__all__ = ["TranscriptDiagnostics", "TranscriptEngine", "TranscriptResult", "TranscriptSegment", "TranscriptStatus", "TranscriptStorage"]

--- a/app/services/transcript/transcript_engine.py
+++ b/app/services/transcript/transcript_engine.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .transcript_models import TranscriptResult, TranscriptStatus
+from .transcript_provider import TranscriptProvider
+from .transcript_storage import TranscriptStorage
+from .whisper_provider import WhisperTranscriptProvider
+from .youtube_transcript_provider import YouTubeTranscriptProvider
+
+YOUTUBE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+
+@dataclass
+class TranscriptDiagnostics:
+    transcript_requests: int = 0
+    transcript_errors: int = 0
+    provider_used: dict[str, int] = field(default_factory=dict)
+
+    def record(self, result: TranscriptResult) -> None:
+        self.transcript_requests += 1
+        self.provider_used[result.source] = self.provider_used.get(result.source, 0) + 1
+        if result.status == TranscriptStatus.ERROR:
+            self.transcript_errors += 1
+
+
+class TranscriptEngine:
+    def __init__(self, providers: list[TranscriptProvider] | None = None, storage: TranscriptStorage | None = None, diagnostics: TranscriptDiagnostics | None = None) -> None:
+        self.providers = providers or [YouTubeTranscriptProvider(), WhisperTranscriptProvider()]
+        self.storage = storage or TranscriptStorage()
+        self.diagnostics = diagnostics or TranscriptDiagnostics()
+
+    def get(self, video: str | dict[str, Any]) -> TranscriptResult:
+        video_id = self._video_id(video)
+        cached = self.storage.load(video_id)
+        if cached:
+            return cached
+        for provider in self.providers:
+            result = provider.get(video_id)
+            self.diagnostics.record(result)
+            if result.status in {TranscriptStatus.FOUND, TranscriptStatus.WHISPER_REQUIRED, TranscriptStatus.NOT_AVAILABLE, TranscriptStatus.ERROR}:
+                self.storage.save(result)
+                return result
+        result = TranscriptResult(video_id, None, "none", "", [], None, TranscriptStatus.NOT_AVAILABLE)
+        self.diagnostics.record(result)
+        self.storage.save(result)
+        return result
+
+    def debug_payload(self) -> dict[str, Any]:
+        return {
+            "transcripts_cached": self.storage.cached_count(),
+            "transcript_requests": self.diagnostics.transcript_requests,
+            "transcript_errors": self.diagnostics.transcript_errors,
+            "provider_used": self.diagnostics.provider_used,
+        }
+
+    def _video_id(self, video: str | dict[str, Any]) -> str:
+        value = video.get("youtube_id") or video.get("video_id") or video.get("id") if isinstance(video, dict) else video
+        video_id = str(value or "").strip()
+        if not YOUTUBE_ID_RE.fullmatch(video_id):
+            raise ValueError("invalid YouTube video id")
+        return video_id

--- a/app/services/transcript/transcript_models.py
+++ b/app/services/transcript/transcript_models.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class TranscriptStatus(StrEnum):
+    FOUND = "FOUND"
+    WHISPER_REQUIRED = "WHISPER_REQUIRED"
+    NOT_AVAILABLE = "NOT_AVAILABLE"
+    ERROR = "ERROR"
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    text: str
+    start: float
+    duration: float
+    speaker: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        if self.speaker is None:
+            payload.pop("speaker", None)
+        return payload
+
+
+@dataclass(frozen=True)
+class TranscriptResult:
+    video_id: str
+    language: str | None
+    source: str
+    transcript: str
+    segments: list[TranscriptSegment] = field(default_factory=list)
+    duration: float | None = None
+    status: TranscriptStatus = TranscriptStatus.NOT_AVAILABLE
+    error: str | None = None
+    cached: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "video_id": self.video_id,
+            "language": self.language,
+            "source": self.source,
+            "transcript": self.transcript,
+            "segments": [segment.to_dict() for segment in self.segments],
+            "duration": self.duration,
+            "status": self.status.value,
+            "cached": self.cached,
+        }
+        if self.error:
+            payload["error"] = self.error
+        return payload

--- a/app/services/transcript/transcript_provider.py
+++ b/app/services/transcript/transcript_provider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .transcript_models import TranscriptResult
+
+
+class TranscriptProvider(Protocol):
+    provider_name: str
+
+    def get(self, video_id: str) -> TranscriptResult:
+        """Return a normalized transcript result for a YouTube video id."""

--- a/app/services/transcript/transcript_storage.py
+++ b/app/services/transcript/transcript_storage.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .transcript_models import TranscriptResult, TranscriptSegment, TranscriptStatus
+
+
+class TranscriptStorage:
+    def __init__(self, directory: Path | str = Path("data/transcripts")) -> None:
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def path_for(self, video_id: str) -> Path:
+        return self.directory / f"{video_id}.json"
+
+    def exists(self, video_id: str) -> bool:
+        return self.path_for(video_id).exists()
+
+    def load(self, video_id: str) -> TranscriptResult | None:
+        path = self.path_for(video_id)
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        segments = [TranscriptSegment(text=str(item.get("text") or ""), start=float(item.get("start") or 0), duration=float(item.get("duration") or 0), speaker=item.get("speaker")) for item in payload.get("segments", []) if isinstance(item, dict)]
+        return TranscriptResult(
+            video_id=str(payload.get("video_id") or video_id),
+            language=payload.get("language"),
+            source=str(payload.get("provider") or payload.get("source") or "cache"),
+            transcript=str(payload.get("full_text") or payload.get("transcript") or ""),
+            segments=segments,
+            duration=payload.get("duration"),
+            status=TranscriptStatus(str(payload.get("status") or ("FOUND" if segments else "NOT_AVAILABLE"))),
+            error=payload.get("error"),
+            cached=True,
+        )
+
+    def save(self, result: TranscriptResult) -> Path:
+        payload = {
+            "video_id": result.video_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "provider": result.source,
+            "language": result.language,
+            "status": result.status.value,
+            "segments": [segment.to_dict() for segment in result.segments],
+            "full_text": result.transcript,
+            "duration": result.duration,
+        }
+        if result.error:
+            payload["error"] = result.error
+        path = self.path_for(result.video_id)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        return path
+
+    def cached_count(self) -> int:
+        return len(list(self.directory.glob("*.json")))

--- a/app/services/transcript/whisper_provider.py
+++ b/app/services/transcript/whisper_provider.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .transcript_models import TranscriptResult, TranscriptStatus
+
+
+class WhisperTranscriptProvider:
+    """Architecture placeholder for a future Whisper/audio transcription provider."""
+
+    provider_name = "whisper-placeholder"
+
+    def get(self, video_id: str) -> TranscriptResult:
+        return TranscriptResult(
+            video_id=video_id,
+            language=None,
+            source=self.provider_name,
+            transcript="",
+            segments=[],
+            duration=None,
+            status=TranscriptStatus.WHISPER_REQUIRED,
+        )

--- a/app/services/transcript/youtube_transcript_provider.py
+++ b/app/services/transcript/youtube_transcript_provider.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from .transcript_models import TranscriptResult, TranscriptSegment, TranscriptStatus
+
+logger = logging.getLogger(__name__)
+_SPACE_RE = re.compile(r"\s+")
+
+
+def clean_transcript_text(value: Any) -> str:
+    return _SPACE_RE.sub(" ", str(value or "").replace("\ufeff", " ")).strip()
+
+
+class YouTubeTranscriptProvider:
+    provider_name = "youtube-transcript-api"
+    preferred_languages = ("ru", "en")
+
+    def get(self, video_id: str) -> TranscriptResult:
+        try:
+            from youtube_transcript_api import (  # type: ignore
+                NoTranscriptAvailable,
+                TranscriptsDisabled,
+                VideoUnavailable,
+                YouTubeTranscriptApi,
+            )
+        except Exception as exc:
+            logger.warning("youtube_transcript_api_import_failed video_id=%s error=%s", video_id, exc)
+            return TranscriptResult(video_id, None, self.provider_name, "", [], None, TranscriptStatus.WHISPER_REQUIRED, str(exc))
+
+        try:
+            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+            transcript = self._select_transcript(transcript_list)
+            language = getattr(transcript, "language_code", None)
+            raw_segments = transcript.fetch()
+            return self._normalize(video_id, language, raw_segments)
+        except (NoTranscriptAvailable, TranscriptsDisabled, VideoUnavailable) as exc:
+            return TranscriptResult(video_id, None, self.provider_name, "", [], None, TranscriptStatus.WHISPER_REQUIRED, str(exc))
+        except Exception as exc:
+            logger.exception("youtube_transcript_fetch_failed video_id=%s", video_id)
+            return TranscriptResult(video_id, None, self.provider_name, "", [], None, TranscriptStatus.ERROR, str(exc))
+
+    def _select_transcript(self, transcript_list: Any) -> Any:
+        for finder in ("find_manually_created_transcript", "find_generated_transcript"):
+            try:
+                return getattr(transcript_list, finder)(list(self.preferred_languages))
+            except Exception:
+                continue
+        for transcript in transcript_list:
+            language = getattr(transcript, "language_code", "")
+            if language in self.preferred_languages:
+                return transcript
+        for transcript in transcript_list:
+            try:
+                if getattr(transcript, "is_translatable", False):
+                    return transcript.translate("ru")
+            except Exception:
+                continue
+        return transcript_list.find_transcript(["ru", "en"])
+
+    def _normalize(self, video_id: str, language: str | None, raw_segments: list[dict[str, Any]]) -> TranscriptResult:
+        segments: list[TranscriptSegment] = []
+        for item in raw_segments or []:
+            text = clean_transcript_text(item.get("text"))
+            if not text:
+                continue
+            start = float(item.get("start") or 0)
+            duration = float(item.get("duration") or 0)
+            speaker = clean_transcript_text(item.get("speaker")) or None
+            segments.append(TranscriptSegment(text=text, start=start, duration=duration, speaker=speaker))
+        full_text = "\n\n".join(segment.text for segment in segments)
+        duration = max((segment.start + segment.duration for segment in segments), default=None)
+        status = TranscriptStatus.FOUND if segments else TranscriptStatus.NOT_AVAILABLE
+        return TranscriptResult(video_id, language or "auto", self.provider_name, full_text, segments, duration, status)

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -59,6 +59,25 @@
     return ReviewSection({ id: 'fxpilotIdea', className: 'tv-review-section--summary', title: 'Current FXPilot idea', content: `<div class="tv-snapshot-grid tv-review-wide-grid">${rows.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div><p class="tv-context-note">Контекст построен фактически из /api/ideas/market. Transcript и LLM не используются.</p>` });
   }
 
+  function transcriptMessage(status) {
+    if (status === 'WHISPER_REQUIRED') return 'Whisper processing required';
+    if (status === 'ERROR') return 'Transcript unavailable';
+    return 'Transcript unavailable';
+  }
+
+  function transcriptParagraphs(text) {
+    return String(text || '').split(/\n{2,}/).map((item) => item.trim()).filter(Boolean).slice(0, 3);
+  }
+
+  function renderTranscript(transcript) {
+    const paragraphs = transcriptParagraphs(transcript && transcript.text);
+    const meta = transcript ? `${value(transcript.provider)} · ${value(transcript.language)} · ${value(transcript.duration ? Math.round(transcript.duration) + ' сек.' : null)}` : '—';
+    const body = transcript && transcript.status === 'FOUND' && paragraphs.length
+      ? `<div class="tv-transcript-preview">${paragraphs.map((paragraph) => `<p>${escapeHtml(paragraph)}</p>`).join('')}</div>`
+      : `<div class="tv-player-empty">${escapeHtml(transcriptMessage(transcript && transcript.status))}</div>`;
+    return ReviewSection({ id: 'transcript', className: 'tv-review-section--summary tv-transcript-section', title: 'Transcript', content: `<div class="tv-context-note">${escapeHtml(meta)}</div>${body}` });
+  }
+
   function renderComparison(review) {
     const idea = review.current_fxpilot_idea || {};
     return ReviewSection({ id: 'comparison', className: 'tv-review-section--summary', title: 'Comparison', content: `
@@ -76,15 +95,24 @@
     return ReviewSection({ id: 'preliminaryVerdict', className: 'tv-review-section--summary tv-verdict-section', title: 'Preliminary verdict', content: `<div class="tv-verdict"><strong>${escapeHtml(verdictRu(review.preliminary_verdict))}</strong><p>Это предварительная проверка рыночного контекста, а не анализ тезисов автора видео.</p></div>` });
   }
 
-  function ReviewPage(review) {
+  function ReviewPage(review, transcript) {
     const video = review.video || {};
-    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, transcript parsing и изменения import pipeline.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
+    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
   }
 
   async function loadReview() {
     const response = await fetch(`/api/media/review/${encodeURIComponent(getVideoId())}`, { headers: { Accept: 'application/json' }, cache: 'no-store' });
     if (!response.ok) throw new Error('review_not_found');
-    root.innerHTML = ReviewPage(await response.json());
+    const review = await response.json();
+    const youtubeId = (review.video && (review.video.youtube_id || review.video.id)) || getVideoId();
+    let transcript = null;
+    try {
+      const transcriptResponse = await fetch(`/api/media/transcript/${encodeURIComponent(youtubeId)}`, { headers: { Accept: 'application/json' }, cache: 'no-store' });
+      if (transcriptResponse.ok) transcript = await transcriptResponse.json();
+    } catch (error) {
+      transcript = { status: 'NOT_AVAILABLE' };
+    }
+    root.innerHTML = ReviewPage(review, transcript);
   }
 
   loadReview().catch(() => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ python-dotenv==1.0.1
 websocket-client==1.8.0
 feedparser==6.0.11
 yt-dlp
+
+youtube-transcript-api==0.6.3

--- a/tests/test_transcript_engine.py
+++ b/tests/test_transcript_engine.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from app.services.transcript import TranscriptEngine, TranscriptStorage, TranscriptStatus
+from app.services.transcript.transcript_models import TranscriptResult, TranscriptSegment
+
+
+class FakeProvider:
+    provider_name = "fake-youtube"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get(self, video_id: str) -> TranscriptResult:
+        self.calls += 1
+        return TranscriptResult(
+            video_id=video_id,
+            language="ru",
+            source=self.provider_name,
+            transcript="Первый абзац.\n\nВторой абзац.",
+            segments=[TranscriptSegment("Первый абзац.", 0, 2), TranscriptSegment("Второй абзац.", 2, 3)],
+            duration=5,
+            status=TranscriptStatus.FOUND,
+        )
+
+
+def test_transcript_engine_saves_and_reuses_cache(tmp_path: Path):
+    provider = FakeProvider()
+    engine = TranscriptEngine(providers=[provider], storage=TranscriptStorage(tmp_path))
+
+    first = engine.get("4M6s03LQbsg")
+    second = engine.get("4M6s03LQbsg")
+
+    assert provider.calls == 1
+    assert first.status == TranscriptStatus.FOUND
+    assert second.cached is True
+    assert second.transcript == "Первый абзац.\n\nВторой абзац."
+    saved = json.loads((tmp_path / "4M6s03LQbsg.json").read_text(encoding="utf-8"))
+    assert {"video_id", "created_at", "provider", "language", "segments", "full_text", "duration"}.issubset(saved.keys())
+
+
+def test_transcript_engine_rejects_invalid_youtube_id(tmp_path: Path):
+    engine = TranscriptEngine(providers=[FakeProvider()], storage=TranscriptStorage(tmp_path))
+    try:
+        engine.get("bad")
+    except ValueError as exc:
+        assert "invalid YouTube video id" in str(exc)
+    else:
+        raise AssertionError("invalid id accepted")


### PR DESCRIPTION
### Motivation
- Построить модульную архитектуру для получения и кеширования YouTube‑транскриптов без использования OpenAI, чтобы позже можно было подключить LLM одной реализацией провайдера. 
- Обеспечить стабильный контракт API для фронтенда и хранение транскриптов на диске для избежания повторных запросов к внешним сервисам.

### Description
- Добавлен новый пакет `app/services/transcript/` с моделями результата/сегмента (`TranscriptResult`, `TranscriptSegment`, `TranscriptStatus`), интерфейсом провайдера (`TranscriptProvider`), движком (`TranscriptEngine`) и локальным хранилищем `TranscriptStorage` (папка `data/transcripts`).
- Реализован провайдер `YouTubeTranscriptProvider` на базе `youtube-transcript-api` с поддержкой `ru`, `en`, попыткой выбрать ручной/сгенерированный или переводимый транскрипт и нормализацией сегментов; добавлен placeholder `WhisperTranscriptProvider`, возвращающий `WHISPER_REQUIRED` (Whisper не реализован).
- Добавлен эндпойнт API `GET /api/media/transcript/{video_id}` который возвращает контракт `{status, provider, language, duration, segments, text}` и расширен `/api/media/debug` диагностикой транскриптов (`transcripts_cached`, `transcript_requests`, `transcript_errors`, `provider_used`).
- Обновлён фронтенд review (`app/static/tv-review.js`), чтобы запрашивать `/api/media/transcript/{video_id}` и показывать первые абзацы при `FOUND`, либо сообщения «Transcript unavailable» / «Whisper processing required" в соответствующих состояниях.
- Добавлена зависимость `youtube-transcript-api==0.6.3` и документация в `README.md`; добавлен тест `tests/test_transcript_engine.py` на поведение кеша и валидацию YouTube ID.

### Testing
- Запущены модульные тесты: `pytest -q tests/test_transcript_engine.py tests/test_media_import_engine.py::test_media_debug_endpoint_contract`, все они прошли (`3 passed`).
- Собрана и проверена компиляция: `python3 -m compileall app/services/transcript app/main.py` успешно выполнена.
- Локальное поведение проверено через UI review: фронтенд запрашивает новый эндпойнт и отображает превью/статусы транскриптов как ожидается.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e4f72de1083319b33a7823dc131bf)