### PR TITLE
Добавлен модульный LLM Review Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 
 
+## Что обновлено в версии 4.5
+- Добавлен модульный FXPilot AI Review Engine Stage 3: `app/services/llm_review/` содержит контракт `LLMReview`, интерфейс `LLMReviewProvider`, OpenAI-провайдер, prompt builder, engine и JSON-cache в `data/llm_reviews/`.
+- Новый endpoint `GET /api/media/llm-review/{video_id}` возвращает `video`, `analysis`, `knowledge` и `llm_review`; существующий `GET /api/media/review/{video_id}` обратносовместимо расширен полем `llm_review`.
+- Архитектура построена через dependency injection: API и frontend зависят от `ReviewEngine -> LLMReviewProvider`, поэтому Gemini/Claude/DeepSeek/Local LLM можно добавить заменой провайдера без изменения UI-контракта.
+- OpenAI-провайдер использует только env `OPENAI_API_KEY`, `FXPILOT_OPENAI_MODEL` (default `gpt-4.1`) и `FXPILOT_LLM_TIMEOUT`, запрашивает structured JSON и валидирует ответ через `LLMReview`.
+- На странице review добавлен блок `AI Expert Verdict` с Summary, Agreement, Recommended Action, Reasoning, Risks, Contradictions, Institutional View, News Impact, Market Bias и Confidence.
+
 ## Что обновлено в версии 4.4
 - YouTube-импорт FXPilot TV переведён на `yt-dlp`: backend больше не требует Google Cloud и YouTube Data API, не парсит HTML вручную и не скачивает видеофайлы — импортируются только метаданные публичных каналов.
 - Добавлен провайдер `youtube_ytdlp`, который принимает `@handle`, `/channel/`, `/user/` и `/c/`, кэширует ответы по каналу на 30 минут, нормализует видео в `MediaItem` и сохраняет каталог с дедупликацией по `youtube_id`.

--- a/app/main.py
+++ b/app/main.py
@@ -46,6 +46,7 @@ from app.services.media_import_engine import MediaConfigError, MediaImportEngine
 from app.services.transcript import TranscriptEngine, TranscriptStorage
 from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge import KnowledgeEngine
+from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewProvider, ReviewEngine
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -152,6 +153,7 @@ media_import_engine = create_media_import_engine()
 transcript_engine = TranscriptEngine(storage=TranscriptStorage(BASE_DIR.parent / "data" / "transcripts"))
 ai_analyzer_engine = AIAnalyzerEngine()
 MEDIA_KNOWLEDGE_DEBUG = {"knowledge_requests": 0, "knowledge_errors": 0, "last_knowledge_video_id": None, "last_agreement_score": None}
+LLM_REVIEW_STORAGE = LLMReviewStorage(BASE_DIR.parent / "data" / "llm_reviews")
 
 class _AnalyticsNewsConnector:
     def _descriptor(self, *, status: str = "unavailable", note_ru: str = "") -> dict[str, str]:
@@ -653,6 +655,59 @@ def _review_transcript_payload(video: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+
+class ContextOnlyReviewProvider:
+    """Local provider fallback that preserves the LLMReview contract when no external key is configured."""
+
+    def generate_review(self, context: dict[str, Any]) -> LLMReview:
+        knowledge = context.get("knowledge_layer") or {}
+        analysis = context.get("ai_analysis") or {}
+        idea = context.get("current_fxpilot_idea") or {}
+        warnings = knowledge.get("warnings") or context.get("detected_risks") or []
+        conflicts = knowledge.get("conflicts") or context.get("detected_conflicts") or []
+        symbol = knowledge.get("symbol") or analysis.get("symbol") or (idea or {}).get("symbol") or "Unknown"
+        direction = knowledge.get("direction") or analysis.get("direction") or (idea or {}).get("direction") or "Unknown"
+        summary = analysis.get("summary") or f"Контекст по {symbol}: направление {direction}. Детали ограничены supplied context."
+        agreement = int(knowledge.get("agreement_score") or context.get("agreement_score") or 0)
+        confidence = int(analysis.get("confidence") or knowledge.get("confidence") or 0)
+        recommended = "WAIT / наблюдать" if conflicts or agreement < 65 else "Использовать как подтверждающий контекст, без входа без собственного риск-менеджмента"
+        return LLMReview(
+            summary=summary,
+            direction=direction,
+            confidence=max(0, min(100, confidence)),
+            agreement_score=max(0, min(100, agreement)),
+            entry=analysis.get("entry") or (idea or {}).get("entry") or "Unknown",
+            stop_loss=analysis.get("sl") or (idea or {}).get("sl") or "Unknown",
+            take_profit=analysis.get("tp") or (idea or {}).get("tp") or "Unknown",
+            targets=analysis.get("targets") or [],
+            reasoning=analysis.get("reasoning") or ["Оценка построена только на Transcript, AI Analyzer, Knowledge Layer и текущей идее FXPilot."],
+            risks=analysis.get("risks") or warnings or ["Unknown"],
+            opportunities=analysis.get("opportunities") or ["Unknown"],
+            contradictions=conflicts,
+            institutional_view=knowledge.get("institutional_narrative") or "Unknown.",
+            news_impact=(knowledge.get("news") or {}).get("status") or (knowledge.get("news") or {}).get("risk") or "Unknown",
+            market_bias=direction,
+            recommended_action=recommended,
+            provider="local-context",
+        )
+
+
+def create_llm_review_provider():
+    if os.getenv("OPENAI_API_KEY", "").strip():
+        return OpenAIReviewProvider()
+    return ContextOnlyReviewProvider()
+
+
+def create_llm_review_engine(market_payload: dict[str, Any] | None = None, provider: Any | None = None) -> ReviewEngine:
+    return ReviewEngine(
+        media_catalog_loader=_load_tv_video_catalog,
+        transcript_engine=transcript_engine,
+        ai_analyzer_engine=ai_analyzer_engine,
+        market_payload_loader=lambda: market_payload if isinstance(market_payload, dict) else ideas_market(),
+        provider=provider or create_llm_review_provider(),
+        storage=LLM_REVIEW_STORAGE,
+    )
+
 def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, Any] | None = None) -> dict[str, Any]:
     market_payload = market_payload if isinstance(market_payload, dict) else ideas_market()
     idea = _find_review_market_idea(market_payload, str(video.get("symbol") or ""))
@@ -662,11 +717,14 @@ def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, An
     ai_review = ai_analyzer_engine.analyze(str(transcript.get("text") or ""), {**video, "video_id": video.get("id")})
     analysis = ai_review.to_api_analysis()
     knowledge_context = _build_knowledge_for_video(str(video.get("id") or ""), market_payload=market_payload).model_dump()
+    llm_review = create_llm_review_engine(market_payload=market_payload).generate(str(video.get("id") or ""))
     return {
         "video": video,
         "transcript": transcript,
         "analysis": analysis,
         "knowledge_context": knowledge_context,
+        "knowledge": knowledge_context,
+        "llm_review": llm_review.model_dump(),
         "agreement_score": knowledge_context.get("agreement_score"),
         "warnings": knowledge_context.get("warnings", []),
         "conflicts": knowledge_context.get("conflicts", []),
@@ -873,6 +931,22 @@ def api_media_knowledge(video_id: str) -> dict[str, Any]:
         "warnings": context.warnings,
     }
 
+
+
+@app.get("/api/media/llm-review/{video_id}")
+def api_media_llm_review(video_id: str, force: bool = False) -> dict[str, Any]:
+    video = next((item for item in _load_tv_video_catalog() if item.get("id") == video_id), None)
+    if not video:
+        raise HTTPException(status_code=404, detail="TV video not found")
+    market_payload = ideas_market()
+    review = create_llm_review_engine(market_payload=market_payload).generate(video_id, force=force)
+    knowledge = _build_knowledge_for_video(video_id, market_payload=market_payload).model_dump()
+    return {
+        "video": video,
+        "analysis": knowledge.get("ai_analysis", {}),
+        "knowledge": knowledge,
+        "llm_review": review.model_dump(),
+    }
 
 @app.get("/api/media/review/{video_id}")
 def api_media_review(video_id: str) -> dict[str, Any]:

--- a/app/services/llm_review/__init__.py
+++ b/app/services/llm_review/__init__.py
@@ -1,0 +1,7 @@
+from app.services.llm_review.models import LLMReview
+from app.services.llm_review.openai_provider import OpenAIReviewProvider
+from app.services.llm_review.provider import LLMReviewProvider
+from app.services.llm_review.review_engine import ReviewEngine
+from app.services.llm_review.storage import LLMReviewStorage
+
+__all__ = ["LLMReview", "LLMReviewProvider", "OpenAIReviewProvider", "ReviewEngine", "LLMReviewStorage"]

--- a/app/services/llm_review/models.py
+++ b/app/services/llm_review/models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+
+
+class LLMReview(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    summary: str = "Unknown."
+    direction: str = "Unknown"
+    confidence: int = Field(default=0, ge=0, le=100)
+    agreement_score: int = Field(default=0, ge=0, le=100)
+    entry: Any = "Unknown"
+    stop_loss: Any = "Unknown"
+    take_profit: Any = "Unknown"
+    targets: list[Any] = Field(default_factory=list)
+    reasoning: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
+    opportunities: list[str] = Field(default_factory=list)
+    contradictions: list[str] = Field(default_factory=list)
+    institutional_view: str = "Unknown."
+    news_impact: str = "Unknown."
+    market_bias: str = "Unknown"
+    recommended_action: str = "Unknown."
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    provider: str = "unknown"
+    tokens_used: int = 0
+    latency_ms: int = 0
+
+    @field_validator("confidence", "agreement_score", mode="before")
+    @classmethod
+    def clamp_percent(cls, value: Any) -> int:
+        try:
+            number = int(round(float(value)))
+        except (TypeError, ValueError):
+            return 0
+        return max(0, min(100, number))
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any], *, provider: str | None = None, tokens_used: int | None = None, latency_ms: int | None = None) -> "LLMReview":
+        data = dict(payload or {})
+        if provider is not None:
+            data["provider"] = provider
+        if tokens_used is not None:
+            data["tokens_used"] = tokens_used
+        if latency_ms is not None:
+            data["latency_ms"] = latency_ms
+        return cls.model_validate(data)

--- a/app/services/llm_review/openai_provider.py
+++ b/app/services/llm_review/openai_provider.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+
+from openai import OpenAI
+
+from app.services.llm_review.models import LLMReview
+from app.services.llm_review.prompt_builder import PromptBuilder
+
+
+class OpenAIReviewProvider:
+    provider_name = "openai"
+
+    def __init__(self, *, api_key: str | None = None, model: str | None = None, timeout: float | None = None, retries: int = 2, prompt_builder: PromptBuilder | None = None) -> None:
+        self.api_key = api_key if api_key is not None else os.getenv("OPENAI_API_KEY", "")
+        self.model = model or os.getenv("FXPILOT_OPENAI_MODEL", "gpt-4.1")
+        self.timeout = timeout if timeout is not None else float(os.getenv("FXPILOT_LLM_TIMEOUT", "30"))
+        self.retries = max(0, int(retries))
+        self.prompt_builder = prompt_builder or PromptBuilder()
+
+    def generate_review(self, context: dict[str, Any]) -> LLMReview:
+        if not self.api_key:
+            raise RuntimeError("OPENAI_API_KEY is not configured")
+        prompt = self.prompt_builder.build(context)
+        client = OpenAI(api_key=self.api_key, timeout=self.timeout, max_retries=self.retries)
+        started = time.perf_counter()
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+            temperature=0.1,
+        )
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        content = response.choices[0].message.content or "{}"
+        payload = json.loads(content)
+        tokens = getattr(getattr(response, "usage", None), "total_tokens", 0) or 0
+        return LLMReview.from_payload(payload, provider=f"openai:{self.model}", tokens_used=int(tokens), latency_ms=latency_ms)

--- a/app/services/llm_review/prompt_builder.py
+++ b/app/services/llm_review/prompt_builder.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+REQUIRED_JSON_FIELDS = [
+    "summary", "direction", "confidence", "agreement_score", "entry", "stop_loss", "take_profit",
+    "targets", "reasoning", "risks", "opportunities", "contradictions", "institutional_view",
+    "news_impact", "market_bias", "recommended_action",
+]
+
+
+class PromptBuilder:
+    def build(self, context: dict[str, Any]) -> str:
+        safe_context = json.dumps(context, ensure_ascii=False, default=str, indent=2)
+        fields = json.dumps(REQUIRED_JSON_FIELDS, ensure_ascii=False)
+        return f"""You are a Senior Institutional FX Analyst.
+
+Rules:
+- Answer ONLY valid JSON. No markdown. No prose outside JSON.
+- Use only the supplied context.
+- Never invent prices.
+- Never invent symbols.
+- If information is missing, write "Unknown".
+- Clearly distinguish proxy metrics from real market metrics.
+- Provide a professional trading review, not financial advice.
+
+Return one JSON object with exactly these business fields: {fields}.
+Use arrays for targets, reasoning, risks, opportunities, contradictions.
+confidence and agreement_score must be integers from 0 to 100.
+
+Supplied context:
+{safe_context}
+"""

--- a/app/services/llm_review/provider.py
+++ b/app/services/llm_review/provider.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.services.llm_review.models import LLMReview
+
+
+class LLMReviewProvider(Protocol):
+    def generate_review(self, context: dict) -> LLMReview:
+        """Generate a structured trading review from an already-built context."""

--- a/app/services/llm_review/review_engine.py
+++ b/app/services/llm_review/review_engine.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from app.services.ai_analyzer import AIAnalyzerEngine
+from app.services.knowledge import KnowledgeEngine
+from app.services.llm_review.models import LLMReview
+from app.services.llm_review.provider import LLMReviewProvider
+from app.services.llm_review.storage import LLMReviewStorage
+from app.services.transcript import TranscriptEngine
+
+
+class ReviewEngine:
+    def __init__(
+        self,
+        *,
+        media_catalog_loader: Callable[[], list[dict[str, Any]]],
+        transcript_engine: TranscriptEngine,
+        ai_analyzer_engine: AIAnalyzerEngine,
+        market_payload_loader: Callable[[], dict[str, Any]],
+        provider: LLMReviewProvider,
+        storage: LLMReviewStorage | None = None,
+    ) -> None:
+        self.media_catalog_loader = media_catalog_loader
+        self.transcript_engine = transcript_engine
+        self.ai_analyzer_engine = ai_analyzer_engine
+        self.market_payload_loader = market_payload_loader
+        self.provider = provider
+        self.storage = storage or LLMReviewStorage()
+
+    def build_context(self, video_id: str) -> dict[str, Any]:
+        video = next((item for item in self.media_catalog_loader() if item.get("id") == video_id), None)
+        if not video:
+            raise ValueError("TV video not found")
+        transcript_id = str(video.get("youtube_id") or video.get("id") or video_id)
+        transcript = self.transcript_engine.get(transcript_id)
+        ai_review = self.ai_analyzer_engine.analyze(transcript.transcript, {**video, "video_id": video.get("id")})
+        market_payload = self.market_payload_loader()
+        knowledge = KnowledgeEngine(
+            media_catalog_loader=self.media_catalog_loader,
+            transcript_engine=self.transcript_engine,
+            ai_analyzer_engine=self.ai_analyzer_engine,
+            market_payload_loader=lambda: market_payload,
+        ).build_for_video(video_id)
+        return {
+            "video": video,
+            "transcript": {"status": transcript.status.value, "text": transcript.transcript, "language": transcript.language, "provider": transcript.source},
+            "ai_analysis": ai_review.to_api_analysis(),
+            "knowledge_layer": knowledge.model_dump(),
+            "market_context": knowledge.market_context,
+            "current_fxpilot_idea": knowledge.market_idea,
+            "agreement_score": knowledge.agreement_score,
+            "detected_risks": knowledge.warnings,
+            "detected_conflicts": knowledge.conflicts,
+        }
+
+    def generate(self, video_id: str, *, force: bool = False) -> LLMReview:
+        if not force:
+            cached = self.storage.get(video_id)
+            if cached:
+                return cached
+        review = self.provider.generate_review(self.build_context(video_id))
+        # Re-validate provider JSON through the explicit contract before caching.
+        review = LLMReview.model_validate(review.model_dump())
+        self.storage.set(video_id, review)
+        return review

--- a/app/services/llm_review/storage.py
+++ b/app/services/llm_review/storage.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.services.llm_review.models import LLMReview
+
+
+class LLMReviewStorage:
+    def __init__(self, base_dir: Path | str = Path("data") / "llm_reviews") -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def path_for(self, video_id: str) -> Path:
+        safe = "".join(ch for ch in str(video_id) if ch.isalnum() or ch in {"-", "_"}) or "unknown"
+        return self.base_dir / f"{safe}.json"
+
+    def get(self, video_id: str) -> LLMReview | None:
+        path = self.path_for(video_id)
+        if not path.exists():
+            return None
+        return LLMReview.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+    def set(self, video_id: str, review: LLMReview) -> None:
+        self.path_for(video_id).write_text(review.model_dump_json(indent=2), encoding="utf-8")

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -124,6 +124,29 @@
   }
 
 
+  function renderExpertVerdict(review) {
+    const verdict = review.llm_review || {};
+    const rows = [
+      ['Agreement', verdict.agreement_score === undefined ? null : `${verdict.agreement_score}/100`],
+      ['Recommended Action', verdict.recommended_action],
+      ['Institutional View', verdict.institutional_view],
+      ['News Impact', verdict.news_impact],
+      ['Market Bias', verdict.market_bias],
+      ['Confidence', percent(verdict.confidence)],
+    ];
+    const block = (title, value) => `<div class="tv-premium-placeholder"><strong>${escapeHtml(title)}</strong><p>${Array.isArray(value) && value.length ? value.map((item) => escapeHtml(item)).join(' · ') : escapeHtml(value || 'Unknown')}</p></div>`;
+    return ReviewSection({ id: 'aiExpertVerdict', className: 'tv-review-section--summary tv-verdict-section', title: 'AI Expert Verdict', content: `
+      ${block('Summary', verdict.summary)}
+      <div class="tv-snapshot-grid tv-review-wide-grid">${rows.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item, 'Unknown'))}</strong></div>`).join('')}</div>
+      <div class="tv-analysis-lists">
+        <div><strong>Reasoning</strong><p>${list(verdict.reasoning)}</p></div>
+        <div><strong>Risks</strong><p>${list(verdict.risks)}</p></div>
+        <div><strong>Contradictions</strong><p>${list(verdict.contradictions)}</p></div>
+      </div>
+      <p class="tv-context-note">Senior Institutional FX Analyst: использует только supplied context, без выдумывания цен и символов.</p>` });
+  }
+
+
   function renderComparison(review) {
     const idea = review.current_fxpilot_idea || {};
     return ReviewSection({ id: 'comparison', className: 'tv-review-section--summary', title: 'Comparison', content: `
@@ -143,7 +166,7 @@
 
   function ReviewPage(review, transcript) {
     const video = review.video || {};
-    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderAIAnalysis(review)}${renderKnowledgeContext(review)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
+    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderAIAnalysis(review)}${renderExpertVerdict(review)}${renderKnowledgeContext(review)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
   }
 
   async function loadReview() {

--- a/tests/test_llm_review.py
+++ b/tests/test_llm_review.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.services.ai_analyzer.models import AIReview
+from app.services.llm_review.models import LLMReview
+from app.services.llm_review.prompt_builder import PromptBuilder
+from app.services.llm_review.review_engine import ReviewEngine
+from app.services.llm_review.storage import LLMReviewStorage
+from app.services.transcript.transcript_models import TranscriptResult, TranscriptStatus
+
+
+class FakeTranscriptEngine:
+    def get(self, video_id):
+        return TranscriptResult(video_id, "en", "cache", "Buy EURUSD from 1.10", status=TranscriptStatus.FOUND)
+
+
+class FakeAnalyzer:
+    def analyze(self, transcript, metadata):
+        return AIReview(video_id=metadata["video_id"], symbol="EURUSD", direction="BUY", entry=1.1, stop_loss=1.09, take_profit=1.12, confidence=80, summary="Покупка EURUSD")
+
+
+class MockProvider:
+    def __init__(self):
+        self.calls = 0
+
+    def generate_review(self, context):
+        self.calls += 1
+        return LLMReview(summary="Professional review", direction="BUY", confidence=80, agreement_score=context["agreement_score"], provider="mock")
+
+
+def market_payload():
+    return {"ideas": [{"symbol": "EURUSD", "direction": "BUY", "entry": 1.1, "sl": 1.09, "tp": 1.12, "confidence": 80, "orderflow": {"available": True}, "options": {"available": True}, "news": {"risk": "neutral"}}]}
+
+
+def build_engine(tmp_path: Path, provider: MockProvider):
+    return ReviewEngine(
+        media_catalog_loader=lambda: [{"id": "v1", "youtube_id": "yt1", "title": "EURUSD buy", "symbol": "EURUSD"}],
+        transcript_engine=FakeTranscriptEngine(),
+        ai_analyzer_engine=FakeAnalyzer(),
+        market_payload_loader=market_payload,
+        provider=provider,
+        storage=LLMReviewStorage(tmp_path),
+    )
+
+
+def test_prompt_builder_requires_json_and_supplied_context_only():
+    prompt = PromptBuilder().build({"transcript": {"text": "Buy EURUSD"}, "agreement_score": 90})
+    assert "Answer ONLY valid JSON" in prompt
+    assert "Never invent prices" in prompt
+    assert "Senior Institutional FX Analyst" in prompt
+    assert "agreement_score" in prompt
+
+
+def test_llm_review_json_validation():
+    review = LLMReview.model_validate({"summary": "Ok", "direction": "BUY", "confidence": 101, "agreement_score": 50})
+    assert review.confidence == 100
+
+
+def test_review_engine_uses_provider_and_cache(tmp_path):
+    provider = MockProvider()
+    engine = build_engine(tmp_path, provider)
+    first = engine.generate("v1")
+    second = engine.generate("v1")
+    assert first.summary == "Professional review"
+    assert second.summary == "Professional review"
+    assert provider.calls == 1
+    assert (tmp_path / "v1.json").exists()
+
+
+def test_llm_review_endpoint(monkeypatch, tmp_path):
+    import app.main as main
+
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [{"id": "v1", "youtube_id": "yt1", "title": "EURUSD buy", "symbol": "EURUSD"}])
+    monkeypatch.setattr(main.transcript_engine, "get", lambda video_id: TranscriptResult(video_id, "en", "cache", "Buy EURUSD 1.10", status=TranscriptStatus.FOUND))
+    monkeypatch.setattr(main.ai_analyzer_engine, "analyze", lambda transcript, metadata: AIReview(video_id="v1", symbol="EURUSD", direction="BUY", mentioned_levels=[1.1], confidence=80, summary="Покупка EURUSD"))
+    monkeypatch.setattr(main, "ideas_market", lambda: market_payload())
+    monkeypatch.setattr(main, "LLM_REVIEW_STORAGE", LLMReviewStorage(tmp_path))
+    monkeypatch.setattr(main, "create_llm_review_provider", lambda: MockProvider())
+
+    response = TestClient(main.app).get("/api/media/llm-review/v1")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "video" in payload
+    assert "analysis" in payload
+    assert "knowledge" in payload
+    assert payload["llm_review"]["summary"] == "Professional review"
+
+
+def test_review_endpoint_includes_llm_review(monkeypatch, tmp_path):
+    import app.main as main
+
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [{"id": "v1", "youtube_id": "yt1", "title": "EURUSD buy", "symbol": "EURUSD"}])
+    monkeypatch.setattr(main.transcript_engine, "get", lambda video_id: TranscriptResult(video_id, "en", "cache", "Buy EURUSD 1.10", status=TranscriptStatus.FOUND))
+    monkeypatch.setattr(main.ai_analyzer_engine, "analyze", lambda transcript, metadata: AIReview(video_id="v1", symbol="EURUSD", direction="BUY", mentioned_levels=[1.1], confidence=80, summary="Покупка EURUSD"))
+    monkeypatch.setattr(main, "ideas_market", lambda: market_payload())
+    monkeypatch.setattr(main, "LLM_REVIEW_STORAGE", LLMReviewStorage(tmp_path))
+    monkeypatch.setattr(main, "create_llm_review_provider", lambda: MockProvider())
+
+    response = TestClient(main.app).get("/api/media/review/v1")
+    assert response.status_code == 200
+    assert response.json()["llm_review"]["provider"] == "mock"


### PR DESCRIPTION
### Motivation
- Ввести модульный LLM-пайплайн для генерации институционного AI-ревью по видео с возможностью легко менять провайдер (OpenAI/Gemini/Claude/DeepSeek/Local) без правок API и frontend. 
- Обеспечить строгий контракт JSON-ответа, локальный fallback без внешних ключей и кеширование результатов для стабильности и повторного использования.

### Description
- Добавлен пакет `app/services/llm_review/` с моделями (`LLMReview`), провайдерным протоколом (`LLMReviewProvider`), `OpenAIReviewProvider`, `PromptBuilder`, `ReviewEngine` и `LLMReviewStorage` для JSON-кэша в `data/llm_reviews/`.
- `LLMReview` содержит все требуемые поля (summary, direction, confidence, agreement_score, entry, stop_loss, take_profit, targets, reasoning, risks, opportunities, contradictions, institutional_view, news_impact, market_bias, recommended_action, created_at, provider, tokens_used, latency_ms) и нормализует проценты в диапазон 0–100.
- `OpenAIReviewProvider` читает `OPENAI_API_KEY`, `FXPILOT_OPENAI_MODEL` и `FXPILOT_LLM_TIMEOUT`, запрашивает структурированный JSON и возвращает `LLMReview`; добавлен безопасный `ContextOnlyReviewProvider` как fallback при отсутствии ключа.
- Интеграция в backend: функции `create_llm_review_provider()` / `create_llm_review_engine()` и endpoint `GET /api/media/llm-review/{video_id}` добавлены, а существующий `GET /api/media/review/{video_id}` расширен полем `llm_review` для обратной совместимости.
- Frontend: секция `AI Expert Verdict` добавлена в `app/static/tv-review.js`, отображающая сводку, agreement, recommended action, reasoning, risks, contradictions, institutional view, news impact, market bias и confidence.
- Документация: обновлён `README.md` с описанием архитектуры Stage 3 и окружения для LLM-провайдеров; добавлены тесты в `tests/test_llm_review.py`.

### Testing
- Скомпилированы файлы Python командой `python3 -m py_compile app/main.py app/services/llm_review/*.py` и проверка прошла успешно.
- Запущены автоматические тесты командой `pytest -q tests/test_llm_review.py tests/test_knowledge_layer.py` и все тесты прошли успешно (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ea36055048331b0b1b8ced76ffc7a)