### PR TITLE
Add FXPilot Knowledge Layer v1

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,7 @@ from app.services.tv_source_manager import TvSourceConfigError, TvSourceManager
 from app.services.media_import_engine import MediaConfigError, MediaImportEngine
 from app.services.transcript import TranscriptEngine, TranscriptStorage
 from app.services.ai_analyzer import AIAnalyzerEngine
+from app.services.knowledge import KnowledgeEngine
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -150,6 +151,7 @@ def create_media_import_engine() -> MediaImportEngine:
 media_import_engine = create_media_import_engine()
 transcript_engine = TranscriptEngine(storage=TranscriptStorage(BASE_DIR.parent / "data" / "transcripts"))
 ai_analyzer_engine = AIAnalyzerEngine()
+MEDIA_KNOWLEDGE_DEBUG = {"knowledge_requests": 0, "knowledge_errors": 0, "last_knowledge_video_id": None, "last_agreement_score": None}
 
 class _AnalyticsNewsConnector:
     def _descriptor(self, *, status: str = "unavailable", note_ru: str = "") -> dict[str, str]:
@@ -659,10 +661,15 @@ def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, An
     transcript = _review_transcript_payload(video)
     ai_review = ai_analyzer_engine.analyze(str(transcript.get("text") or ""), {**video, "video_id": video.get("id")})
     analysis = ai_review.to_api_analysis()
+    knowledge_context = _build_knowledge_for_video(str(video.get("id") or ""), market_payload=market_payload).model_dump()
     return {
         "video": video,
         "transcript": transcript,
         "analysis": analysis,
+        "knowledge_context": knowledge_context,
+        "agreement_score": knowledge_context.get("agreement_score"),
+        "warnings": knowledge_context.get("warnings", []),
+        "conflicts": knowledge_context.get("conflicts", []),
         "ai_review": ai_review.to_dict(),
         "author_source": {
             "author": video.get("author"),
@@ -673,13 +680,34 @@ def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, An
         "detected_symbol": video.get("symbol"),
         "current_fxpilot_idea": model,
         "comparison": {
-            "video_says": analysis.get("summary") or "Transcript data is insufficient for AI analysis.",
+            "video_says": analysis.get("summary") if transcript.get("status") == "FOUND" and analysis.get("summary") else "No transcript yet. AI summary will appear later.",
             "fxpilot_says": model,
         },
         "confluence_score": score,
         "preliminary_verdict": _review_verdict(model, score, idea is not None),
         "source_endpoints": {"media": "/api/media", "market": "/api/ideas/market"},
     }
+
+
+def _build_knowledge_for_video(video_id: str, market_payload: dict[str, Any] | None = None):
+    def _market_payload_loader() -> dict[str, Any]:
+        return market_payload if isinstance(market_payload, dict) else ideas_market()
+
+    engine = KnowledgeEngine(
+        media_catalog_loader=_load_tv_video_catalog,
+        transcript_engine=transcript_engine,
+        ai_analyzer_engine=ai_analyzer_engine,
+        market_payload_loader=_market_payload_loader,
+    )
+    MEDIA_KNOWLEDGE_DEBUG["knowledge_requests"] += 1
+    MEDIA_KNOWLEDGE_DEBUG["last_knowledge_video_id"] = video_id
+    try:
+        context = engine.build_for_video(video_id)
+        MEDIA_KNOWLEDGE_DEBUG["last_agreement_score"] = context.agreement_score
+        return context
+    except Exception:
+        MEDIA_KNOWLEDGE_DEBUG["knowledge_errors"] += 1
+        raise
 
 
 @app.get("/api/tv/videos")
@@ -768,6 +796,7 @@ def api_media_debug() -> dict[str, Any]:
     try:
         payload = create_media_import_engine().debug_sources()
         payload.update(transcript_engine.debug_payload())
+        payload.update(MEDIA_KNOWLEDGE_DEBUG)
         return payload
     except MediaConfigError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -826,6 +855,23 @@ def _get_media_review(video_id: str) -> dict[str, Any]:
         if video.get("id") == video_id:
             return _build_tv_review_payload(video)
     raise HTTPException(status_code=404, detail="TV video not found")
+
+
+@app.get("/api/media/knowledge/{video_id}")
+def api_media_knowledge(video_id: str) -> dict[str, Any]:
+    try:
+        context = _build_knowledge_for_video(video_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {
+        "video": context.video,
+        "analysis": context.ai_analysis,
+        "market_context": context.market_context,
+        "risk": context.risk,
+        "agreement_score": context.agreement_score,
+        "conflicts": context.conflicts,
+        "warnings": context.warnings,
+    }
 
 
 @app.get("/api/media/review/{video_id}")

--- a/app/services/knowledge/__init__.py
+++ b/app/services/knowledge/__init__.py
@@ -1,0 +1,4 @@
+from app.services.knowledge.knowledge_engine import KnowledgeEngine
+from app.services.knowledge.context_builder import calculate_agreement_score, build_unified_context
+
+__all__ = ["KnowledgeEngine", "calculate_agreement_score", "build_unified_context"]

--- a/app/services/knowledge/context_builder.py
+++ b/app/services/knowledge/context_builder.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from app.services.knowledge.models import MarketKnowledgeContext, MediaKnowledgeContext, UnifiedKnowledgeContext
+from app.services.knowledge.risk_context import build_risk_context, is_high_news_risk
+from app.services.knowledge.market_context import normalize_direction, normalize_symbol
+
+
+def calculate_agreement_score(media: MediaKnowledgeContext, market: MarketKnowledgeContext) -> int:
+    score = 0
+    if media.detected_symbol and normalize_symbol(media.detected_symbol) == normalize_symbol(market.symbol):
+        score += 15
+    if normalize_direction(media.detected_direction) and normalize_direction(media.detected_direction) == normalize_direction(market.direction):
+        score += 20
+    if media.detected_levels:
+        score += 10
+    if market.market_idea:
+        score += 15
+    if market.orderflow.get("available"):
+        score += 10
+    if market.options.get("available"):
+        score += 10
+    if not is_high_news_risk(market.news.get("status")):
+        score += 10
+    score += round(max(0, min(100, media.confidence)) * 0.10)
+    return max(0, min(100, int(score)))
+
+
+def build_unified_context(media: MediaKnowledgeContext, market: MarketKnowledgeContext, ai_analysis: dict) -> UnifiedKnowledgeContext:
+    risk = build_risk_context(media, market)
+    score = calculate_agreement_score(media, market)
+    conflicts = list(risk.conflicts)
+    if score < 50 and "weak_confirmation" not in conflicts:
+        conflicts.append("weak_confirmation")
+    return UnifiedKnowledgeContext(
+        video=media.video,
+        transcript_status=media.transcript_status,
+        ai_analysis=ai_analysis,
+        symbol=media.detected_symbol or market.symbol,
+        direction=media.detected_direction or market.direction,
+        market_idea=market.market_idea,
+        orderflow=market.orderflow,
+        options=market.options,
+        news=market.news,
+        institutional_narrative=market.institutional_narrative,
+        risk=risk.model_dump(),
+        confidence=media.confidence,
+        agreement_score=score,
+        conflicts=conflicts,
+        warnings=risk.warnings,
+        market_context=market.model_dump(),
+    )

--- a/app/services/knowledge/knowledge_engine.py
+++ b/app/services/knowledge/knowledge_engine.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from app.services.ai_analyzer import AIAnalyzerEngine
+from app.services.knowledge.context_builder import build_unified_context
+from app.services.knowledge.market_context import build_market_context
+from app.services.knowledge.media_context import build_media_context
+from app.services.transcript import TranscriptEngine
+
+
+class KnowledgeEngine:
+    def __init__(self, *, media_catalog_loader: Callable[[], list[dict[str, Any]]], transcript_engine: TranscriptEngine, ai_analyzer_engine: AIAnalyzerEngine, market_payload_loader: Callable[[], dict[str, Any]]) -> None:
+        self.media_catalog_loader = media_catalog_loader
+        self.transcript_engine = transcript_engine
+        self.ai_analyzer_engine = ai_analyzer_engine
+        self.market_payload_loader = market_payload_loader
+
+    def build_for_video(self, video_id: str):
+        video = next((item for item in self.media_catalog_loader() if item.get("id") == video_id), None)
+        if not video:
+            raise ValueError("TV video not found")
+        transcript_id = str(video.get("youtube_id") or video.get("id") or video_id)
+        transcript = self.transcript_engine.get(transcript_id)
+        ai_review = self.ai_analyzer_engine.analyze(transcript.transcript, {**video, "video_id": video.get("id")})
+        media = build_media_context(video, transcript, ai_review)
+        market = build_market_context(media.detected_symbol, self.market_payload_loader)
+        return build_unified_context(media, market, ai_review.to_api_analysis())

--- a/app/services/knowledge/market_context.py
+++ b/app/services/knowledge/market_context.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from app.services.knowledge.models import MarketKnowledgeContext
+
+
+def _first(*values: Any) -> Any:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def normalize_symbol(value: Any) -> str:
+    return str(value or "").upper().replace("/", "").replace(" ", "").strip()
+
+
+def normalize_direction(value: Any) -> str | None:
+    raw = str(value or "").strip().upper()
+    if raw in {"BUY", "LONG", "BULLISH", "ПОКУПКА", "БЫЧИЙ"}:
+        return "BUY"
+    if raw in {"SELL", "SHORT", "BEARISH", "ПРОДАЖА", "МЕДВЕЖИЙ"}:
+        return "SELL"
+    return raw or None
+
+
+def _available(*values: Any) -> bool:
+    for value in values:
+        if isinstance(value, bool):
+            return value
+        if value not in (None, "") and str(value).lower() not in {"false", "0", "none", "null", "unavailable"}:
+            return True
+    return False
+
+
+def _ideas(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    out = []
+    for key in ("ideas", "signals", "active", "archive"):
+        if isinstance(payload.get(key), list):
+            out.extend(item for item in payload[key] if isinstance(item, dict))
+    return out
+
+
+def find_market_idea(market_payload: dict[str, Any], symbol: str | None) -> dict[str, Any] | None:
+    wanted = normalize_symbol(symbol)
+    if not wanted:
+        return None
+    for idea in _ideas(market_payload):
+        if normalize_symbol(_first(idea.get("symbol"), idea.get("pair"), idea.get("instrument"), idea.get("ticker"))) == wanted:
+            return idea
+    return None
+
+
+def build_market_context(symbol: str | None, market_payload_loader: Callable[[], dict[str, Any]]) -> MarketKnowledgeContext:
+    payload = market_payload_loader()
+    idea = find_market_idea(payload, symbol)
+    if not idea:
+        return MarketKnowledgeContext(symbol=normalize_symbol(symbol) or None, market_idea=None)
+    levels = idea.get("levels") if isinstance(idea.get("levels"), dict) else {}
+    setup = idea.get("setup") if isinstance(idea.get("setup"), dict) else {}
+    context = idea.get("market_context") if isinstance(idea.get("market_context"), dict) else {}
+    ms = idea.get("market_structure") if isinstance(idea.get("market_structure"), dict) else {}
+    orderflow = idea.get("orderflow") if isinstance(idea.get("orderflow"), dict) else {}
+    options = idea.get("options") if isinstance(idea.get("options"), dict) else {}
+    news = idea.get("news") if isinstance(idea.get("news"), dict) else {}
+    orderflow_available = _available(idea.get("orderflow_available"), context.get("orderflow_available"), orderflow.get("available"), idea.get("orderflow_bias"), orderflow.get("bias"))
+    options_available = _available(idea.get("options_available"), context.get("options_available"), options.get("available"), idea.get("options_bias"), options.get("bias"))
+    news_status = _first(idea.get("news_risk"), idea.get("news_status"), news.get("risk"), news.get("status"), "neutral")
+    return MarketKnowledgeContext(
+        symbol=normalize_symbol(_first(idea.get("symbol"), symbol)),
+        market_idea=idea,
+        direction=normalize_direction(_first(idea.get("action"), idea.get("direction"), idea.get("signal"), idea.get("bias"))),
+        entry=_first(idea.get("entry"), idea.get("entry_price"), levels.get("entry"), setup.get("entry")),
+        sl=_first(idea.get("sl"), idea.get("stop_loss"), levels.get("sl"), levels.get("stop_loss")),
+        tp=_first(idea.get("tp"), idea.get("take_profit"), levels.get("tp"), levels.get("take_profit")),
+        confidence=_first(idea.get("confidence"), idea.get("score"), idea.get("prop_score"), idea.get("total_score")),
+        grade=_first(idea.get("grade"), idea.get("quality_grade")),
+        mode=_first(idea.get("mode"), context.get("mode"), idea.get("data_mode")),
+        market_structure=ms or context.get("market_structure") or {},
+        trend=_first(idea.get("trend"), idea.get("htf_bias"), ms.get("trend_regime"), ms.get("trend")),
+        orderflow={"available": orderflow_available, "status": "available" if orderflow_available else "unavailable", "bias": _first(idea.get("orderflow_bias"), orderflow.get("bias")), "raw": orderflow},
+        options={"available": options_available, "status": "available" if options_available else "unavailable", "bias": _first(idea.get("options_bias"), idea.get("external_options_bias"), options.get("bias")), "raw": options},
+        news={"status": news_status, "raw": news},
+        institutional_narrative=_first(idea.get("institutional_narrative"), idea.get("narrative"), context.get("institutional_narrative"), idea.get("reason_ru")),
+    )

--- a/app/services/knowledge/media_context.py
+++ b/app/services/knowledge/media_context.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.ai_analyzer.models import AIReview
+from app.services.transcript.transcript_models import TranscriptResult
+from app.services.knowledge.models import MediaKnowledgeContext
+
+
+def build_media_context(media_item: dict[str, Any], transcript: TranscriptResult, ai_review: AIReview) -> MediaKnowledgeContext:
+    symbol = ai_review.symbol or media_item.get("symbol")
+    direction = ai_review.direction or media_item.get("direction")
+    video = {
+        "id": media_item.get("id"),
+        "title": media_item.get("title"),
+        "author": media_item.get("author"),
+        "source_id": media_item.get("source_id"),
+        "youtube_id": media_item.get("youtube_id"),
+        "published_at": media_item.get("published_at"),
+        "detected_symbol": symbol,
+        "detected_direction": direction,
+        "detected_levels": ai_review.mentioned_levels,
+        "summary": ai_review.summary,
+        "confidence": ai_review.confidence,
+    }
+    return MediaKnowledgeContext(
+        video=video,
+        transcript_status=transcript.status.value,
+        detected_symbol=symbol,
+        detected_direction=direction,
+        detected_levels=ai_review.mentioned_levels,
+        summary=ai_review.summary,
+        confidence=ai_review.confidence,
+    )

--- a/app/services/knowledge/models.py
+++ b/app/services/knowledge/models.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MediaKnowledgeContext(BaseModel):
+    video: dict[str, Any] = Field(default_factory=dict)
+    transcript_status: str = "NOT_AVAILABLE"
+    detected_symbol: str | None = None
+    detected_direction: str | None = None
+    detected_levels: list[float] = Field(default_factory=list)
+    summary: str = ""
+    confidence: int = 0
+
+
+class MarketKnowledgeContext(BaseModel):
+    symbol: str | None = None
+    market_idea: dict[str, Any] | None = None
+    direction: str | None = None
+    entry: Any = None
+    sl: Any = None
+    tp: Any = None
+    confidence: float | None = None
+    grade: Any = None
+    mode: Any = None
+    market_structure: dict[str, Any] = Field(default_factory=dict)
+    trend: Any = None
+    orderflow: dict[str, Any] = Field(default_factory=dict)
+    options: dict[str, Any] = Field(default_factory=dict)
+    news: dict[str, Any] = Field(default_factory=dict)
+    institutional_narrative: str | None = None
+
+
+class RiskKnowledgeContext(BaseModel):
+    warnings: list[str] = Field(default_factory=list)
+    conflicts: list[str] = Field(default_factory=list)
+
+
+class UnifiedKnowledgeContext(BaseModel):
+    video: dict[str, Any] = Field(default_factory=dict)
+    transcript_status: str = "NOT_AVAILABLE"
+    ai_analysis: dict[str, Any] = Field(default_factory=dict)
+    symbol: str | None = None
+    direction: str | None = None
+    market_idea: dict[str, Any] | None = None
+    orderflow: dict[str, Any] = Field(default_factory=dict)
+    options: dict[str, Any] = Field(default_factory=dict)
+    news: dict[str, Any] = Field(default_factory=dict)
+    institutional_narrative: str | None = None
+    risk: dict[str, Any] = Field(default_factory=dict)
+    confidence: float | None = None
+    agreement_score: int = 0
+    conflicts: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    market_context: dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())

--- a/app/services/knowledge/risk_context.py
+++ b/app/services/knowledge/risk_context.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from app.services.knowledge.models import MarketKnowledgeContext, MediaKnowledgeContext, RiskKnowledgeContext
+from app.services.knowledge.market_context import normalize_direction
+
+
+def is_high_news_risk(status: object) -> bool:
+    text = str(status or "").lower()
+    return any(token in text for token in ("high", "risk", "negative", "blocked", "красн", "риск", "негатив"))
+
+
+def build_risk_context(media: MediaKnowledgeContext, market: MarketKnowledgeContext) -> RiskKnowledgeContext:
+    warnings: list[str] = []
+    conflicts: list[str] = []
+    if media.transcript_status != "FOUND":
+        warnings.append("Transcript unavailable")
+    if not media.detected_symbol:
+        warnings.append("No detected symbol")
+        conflicts.append("no_symbol")
+    if not media.detected_direction:
+        warnings.append("No detected direction")
+    if not market.market_idea:
+        warnings.append("FXPilot has no current idea for this symbol")
+        conflicts.append("no_fxp_idea")
+    if not market.orderflow.get("available"):
+        warnings.append("OrderFlow unavailable")
+    if not market.options.get("available"):
+        warnings.append("Options unavailable")
+    if is_high_news_risk(market.news.get("status")):
+        warnings.append("News risk high")
+        conflicts.append("high_news_risk")
+    if media.confidence < 45:
+        warnings.append("AI analysis confidence low")
+    video_direction = normalize_direction(media.detected_direction)
+    market_direction = normalize_direction(market.direction)
+    if video_direction and market_direction and video_direction != market_direction:
+        warnings.append("Video direction conflicts with FXPilot direction")
+        conflicts.append("direction_conflict")
+    return RiskKnowledgeContext(warnings=warnings, conflicts=conflicts)

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -107,6 +107,22 @@
         <div><strong>Opportunities</strong><p>${list(analysis.opportunities)}</p></div>
       </div>` });
   }
+  function renderKnowledgeContext(review) {
+    const knowledge = review.knowledge_context || {};
+    const market = knowledge.market_context || {};
+    const cards = [
+      ['Market Idea', `${value(market.symbol || knowledge.symbol)} · ${directionRu(market.direction || knowledge.direction)} · Entry ${value(market.entry)} · SL ${value(market.sl)} · TP ${value(market.tp)}`],
+      ['Agreement Score', `${value(knowledge.agreement_score, 0)}/100`],
+      ['OrderFlow', `${statusRu(knowledge.orderflow?.status || (knowledge.orderflow?.available ? 'available' : 'unavailable'))}${knowledge.orderflow?.bias ? ` · ${knowledge.orderflow.bias}` : ''}`],
+      ['Options', `${statusRu(knowledge.options?.status || (knowledge.options?.available ? 'available' : 'unavailable'))}${knowledge.options?.bias ? ` · ${knowledge.options.bias}` : ''}`],
+      ['News', knowledge.news?.status || 'neutral'],
+      ['Institutional Narrative', knowledge.institutional_narrative],
+      ['Risk Warnings', Array.isArray(knowledge.warnings) && knowledge.warnings.length ? knowledge.warnings.join(' · ') : 'Предупреждений нет'],
+      ['Conflicts', Array.isArray(knowledge.conflicts) && knowledge.conflicts.length ? knowledge.conflicts.join(' · ') : 'Конфликтов нет'],
+    ];
+    return ReviewSection({ id: 'knowledgeContext', className: 'tv-review-section--summary tv-verdict-section', title: 'FXPilot Knowledge Context', content: `<div class="tv-snapshot-grid tv-review-wide-grid">${cards.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div><p class="tv-context-note">Единый Knowledge Layer: metadata + transcript + rule AI analysis + FXPilot market idea. LLM/external AI calls не используются.</p>` });
+  }
+
 
   function renderComparison(review) {
     const idea = review.current_fxpilot_idea || {};
@@ -127,7 +143,7 @@
 
   function ReviewPage(review, transcript) {
     const video = review.video || {};
-    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderAIAnalysis(review)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
+    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderAIAnalysis(review)}${renderKnowledgeContext(review)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
   }
 
   async function loadReview() {

--- a/tests/test_knowledge_layer.py
+++ b/tests/test_knowledge_layer.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from app.services.ai_analyzer.models import AIReview
+from app.services.knowledge.context_builder import calculate_agreement_score
+from app.services.knowledge.knowledge_engine import KnowledgeEngine
+from app.services.knowledge.market_context import build_market_context
+from app.services.knowledge.media_context import build_media_context
+from app.services.transcript.transcript_models import TranscriptResult, TranscriptStatus
+
+
+class FakeTranscriptEngine:
+    def __init__(self, result):
+        self.result = result
+
+    def get(self, video_id):
+        return self.result
+
+
+class FakeAnalyzer:
+    def __init__(self, review):
+        self.review = review
+
+    def analyze(self, transcript, metadata):
+        return self.review
+
+
+def market_payload(direction="BUY", orderflow=True, symbol="EURUSD"):
+    return {
+        "ideas": [
+            {
+                "symbol": symbol,
+                "direction": direction,
+                "entry": 1.1,
+                "sl": 1.09,
+                "tp": 1.12,
+                "confidence": 80,
+                "grade": "A",
+                "mode": "live",
+                "market_structure": {"trend_regime": "bullish"},
+                "orderflow": {"available": orderflow, "bias": "buy"},
+                "options": {"available": True, "bias": "supportive"},
+                "news": {"risk": "neutral"},
+                "institutional_narrative": "Покупатели удерживают discount.",
+            }
+        ]
+    }
+
+
+def build_engine(review, transcript, payload):
+    return KnowledgeEngine(
+        media_catalog_loader=lambda: [{"id": "v1", "youtube_id": "yt1", "title": "EURUSD buy", "symbol": "EURUSD"}],
+        transcript_engine=FakeTranscriptEngine(transcript),
+        ai_analyzer_engine=FakeAnalyzer(review),
+        market_payload_loader=lambda: payload,
+    )
+
+
+def test_build_context_with_transcript_ai_analysis_and_market_idea():
+    transcript = TranscriptResult("yt1", "en", "cache", "Buy EURUSD from 1.10", status=TranscriptStatus.FOUND)
+    review = AIReview(video_id="v1", symbol="EURUSD", direction="BUY", mentioned_levels=[1.1], confidence=75, summary="Покупка EURUSD")
+    context = build_engine(review, transcript, market_payload()).build_for_video("v1")
+    assert context.symbol == "EURUSD"
+    assert context.market_idea is not None
+    assert context.orderflow["available"] is True
+    assert context.agreement_score > 80
+
+
+def test_missing_transcript_warning():
+    transcript = TranscriptResult("yt1", None, "none", "", status=TranscriptStatus.NOT_AVAILABLE)
+    review = AIReview(video_id="v1", symbol="EURUSD", direction="BUY", confidence=60)
+    context = build_engine(review, transcript, market_payload()).build_for_video("v1")
+    assert "Transcript unavailable" in context.warnings
+
+
+def test_missing_symbol_conflict():
+    media = build_media_context({"id": "v1"}, TranscriptResult("v1", None, "none", "", status=TranscriptStatus.FOUND), AIReview(video_id="v1", confidence=20))
+    market = build_market_context(media.detected_symbol, lambda: market_payload())
+    score = calculate_agreement_score(media, market)
+    assert score < 50
+
+
+def test_direction_conflict():
+    transcript = TranscriptResult("yt1", "en", "cache", "Sell EURUSD", status=TranscriptStatus.FOUND)
+    review = AIReview(video_id="v1", symbol="EURUSD", direction="SELL", confidence=70)
+    context = build_engine(review, transcript, market_payload(direction="BUY")).build_for_video("v1")
+    assert "direction_conflict" in context.conflicts
+
+
+def test_orderflow_unavailable_warning_and_agreement_score_calculation():
+    transcript = TranscriptResult("yt1", "en", "cache", "Buy EURUSD 1.10", status=TranscriptStatus.FOUND)
+    review = AIReview(video_id="v1", symbol="EURUSD", direction="BUY", mentioned_levels=[1.1], confidence=100)
+    context = build_engine(review, transcript, market_payload(orderflow=False)).build_for_video("v1")
+    assert "OrderFlow unavailable" in context.warnings
+    assert context.agreement_score == 90
+
+
+def test_review_api_contains_knowledge_context(monkeypatch):
+    from fastapi.testclient import TestClient
+    import app.main as main
+
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [{"id": "v1", "youtube_id": "yt1", "title": "EURUSD buy", "symbol": "EURUSD"}])
+    monkeypatch.setattr(main.transcript_engine, "get", lambda video_id: TranscriptResult(video_id, "en", "cache", "Buy EURUSD 1.10", status=TranscriptStatus.FOUND))
+    monkeypatch.setattr(main.ai_analyzer_engine, "analyze", lambda transcript, metadata: AIReview(video_id="v1", symbol="EURUSD", direction="BUY", mentioned_levels=[1.1], confidence=80))
+    monkeypatch.setattr(main, "ideas_market", lambda: market_payload())
+    response = TestClient(main.app).get("/api/media/review/v1")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "analysis" in payload
+    assert "knowledge_context" in payload
+    assert "agreement_score" in payload
+    assert "warnings" in payload
+    assert "conflicts" in payload


### PR DESCRIPTION
### Motivation
- Объединить метаданные видео, транскрипт, rule‑based AI‑анализ и текущую идею FXPilot в единый Knowledge Layer для TV‑review без вызовов внешних LLM/AI.
- Дать фронтенду и API стабильный контракт с оценкой согласованности, предупреждениями и конфликтами для удобного отображения и автоматической фильтрации сигналов.

### Description
- Добавлен пакет `app/services/knowledge/` с Pydantic‑моделями `MediaKnowledgeContext`, `MarketKnowledgeContext`, `RiskKnowledgeContext` и `UnifiedKnowledgeContext` в `models.py`.
- Реализованы сборщики контекста: `media_context.py` (metadata + transcript + `AIReview`), `market_context.py` (подгрузка / сопоставление идей из существующей логики `/api/ideas/market`), `risk_context.py` (rule‑based warnings/conflicts) и `context_builder.py` (агрегация + `agreement_score`).
- Добавлен оркестратор `KnowledgeEngine` в `knowledge_engine.py` и экспорт в `app.services.knowledge` для повторного использования существующих движков (media catalog, transcript engine, rule AI analyzer, идеи FXPilot).
- API: добавлен `GET /api/media/knowledge/{video_id}` и расширен ответ `GET /api/media/review/{video_id}` полями `knowledge_context`, `agreement_score`, `warnings` и `conflicts`; `/api/media/debug` теперь содержит счётчики knowledge requests/errors и последние метрики.
- Frontend: на странице обзора TV добавлен блок «FXPilot Knowledge Context» с карточками Market Idea, Agreement Score, OrderFlow, Options, News, Institutional Narrative, Risk Warnings и Conflicts, без редизайна существующих секций.
- Сохранены ограничения: не вызываем внешние LLM/AI, не меняем OrderFlow Engine, не перестраиваем TV‑архитектуру; модуль использует внутренние функции загрузки идей и локальные анализаторы.

### Testing
- Успешно проверена статическая компиляция: `python -m py_compile app/main.py app/services/knowledge/*.py`.
- Прогон юнит‑тестов: `pytest tests/test_knowledge_layer.py tests/test_media_import_engine.py tests/test_transcript_engine.py tests/ai_analyzer/test_rule_provider.py` завершился успешно с результатом `37 passed` и предупреждениями `18 warnings`.
- Добавлены и выполнены новые юнит‑тесты `tests/test_knowledge_layer.py`, покрывающие: сбор контекста при наличии транскрипта и идеи, отсутствие транскрипта, отсутствие символа, конфликт направлений, недоступный OrderFlow и контракт API обзора с полем `knowledge_context`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e675c563c8331a4e43aa0e1fcbb91)