### PR TITLE
Добавить rule-based AI Analyzer (AIAnalyzerEngine)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,7 @@ from app.services.visitor_counter import get_visit_stats, increment_visit
 from app.services.tv_source_manager import TvSourceConfigError, TvSourceManager
 from app.services.media_import_engine import MediaConfigError, MediaImportEngine
 from app.services.transcript import TranscriptEngine, TranscriptStorage
+from app.services.ai_analyzer import AIAnalyzerEngine
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,7 @@ def create_media_import_engine() -> MediaImportEngine:
 
 media_import_engine = create_media_import_engine()
 transcript_engine = TranscriptEngine(storage=TranscriptStorage(BASE_DIR.parent / "data" / "transcripts"))
+ai_analyzer_engine = AIAnalyzerEngine()
 
 class _AnalyticsNewsConnector:
     def _descriptor(self, *, status: str = "unavailable", note_ru: str = "") -> dict[str, str]:
@@ -632,13 +634,36 @@ def _review_verdict(model: dict[str, Any], score: int, has_idea: bool) -> str:
     return "FXPilot currently supports this market context."
 
 
+def _review_transcript_payload(video: dict[str, Any]) -> dict[str, Any]:
+    transcript_id = str(_first_review_value(video.get("youtube_id"), video.get("id")) or "")
+    try:
+        result = transcript_engine.get(transcript_id)
+    except ValueError:
+        return {"video_id": transcript_id, "status": "ERROR", "provider": "none", "language": None, "duration": None, "segments": [], "text": ""}
+    return {
+        "video_id": result.video_id,
+        "status": result.status.value,
+        "provider": result.source,
+        "language": result.language,
+        "duration": result.duration,
+        "segments": [segment.to_dict() for segment in result.segments],
+        "text": result.transcript,
+    }
+
+
 def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, Any] | None = None) -> dict[str, Any]:
     market_payload = market_payload if isinstance(market_payload, dict) else ideas_market()
     idea = _find_review_market_idea(market_payload, str(video.get("symbol") or ""))
     model = _build_review_market_model(video, idea)
     score = _review_confluence_score(video, model, idea is not None)
+    transcript = _review_transcript_payload(video)
+    ai_review = ai_analyzer_engine.analyze(str(transcript.get("text") or ""), {**video, "video_id": video.get("id")})
+    analysis = ai_review.to_api_analysis()
     return {
         "video": video,
+        "transcript": transcript,
+        "analysis": analysis,
+        "ai_review": ai_review.to_dict(),
         "author_source": {
             "author": video.get("author"),
             "provider": video.get("provider"),
@@ -648,7 +673,7 @@ def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, An
         "detected_symbol": video.get("symbol"),
         "current_fxpilot_idea": model,
         "comparison": {
-            "video_says": "No transcript yet. AI summary will appear later.",
+            "video_says": analysis.get("summary") or "Transcript data is insufficient for AI analysis.",
             "fxpilot_says": model,
         },
         "confluence_score": score,

--- a/app/services/ai_analyzer/__init__.py
+++ b/app/services/ai_analyzer/__init__.py
@@ -1,0 +1,6 @@
+from app.services.ai_analyzer.engine import AIAnalyzerEngine
+from app.services.ai_analyzer.models import AIReview
+from app.services.ai_analyzer.provider import AIAnalyzerProvider
+from app.services.ai_analyzer.rule_provider import RuleBasedAnalyzerProvider
+
+__all__ = ["AIAnalyzerEngine", "AIAnalyzerProvider", "AIReview", "RuleBasedAnalyzerProvider"]

--- a/app/services/ai_analyzer/confidence.py
+++ b/app/services/ai_analyzer/confidence.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from app.services.ai_analyzer.models import ConfidenceBreakdown, ExtractedEntities, TradingIdea
+
+
+class ConfidenceEngine:
+    def calculate(self, entities: ExtractedEntities, idea: TradingIdea, reasoning: list[str]) -> ConfidenceBreakdown:
+        scores = {
+            "symbol_score": 15 if entities.symbols else 0,
+            "direction_score": 15 if entities.directions else 0,
+            "level_score": min(15, len(entities.levels) * 4),
+            "entry_score": 10 if idea.entry is not None else 0,
+            "sl_score": 10 if idea.stop_loss is not None else 0,
+            "tp_score": 10 if idea.take_profit is not None or idea.targets else 0,
+            "indicator_score": min(10, len(entities.indicators) * 3),
+            "reasoning_score": min(10, len(reasoning) * 3),
+        }
+        present = sum(1 for value in [entities.symbols, entities.directions, entities.levels, idea.entry, idea.stop_loss, idea.take_profit or idea.targets] if value)
+        scores["completeness_score"] = min(5, present)
+        confidence = max(0, min(100, sum(scores.values())))
+        return ConfidenceBreakdown(**scores, confidence=confidence)

--- a/app/services/ai_analyzer/engine.py
+++ b/app/services/ai_analyzer/engine.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.ai_analyzer.models import AIReview
+from app.services.ai_analyzer.provider import AIAnalyzerProvider
+from app.services.ai_analyzer.rule_provider import RuleBasedAnalyzerProvider
+
+
+class AIAnalyzerEngine:
+    def __init__(self, provider: AIAnalyzerProvider | None = None) -> None:
+        self.provider = provider or RuleBasedAnalyzerProvider()
+
+    def analyze(self, transcript: str, metadata: dict[str, Any]) -> AIReview:
+        return self.provider.analyze(transcript, metadata)

--- a/app/services/ai_analyzer/entity_extractor.py
+++ b/app/services/ai_analyzer/entity_extractor.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+
+from app.services.ai_analyzer.models import ExtractedEntities
+
+SYMBOLS = ["EURUSD","GBPUSD","USDJPY","USDCHF","AUDUSD","NZDUSD","USDCAD","XAUUSD","XAGUSD","BTC","ETH","NASDAQ","SP500","US30","GER40","DXY","WTI","BRENT"]
+TIMEFRAMES = ["M1","M5","M15","M30","H1","H4","D1","W1","MN"]
+DIRECTION_ALIASES = {"BULLISH":"BUY","LONG":"BUY","BUY":"BUY","РОСТ":"BUY","ЛОНГ":"BUY","ПОКУПКА":"BUY","BEARISH":"SELL","SHORT":"SELL","SELL":"SELL","ПАДЕНИЕ":"SELL","ШОРТ":"SELL","ПРОДАЖА":"SELL","NEUTRAL":"NEUTRAL"}
+INDICATORS = ["VWAP","Delta","CumDelta","Footprint","Volume Profile","Volume","POC","VAH","VAL","DOM","Liquidity","Absorption","Sweep","Iceberg","Imbalance","OrderFlow","Gamma","Options","Open Interest","OI"]
+CONCEPTS = ["Liquidity","Absorption","Sweep","Iceberg","Imbalance","OrderFlow","Gamma","Options","Open Interest"]
+PRICE_RE = re.compile(r"(?<![\w])\d{1,6}(?:[.,]\d{1,5})?(?![\w])")
+
+
+def _unique(items: list[str]) -> list[str]:
+    return list(dict.fromkeys(items))
+
+
+class EntityExtractor:
+    def extract(self, transcript: str) -> ExtractedEntities:
+        text = transcript or ""
+        upper = text.upper()
+        symbols = [symbol for symbol in SYMBOLS if re.search(rf"(?<![A-Z0-9]){re.escape(symbol)}(?![A-Z0-9])", upper)]
+        timeframes = [tf for tf in TIMEFRAMES if re.search(rf"(?<![A-Z0-9]){re.escape(tf)}(?![A-Z0-9])", upper)]
+        directions = _unique([normalized for alias, normalized in DIRECTION_ALIASES.items() if re.search(rf"(?<![\wА-ЯЁ]){re.escape(alias)}(?![\wА-ЯЁ])", upper)])
+        indicators = [name for name in INDICATORS if re.search(rf"(?<![\w]){re.escape(name)}(?![\w])", text, flags=re.IGNORECASE)]
+        concepts = [name for name in CONCEPTS if name in indicators]
+        levels = _unique_numbers([float(match.group(0).replace(",", ".")) for match in PRICE_RE.finditer(text)])
+        return ExtractedEntities(symbols=symbols, timeframes=timeframes, directions=directions, indicators=indicators, concepts=concepts, levels=levels)
+
+
+def _unique_numbers(values: list[float]) -> list[float]:
+    seen: set[float] = set()
+    result: list[float] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value); result.append(value)
+    return result

--- a/app/services/ai_analyzer/idea_extractor.py
+++ b/app/services/ai_analyzer/idea_extractor.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import re
+
+from app.services.ai_analyzer.models import TradingIdea
+
+NUMBER = r"(\d{1,6}(?:[.,]\d{1,5})?)"
+PATTERNS = {
+    "entry": [rf"(?:entry|вход|заход|buy from|sell from)\D{{0,24}}{NUMBER}"],
+    "stop_loss": [rf"(?:stop loss|stop-loss|stop|sl|стоп|стоп.?лосс)\D{{0,24}}{NUMBER}"],
+    "take_profit": [rf"(?:take profit|take-profit|tp|тейк|профит)\D{{0,24}}{NUMBER}"],
+    "targets": [rf"(?:target\s*[12]?|цель\s*[12]?|таргет\s*[12]?)\D{{0,24}}{NUMBER}"],
+    "risk": [rf"(?:risk|риск)\D{{0,24}}{NUMBER}"],
+    "reward": [rf"(?:reward|прибыль|потенциал)\D{{0,24}}{NUMBER}"],
+    "rr": [rf"(?:rr|r/r|risk.?reward)\D{{0,12}}(\d+(?:[.,]\d+)?)"],
+}
+
+
+def _number(value: str) -> float:
+    return float(value.replace(",", "."))
+
+
+class TradingIdeaExtractor:
+    def extract(self, transcript: str) -> TradingIdea:
+        text = transcript or ""
+        found: dict[str, float | list[float] | None] = {"entry": None, "stop_loss": None, "take_profit": None, "targets": [], "risk": None, "reward": None, "rr": None}
+        for key, patterns in PATTERNS.items():
+            values: list[float] = []
+            for pattern in patterns:
+                values.extend(_number(match.group(1)) for match in re.finditer(pattern, text, flags=re.IGNORECASE))
+            if key == "targets":
+                found[key] = list(dict.fromkeys(values))
+            elif values:
+                found[key] = values[0]
+        tp = found["take_profit"]
+        targets = found["targets"] if isinstance(found["targets"], list) else []
+        if tp is None and targets:
+            tp = targets[0]
+        return TradingIdea(entry=found["entry"], stop_loss=found["stop_loss"], take_profit=tp, targets=targets, risk=found["risk"], reward=found["reward"], rr=found["rr"])  # type: ignore[arg-type]

--- a/app/services/ai_analyzer/models.py
+++ b/app/services/ai_analyzer/models.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ExtractedEntities:
+    symbols: list[str] = field(default_factory=list)
+    timeframes: list[str] = field(default_factory=list)
+    directions: list[str] = field(default_factory=list)
+    indicators: list[str] = field(default_factory=list)
+    concepts: list[str] = field(default_factory=list)
+    levels: list[float] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TradingIdea:
+    entry: float | None = None
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    targets: list[float] = field(default_factory=list)
+    risk: float | None = None
+    reward: float | None = None
+    rr: float | None = None
+
+
+@dataclass(frozen=True)
+class ConfidenceBreakdown:
+    symbol_score: int = 0
+    direction_score: int = 0
+    level_score: int = 0
+    entry_score: int = 0
+    sl_score: int = 0
+    tp_score: int = 0
+    indicator_score: int = 0
+    reasoning_score: int = 0
+    completeness_score: int = 0
+    confidence: int = 0
+
+
+@dataclass(frozen=True)
+class AIReview:
+    video_id: str
+    symbol: str | None = None
+    timeframe: str | None = None
+    direction: str | None = None
+    entry: float | None = None
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    targets: list[float] = field(default_factory=list)
+    mentioned_levels: list[float] = field(default_factory=list)
+    mentioned_indicators: list[str] = field(default_factory=list)
+    mentioned_concepts: list[str] = field(default_factory=list)
+    confidence: int = 0
+    summary: str = ""
+    reasoning: list[str] = field(default_factory=list)
+    risks: list[str] = field(default_factory=list)
+    opportunities: list[str] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    confidence_breakdown: ConfidenceBreakdown = field(default_factory=ConfidenceBreakdown)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_api_analysis(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "direction": self.direction,
+            "entry": self.entry,
+            "sl": self.stop_loss,
+            "tp": self.take_profit,
+            "targets": self.targets,
+            "levels": self.mentioned_levels,
+            "confidence": self.confidence,
+            "summary": self.summary,
+            "indicators": self.mentioned_indicators,
+            "concepts": self.mentioned_concepts,
+            "risks": self.risks,
+            "opportunities": self.opportunities,
+            "reasoning": self.reasoning,
+            "created_at": self.created_at,
+            "confidence_breakdown": asdict(self.confidence_breakdown),
+        }

--- a/app/services/ai_analyzer/provider.py
+++ b/app/services/ai_analyzer/provider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from app.services.ai_analyzer.models import AIReview
+
+
+class AIAnalyzerProvider(ABC):
+    @abstractmethod
+    def analyze(self, transcript: str, metadata: dict[str, Any]) -> AIReview:
+        """Analyze transcript and return normalized AIReview without changing API consumers."""

--- a/app/services/ai_analyzer/rule_provider.py
+++ b/app/services/ai_analyzer/rule_provider.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.ai_analyzer.confidence import ConfidenceEngine
+from app.services.ai_analyzer.entity_extractor import EntityExtractor
+from app.services.ai_analyzer.idea_extractor import TradingIdeaExtractor
+from app.services.ai_analyzer.models import AIReview
+from app.services.ai_analyzer.provider import AIAnalyzerProvider
+from app.services.ai_analyzer.summary import SummaryEngine
+
+
+class RuleBasedAnalyzerProvider(AIAnalyzerProvider):
+    def __init__(self) -> None:
+        self.entities = EntityExtractor()
+        self.ideas = TradingIdeaExtractor()
+        self.confidence = ConfidenceEngine()
+        self.summary = SummaryEngine()
+
+    def analyze(self, transcript: str, metadata: dict[str, Any]) -> AIReview:
+        entities = self.entities.extract(transcript)
+        idea = self.ideas.extract(transcript)
+        reasoning = self._reasoning(entities, idea)
+        breakdown = self.confidence.calculate(entities, idea, reasoning)
+        direction = entities.directions[0] if entities.directions else None
+        return AIReview(
+            video_id=str(metadata.get("video_id") or metadata.get("id") or ""),
+            symbol=entities.symbols[0] if entities.symbols else metadata.get("symbol"),
+            timeframe=entities.timeframes[0] if entities.timeframes else metadata.get("timeframe"),
+            direction=direction,
+            entry=idea.entry,
+            stop_loss=idea.stop_loss,
+            take_profit=idea.take_profit,
+            targets=idea.targets,
+            mentioned_levels=entities.levels,
+            mentioned_indicators=entities.indicators,
+            mentioned_concepts=entities.concepts,
+            confidence=breakdown.confidence,
+            summary=self.summary.build(entities, idea),
+            reasoning=reasoning,
+            risks=self._risks(entities, idea),
+            opportunities=self._opportunities(entities, idea),
+            confidence_breakdown=breakdown,
+        )
+
+    def _reasoning(self, entities, idea) -> list[str]:
+        items: list[str] = []
+        if entities.symbols: items.append(f"Найден символ: {entities.symbols[0]}")
+        if entities.directions: items.append(f"Найдено направление: {entities.directions[0]}")
+        if entities.indicators: items.append(f"Найдены индикаторы/концепты: {', '.join(entities.indicators[:5])}")
+        if idea.entry is not None: items.append("Найден уровень входа")
+        return items
+
+    def _risks(self, entities, idea) -> list[str]:
+        risks = []
+        if idea.stop_loss is None: risks.append("Stop Loss не найден в транскрипте.")
+        if not entities.directions: risks.append("Направление сделки не определено явно.")
+        if not entities.symbols: risks.append("Символ не найден в тексте обзора.")
+        return risks
+
+    def _opportunities(self, entities, idea) -> list[str]:
+        opportunities = []
+        if idea.entry is not None and (idea.take_profit is not None or idea.targets): opportunities.append("Есть структурированная идея с входом и целью.")
+        if entities.indicators: opportunities.append("Есть подтверждения через рыночные индикаторы/концепты.")
+        return opportunities

--- a/app/services/ai_analyzer/summary.py
+++ b/app/services/ai_analyzer/summary.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from app.services.ai_analyzer.models import ExtractedEntities, TradingIdea
+
+
+def direction_ru(direction: str | None) -> str:
+    return {"BUY": "рост", "SELL": "снижение", "NEUTRAL": "нейтральный сценарий"}.get(direction or "", "сценарий без явного направления")
+
+
+class SummaryEngine:
+    def build(self, entities: ExtractedEntities, idea: TradingIdea) -> str:
+        symbol = entities.symbols[0] if entities.symbols else "инструменту"
+        direction = entities.directions[0] if entities.directions else None
+        sentences = [f"Автор описывает {direction_ru(direction)} по {symbol}."]
+        if entities.indicators:
+            sentences.append(f"Основные аргументы: {', '.join(entities.indicators[:3])}.")
+        if idea.entry is not None:
+            sentences.append(f"Зона входа отмечена около {idea.entry}.")
+        target = idea.take_profit or (idea.targets[0] if idea.targets else None)
+        if target is not None:
+            sentences.append(f"Цель движения находится около {target}.")
+        if len(sentences) < 2:
+            sentences.append("Транскрипт содержит недостаточно структурированных торговых данных для полного вывода.")
+        return " ".join(sentences[:4])

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3556,3 +3556,38 @@ body[data-page="tv-sources"] {
     grid-template-columns: 1fr;
   }
 }
+
+.tv-ai-analysis-section {
+  border-color: rgba(76, 201, 240, 0.28);
+}
+
+.tv-analysis-lists {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  margin-top: 16px;
+}
+
+.tv-analysis-lists > div {
+  border: 1px solid rgba(141, 162, 189, 0.18);
+  border-radius: 16px;
+  background: rgba(6, 14, 28, 0.42);
+  padding: 14px;
+}
+
+.tv-analysis-lists strong {
+  color: #eaf6ff;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.tv-analysis-pill {
+  display: inline-flex;
+  margin: 0 6px 6px 0;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: #dff7ff;
+  background: rgba(76, 201, 240, 0.12);
+  border: 1px solid rgba(76, 201, 240, 0.24);
+  font-size: 0.86rem;
+}

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -78,6 +78,36 @@
     return ReviewSection({ id: 'transcript', className: 'tv-review-section--summary tv-transcript-section', title: 'Transcript', content: `<div class="tv-context-note">${escapeHtml(meta)}</div>${body}` });
   }
 
+
+  function list(items) {
+    const values = Array.isArray(items) ? items.filter((item) => item !== null && item !== undefined && item !== '') : [];
+    return values.length ? values.map((item) => `<span class="tv-analysis-pill">${escapeHtml(item)}</span>`).join('') : '<span class="tv-context-note">—</span>';
+  }
+
+  function renderAIAnalysis(review) {
+    const analysis = review.analysis || {};
+    const rows = [
+      ['Symbol', analysis.symbol],
+      ['Direction', directionRu(analysis.direction)],
+      ['Confidence', percent(analysis.confidence)],
+      ['Entry', analysis.entry],
+      ['SL', analysis.sl],
+      ['TP', analysis.tp],
+    ];
+    return ReviewSection({ id: 'aiAnalysis', className: 'tv-review-section--summary tv-ai-analysis-section', title: 'AI Analysis', content: `
+      <p class="tv-context-note">Rule Engine: без OpenAI/GPT/Gemini/Claude. Провайдер можно заменить без изменения API и Frontend.</p>
+      <div class="tv-premium-placeholder"><strong>Summary</strong><p>${escapeHtml(analysis.summary || 'Недостаточно данных транскрипта для резюме.')}</p></div>
+      <div class="tv-snapshot-grid tv-review-wide-grid">${rows.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div>
+      <div class="tv-analysis-lists">
+        <div><strong>Targets</strong><p>${list(analysis.targets)}</p></div>
+        <div><strong>Detected Levels</strong><p>${list(analysis.levels)}</p></div>
+        <div><strong>Indicators</strong><p>${list(analysis.indicators)}</p></div>
+        <div><strong>Concepts</strong><p>${list(analysis.concepts)}</p></div>
+        <div><strong>Risks</strong><p>${list(analysis.risks)}</p></div>
+        <div><strong>Opportunities</strong><p>${list(analysis.opportunities)}</p></div>
+      </div>` });
+  }
+
   function renderComparison(review) {
     const idea = review.current_fxpilot_idea || {};
     return ReviewSection({ id: 'comparison', className: 'tv-review-section--summary', title: 'Comparison', content: `
@@ -97,21 +127,14 @@
 
   function ReviewPage(review, transcript) {
     const video = review.video || {};
-    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
+    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderAIAnalysis(review)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
   }
 
   async function loadReview() {
     const response = await fetch(`/api/media/review/${encodeURIComponent(getVideoId())}`, { headers: { Accept: 'application/json' }, cache: 'no-store' });
     if (!response.ok) throw new Error('review_not_found');
     const review = await response.json();
-    const youtubeId = (review.video && (review.video.youtube_id || review.video.id)) || getVideoId();
-    let transcript = null;
-    try {
-      const transcriptResponse = await fetch(`/api/media/transcript/${encodeURIComponent(youtubeId)}`, { headers: { Accept: 'application/json' }, cache: 'no-store' });
-      if (transcriptResponse.ok) transcript = await transcriptResponse.json();
-    } catch (error) {
-      transcript = { status: 'NOT_AVAILABLE' };
-    }
+    const transcript = review.transcript || { status: 'NOT_AVAILABLE' };
     root.innerHTML = ReviewPage(review, transcript);
   }
 

--- a/tests/ai_analyzer/test_rule_provider.py
+++ b/tests/ai_analyzer/test_rule_provider.py
@@ -1,0 +1,33 @@
+from app.services.ai_analyzer import RuleBasedAnalyzerProvider
+
+
+def test_rule_based_provider_extracts_full_trading_idea() -> None:
+    transcript = (
+        "На H1 EURUSD bullish setup после sweep liquidity. "
+        "Buy entry 1.1745, stop loss 1.1680, target1 1.1830, target2 1.1900. "
+        "Подтверждение через OrderFlow, VWAP и Volume Profile."
+    )
+
+    review = RuleBasedAnalyzerProvider().analyze(transcript, {"video_id": "video-1"})
+
+    assert review.video_id == "video-1"
+    assert review.symbol == "EURUSD"
+    assert review.timeframe == "H1"
+    assert review.direction == "BUY"
+    assert review.entry == 1.1745
+    assert review.stop_loss == 1.1680
+    assert review.take_profit == 1.1830
+    assert review.targets == [1.1830, 1.1900]
+    assert "VWAP" in review.mentioned_indicators
+    assert "OrderFlow" in review.mentioned_indicators
+    assert review.confidence >= 80
+    assert review.summary
+
+
+def test_rule_based_provider_keeps_low_confidence_when_transcript_is_sparse() -> None:
+    review = RuleBasedAnalyzerProvider().analyze("Обзор рынка без конкретной сделки.", {"video_id": "empty"})
+
+    assert review.video_id == "empty"
+    assert review.entry is None
+    assert review.confidence < 30
+    assert review.risks


### PR DESCRIPTION
### Motivation
- Построить модульный AI-анализатор, работающий сейчас на наборе правил (Rule Engine) и позволяющий в будущем заменить провайдер на LLM без изменения API и фронтенда. 
- Требуется извлекать сущности, торговые идеи и рассчитывать confidence локально, без вызовов OpenAI/GPT/Gemini/Claude.

### Description
- Добавлен пакет `app/services/ai_analyzer` с типизированными моделями `AIReview`, `ExtractedEntities`, `TradingIdea` и `ConfidenceBreakdown` в `models.py`.
- Введён интерфейс `AIAnalyzerProvider` и реализация `RuleBasedAnalyzerProvider` с модулями: `entity_extractor.py`, `idea_extractor.py`, `confidence.py`, `summary.py`, `rule_provider.py` и обёрткой `AIAnalyzerEngine` в `engine.py`.
- Интеграция в ревью-пайплайн: `app/main.py` теперь собирает транскрипт и вызывает `ai_analyzer_engine.analyze(...)`, а ответ `GET /api/media/review/{video_id}` расширен полями `transcript`, `analysis` и `ai_review` при сохранении совместимости с legacy-полями.
- Фронтенд обновлён: `app/static/tv-review.js` добавлен блок "AI Analysis" и соответствующие изменения в `app/static/styles.css` для отображения summary, symbol, direction, confidence, entry/sl/tp, targets, detected levels, indicators, concepts, risks и opportunities.
- Добавлены модульные тесты `tests/ai_analyzer/test_rule_provider.py`, проверяющие корректное извлечение торговой идеи и поведение на малоданных транскриптах.
- Все изменения реализованы без интеграции внешних LLM — провайдерная архитектура позволяет добавить `OpenAIAnalyzerProvider`/`GeminiAnalyzerProvider`/другие позже.

### Testing
- Запуск `pytest -q tests/ai_analyzer/test_rule_provider.py` прошёл успешно: `2 passed`.
- Запуск `python -m py_compile app/main.py app/services/ai_analyzer/*.py` прошёл успешно и подтверждает синтаксическую корректность.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e5a596e5c83319d99a084fe09fdfb)