### PR TITLE
Stage 8: добавить AI Consensus Engine — `/api/consensus` и страница `/consensus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,3 +549,8 @@ Admin endpoints:
 - Локальный кеш хранится в `data/transcripts/{video_id}.json` с `video_id`, `created_at`, `provider`, `language`, `segments`, `full_text`, `duration`; повторный запрос читает файл и не обращается к YouTube повторно.
 - `/api/media/debug` дополнительно показывает `transcripts_cached`, `transcript_requests`, `transcript_errors`, `provider_used`.
 - Страница `/tv/review/{video_id}` показывает секцию Transcript: первые абзацы при `FOUND`, `Transcript unavailable` при недоступности и `Whisper processing required`, если нужен будущий Whisper-процессинг.
+
+
+## FXPilot TV Stage 8 — AI Consensus Engine
+
+Stage 8 adds `/api/consensus/{symbol}` and `/api/consensus/{symbol}/{timeframe}` plus the `/consensus` page. The consensus engine aggregates all imported Media Catalog videos for the requested market, reusing Transcript Engine, Rule Analyzer, Knowledge Layer, LLM Review, and Investment Committee contracts through existing service builders. It returns bullish/bearish/neutral distribution, average confidence, average committee score, author leaderboard, detected conflicts, and a provider-independent consensus report. Historical author accuracy is intentionally exposed as a placeholder until verified performance data is available.

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,7 @@ from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge import KnowledgeEngine
 from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewProvider, ReviewEngine
 from app.services.investment_committee import InvestmentCommitteeEngine
+from app.services.consensus import ConsensusEngine
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -958,6 +959,27 @@ def api_media_committee(video_id: str) -> dict[str, Any]:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+def create_consensus_engine() -> ConsensusEngine:
+    return ConsensusEngine(
+        media_catalog_loader=_load_tv_video_catalog,
+        review_payload_builder=_build_tv_review_payload,
+        committee_builder=lambda video_id: InvestmentCommitteeEngine(
+            media_catalog_loader=_load_tv_video_catalog,
+            review_payload_builder=_build_tv_review_payload,
+        ).build_for_video(video_id).model_dump(),
+    )
+
+
+@app.get("/api/consensus/{symbol}")
+def api_consensus_symbol(symbol: str, timeframe: str | None = None, date_from: str | None = None, date_to: str | None = None) -> dict[str, Any]:
+    return create_consensus_engine().build(symbol, timeframe, date_from=date_from, date_to=date_to)
+
+
+@app.get("/api/consensus/{symbol}/{timeframe}")
+def api_consensus_symbol_timeframe(symbol: str, timeframe: str, date_from: str | None = None, date_to: str | None = None) -> dict[str, Any]:
+    return create_consensus_engine().build(symbol, timeframe, date_from=date_from, date_to=date_to)
+
+
 @app.get("/api/media/review/{video_id}")
 def api_media_review(video_id: str) -> dict[str, Any]:
     return _get_media_review(video_id)
@@ -966,6 +988,11 @@ def api_media_review(video_id: str) -> dict[str, Any]:
 @app.get("/api/tv/review/{video_id}")
 def api_tv_review(video_id: str) -> dict[str, Any]:
     return _get_media_review(video_id)
+
+
+@app.get("/consensus", include_in_schema=False)
+def consensus_page():
+    return FileResponse(STATIC_DIR / "consensus.html")
 
 
 @app.get("/committee", include_in_schema=False)

--- a/app/services/consensus/__init__.py
+++ b/app/services/consensus/__init__.py
@@ -1,0 +1,3 @@
+from app.services.consensus.engine import ConsensusEngine
+
+__all__ = ["ConsensusEngine"]

--- a/app/services/consensus/engine.py
+++ b/app/services/consensus/engine.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+_DIRECTION_MAP = {"BUY": "BUY", "BULLISH": "BUY", "LONG": "BUY", "SELL": "SELL", "BEARISH": "SELL", "SHORT": "SELL", "WAIT": "WAIT", "HOLD": "WAIT", "NEUTRAL": "WAIT", "IGNORE": "WAIT"}
+
+
+def _norm_symbol(value: Any) -> str:
+    return str(value or "").replace("/", "").replace(" ", "").upper()
+
+
+def _norm_timeframe(value: Any) -> str:
+    return str(value or "").strip().upper()
+
+
+def _direction(value: Any) -> str:
+    text = str(value or "").strip().upper()
+    if text in _DIRECTION_MAP:
+        return _DIRECTION_MAP[text]
+    if "BUY" in text or "BULL" in text or "LONG" in text:
+        return "BUY"
+    if "SELL" in text or "BEAR" in text or "SHORT" in text:
+        return "SELL"
+    return "WAIT"
+
+
+def _percent(part: int, total: int) -> int:
+    return round((part / total) * 100) if total else 0
+
+
+def _number(value: Any) -> float | None:
+    try:
+        if value in (None, "", "Unknown"):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _date(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        raw = str(value).replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(raw)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+class ConsensusEngine:
+    """Aggregates all imported media opinions for one symbol/timeframe without replacing existing APIs."""
+
+    def __init__(
+        self,
+        *,
+        media_catalog_loader: Callable[[], list[dict[str, Any]]],
+        review_payload_builder: Callable[[dict[str, Any]], dict[str, Any]],
+        committee_builder: Callable[[str], dict[str, Any]],
+    ) -> None:
+        self.media_catalog_loader = media_catalog_loader
+        self.review_payload_builder = review_payload_builder
+        self.committee_builder = committee_builder
+
+    def build(self, symbol: str, timeframe: str | None = None, *, date_from: str | None = None, date_to: str | None = None) -> dict[str, Any]:
+        wanted_symbol = _norm_symbol(symbol)
+        wanted_timeframe = _norm_timeframe(timeframe)
+        start = _date(date_from)
+        end = _date(date_to)
+        videos = [v for v in self.media_catalog_loader() if _norm_symbol(v.get("symbol")) == wanted_symbol]
+        if wanted_timeframe:
+            videos = [v for v in videos if _norm_timeframe(v.get("timeframe")) == wanted_timeframe]
+        if start or end:
+            filtered = []
+            for video in videos:
+                published = _date(video.get("published_at"))
+                if start and published and published < start:
+                    continue
+                if end and published and published > end:
+                    continue
+                filtered.append(video)
+            videos = filtered
+
+        opinions = [self._opinion(video) for video in videos]
+        counts = Counter(item["direction"] for item in opinions)
+        total = len(opinions)
+        agreement_count = max((counts.get("BUY", 0), counts.get("SELL", 0), counts.get("WAIT", 0)), default=0)
+        overall = "WAIT"
+        if total and agreement_count:
+            winners = [d for d in ("BUY", "SELL", "WAIT") if counts.get(d, 0) == agreement_count]
+            overall = winners[0] if len(winners) == 1 else "WAIT"
+        avg_conf = round(sum(item["confidence"] for item in opinions) / total) if total else 0
+        avg_committee = round(sum(item["committee_score"] for item in opinions) / total) if total else 0
+        agreement = _percent(agreement_count, total)
+        return {
+            "symbol": wanted_symbol,
+            "timeframe": wanted_timeframe or "ALL",
+            "date_window": {"from": date_from, "to": date_to},
+            "overall_direction": overall,
+            "consensus_strength": self._strength(agreement),
+            "agreement_percent": agreement,
+            "average_confidence": avg_conf,
+            "average_committee_score": avg_committee,
+            "bullish_count": counts.get("BUY", 0),
+            "bearish_count": counts.get("SELL", 0),
+            "neutral_count": counts.get("WAIT", 0),
+            "bullish_percent": _percent(counts.get("BUY", 0), total),
+            "bearish_percent": _percent(counts.get("SELL", 0), total),
+            "neutral_percent": _percent(counts.get("WAIT", 0), total),
+            "opinions": opinions,
+            "top_authors": self._leaderboard(opinions),
+            "disagreements": self._disagreements(counts),
+            "market_summary": self._summary(wanted_symbol, wanted_timeframe or "все TF", overall, agreement, counts),
+        }
+
+    def _opinion(self, video: dict[str, Any]) -> dict[str, Any]:
+        payload = self.review_payload_builder(video)
+        analysis = payload.get("analysis") or payload.get("ai_review") or {}
+        knowledge = payload.get("knowledge") or payload.get("knowledge_context") or {}
+        committee = self.committee_builder(str(video.get("id") or ""))
+        direction = _direction(committee.get("decision") or analysis.get("direction") or knowledge.get("direction"))
+        targets = analysis.get("targets") or ([analysis.get("tp")] if analysis.get("tp") is not None else [])
+        return {
+            "video_id": video.get("id"),
+            "title": video.get("title"),
+            "author": video.get("author") or video.get("source_id") or "Unknown",
+            "published_at": video.get("published_at"),
+            "timeframe": video.get("timeframe"),
+            "direction": direction,
+            "confidence": int(_number(analysis.get("confidence") or committee.get("overall_score")) or 0),
+            "entry": _number(analysis.get("entry")),
+            "stop": _number(analysis.get("sl") or analysis.get("stop_loss")),
+            "targets": [_number(item) for item in targets if _number(item) is not None],
+            "committee_score": int(_number(committee.get("overall_score")) or 0),
+            "committee_verdict": committee.get("committee_verdict") or "WATCH",
+            "agreement_score": int(_number(committee.get("agreement_score") or knowledge.get("agreement_score")) or 0),
+        }
+
+    def _leaderboard(self, opinions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for item in opinions:
+            grouped[item["author"]].append(item)
+        rows = []
+        for author, items in grouped.items():
+            latest = sorted(items, key=lambda x: str(x.get("published_at") or ""), reverse=True)[0]
+            rows.append({"author": author, "historical_accuracy": None, "historical_accuracy_label": "placeholder", "current_confidence": round(sum(i["confidence"] for i in items) / len(items)), "committee_score": round(sum(i["committee_score"] for i in items) / len(items)), "latest_opinion": latest["direction"]})
+        return sorted(rows, key=lambda x: (x["committee_score"], x["current_confidence"]), reverse=True)
+
+    def _disagreements(self, counts: Counter) -> list[str]:
+        parts = [f"{counts.get('BUY',0)} authors BUY", f"{counts.get('SELL',0)} authors SELL", f"{counts.get('WAIT',0)} WAIT"]
+        active = sum(1 for key in ("BUY", "SELL", "WAIT") if counts.get(key, 0))
+        return [", ".join(parts)] if active > 1 else []
+
+    def _strength(self, agreement: int) -> str:
+        if agreement >= 75: return "STRONG"
+        if agreement >= 55: return "MODERATE"
+        if agreement > 0: return "WEAK"
+        return "NO_DATA"
+
+    def _summary(self, symbol: str, timeframe: str, overall: str, agreement: int, counts: Counter) -> str:
+        if not sum(counts.values()):
+            return f"Для {symbol} {timeframe} пока нет импортированных видео с анализом."
+        return f"Consensus по {symbol} {timeframe}: {overall}, согласие {agreement}%; BUY {counts.get('BUY',0)}, SELL {counts.get('SELL',0)}, WAIT {counts.get('WAIT',0)}."

--- a/app/static/consensus.html
+++ b/app/static/consensus.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AI Consensus Engine — FXPilot TV</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <main class="page-shell consensus-shell">
+    <nav class="top-nav"><a href="/">Главная</a><a href="/tv">🎥 FXPilot TV</a><a href="/committee">Committee</a><a href="/consensus">AI Consensus</a><a href="/analytics">Аналитика</a></nav>
+    <section class="hero panel">
+      <p class="eyebrow">Stage 8 · AI Consensus Engine</p>
+      <h1>Консенсус аналитиков по импортированным видео</h1>
+      <p class="lead">Агрегация всех мнений по символу и таймфрейму с учётом Rule Analyzer, Knowledge Layer, LLM Review и Investment Committee.</p>
+      <form id="consensusForm" class="consensus-form">
+        <label>Символ <input id="symbolInput" value="EURUSD" /></label>
+        <label>Таймфрейм <input id="timeframeInput" value="H4" /></label>
+        <button type="submit">Обновить</button>
+      </form>
+    </section>
+    <section id="consensusRoot" class="consensus-grid"><article class="panel">Загрузка...</article></section>
+  </main>
+  <script src="/static/nav.js"></script>
+  <script src="/static/consensus.js"></script>
+</body>
+</html>

--- a/app/static/consensus.js
+++ b/app/static/consensus.js
@@ -1,0 +1,29 @@
+const root = document.getElementById('consensusRoot');
+const form = document.getElementById('consensusForm');
+const symbolInput = document.getElementById('symbolInput');
+const timeframeInput = document.getElementById('timeframeInput');
+const fmt = (v) => (v === null || v === undefined || v === '' ? '—' : v);
+function card(title, value, extra = '') { return `<article class="panel consensus-card"><p class="eyebrow">${title}</p><h2>${value}</h2>${extra}</article>`; }
+function render(data) {
+  const authors = (data.top_authors || []).map((a) => `<tr><td>${a.author}</td><td>${a.historical_accuracy_label || 'placeholder'}</td><td>${a.current_confidence}%</td><td>${a.committee_score}</td><td>${a.latest_opinion}</td></tr>`).join('');
+  const conflicts = (data.disagreements || []).map((x) => `<li>${x}</li>`).join('') || '<li>Явных конфликтов нет</li>';
+  root.innerHTML = `
+    ${card('Overall Consensus', data.overall_direction, `<p>Сила: ${data.consensus_strength}</p>`)}
+    ${card('Agreement %', `${data.agreement_percent}%`)}
+    ${card('Bullish %', `${data.bullish_percent}%`, `<p>${data.bullish_count} мнений</p>`)}
+    ${card('Bearish %', `${data.bearish_percent}%`, `<p>${data.bearish_count} мнений</p>`)}
+    ${card('Neutral %', `${data.neutral_percent}%`, `<p>${data.neutral_count} мнений</p>`)}
+    ${card('Committee Average', fmt(data.average_committee_score), `<p>Средняя уверенность: ${data.average_confidence}%</p>`)}
+    <article class="panel consensus-wide"><h2>Top Analysts</h2><table><thead><tr><th>Автор</th><th>Historical accuracy</th><th>Confidence</th><th>Committee</th><th>Latest</th></tr></thead><tbody>${authors || '<tr><td colspan="5">Нет данных</td></tr>'}</tbody></table></article>
+    <article class="panel consensus-wide"><h2>Conflicts</h2><ul>${conflicts}</ul><p>${data.market_summary}</p></article>`;
+}
+async function load() {
+  root.innerHTML = '<article class="panel">Загрузка...</article>';
+  const symbol = encodeURIComponent(symbolInput.value.trim() || 'EURUSD');
+  const tf = timeframeInput.value.trim();
+  const url = tf ? `/api/consensus/${symbol}/${encodeURIComponent(tf)}` : `/api/consensus/${symbol}`;
+  const res = await fetch(url);
+  render(await res.json());
+}
+form.addEventListener('submit', (e) => { e.preventDefault(); load(); });
+load().catch(() => { root.innerHTML = '<article class="panel">Consensus временно недоступен.</article>'; });

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -29,6 +29,13 @@
     nav.appendChild(committeeLink);
   }
 
+  if (!nav.querySelector('a[href="/consensus"]')) {
+    const consensusLink = document.createElement('a');
+    consensusLink.href = '/consensus';
+    consensusLink.textContent = '🤝 Consensus';
+    nav.appendChild(consensusLink);
+  }
+
   if (!nav.querySelector('a[href="/tv"]')) {
     const tvLink = document.createElement('a');
     tvLink.href = '/tv';

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3592,3 +3592,29 @@ body[data-page="tv-sources"] {
   font-size: 0.86rem;
 }
 .committee-shell .committee-picker{display:grid;gap:8px;max-width:560px;margin-top:18px;color:#90a4c3}.committee-picker select{border:1px solid rgba(104,143,191,.24);background:rgba(8,18,30,.92);color:#e8eef8;border-radius:14px;padding:12px}.committee-score-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:14px;grid-column:1/-1}.committee-card{padding:18px;border-radius:22px;background:linear-gradient(145deg,rgba(8,18,30,.94),rgba(13,29,48,.82));border:1px solid rgba(104,143,191,.2);box-shadow:0 18px 50px rgba(0,0,0,.22);animation:committeePulse .7s ease both}.committee-card span{display:block;color:#90a4c3;text-transform:uppercase;font-size:.76rem;letter-spacing:.08em}.committee-card strong{display:block;margin-top:8px;font-size:1.75rem;color:#e8eef8}.committee-card.buy,.committee-card.bullish,.committee-card.accept,.committee-card.low{border-color:rgba(34,197,94,.42)}.committee-card.sell,.committee-card.bearish,.committee-card.reject,.committee-card.high{border-color:rgba(239,68,68,.42)}.committee-card.wait,.committee-card.neutral,.committee-card.watch,.committee-card.medium{border-color:rgba(251,191,36,.42)}.committee-list{display:grid;gap:10px;margin:0;padding-left:20px}.committee-list li{padding:10px 12px;border-radius:14px;background:rgba(76,201,240,.07);border:1px solid rgba(76,201,240,.12)}.committee-hero-card{grid-column:1/-1}@keyframes committeePulse{from{opacity:0;transform:translateY(10px) scale(.98)}to{opacity:1;transform:none}}
+
+.consensus-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 18px;
+  align-items: end;
+}
+.consensus-form label { color: var(--muted); display: grid; gap: 6px; }
+.consensus-form input, .consensus-form button {
+  border: 1px solid rgba(76, 201, 240, 0.22);
+  border-radius: 14px;
+  padding: 12px 14px;
+  color: var(--text);
+  background: rgba(8, 18, 34, 0.9);
+}
+.consensus-form button { cursor: pointer; color: #06111f; background: linear-gradient(135deg, var(--accent), #9bf6ff); font-weight: 800; }
+.consensus-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; margin-top: 18px; }
+.consensus-card { animation: signalPulse 0.7s ease both; }
+.consensus-card h2 { font-size: clamp(1.8rem, 4vw, 3rem); }
+.consensus-wide { grid-column: 1 / -1; overflow-x: auto; }
+.consensus-wide table { width: 100%; border-collapse: collapse; }
+.consensus-wide th, .consensus-wide td { padding: 12px; border-bottom: 1px solid var(--line); text-align: left; color: var(--muted); }
+.consensus-wide th { color: var(--text); }
+@media (max-width: 860px) { .consensus-grid { grid-template-columns: 1fr; } }
+@keyframes signalPulse { from { opacity: 0; transform: translateY(12px) scale(0.98); } to { opacity: 1; transform: none; } }

--- a/tests/test_consensus_api.py
+++ b/tests/test_consensus_api.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from app import main
+
+
+def test_consensus_api_keeps_existing_routes_and_returns_contract(monkeypatch):
+    videos = [{"id": "v1", "author": "Desk", "symbol": "EURUSD", "timeframe": "H4", "published_at": "2026-07-01"}]
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: videos)
+    monkeypatch.setattr(main, "_build_tv_review_payload", lambda video: {"analysis": {"direction": "BUY", "confidence": 75}, "knowledge": {"agreement_score": 65}})
+
+    class Committee:
+        def __init__(self, **kwargs): pass
+        def build_for_video(self, video_id):
+            class Report:
+                def model_dump(self):
+                    return {"decision": "BUY", "overall_score": 82, "agreement_score": 72, "committee_verdict": "ACCEPT"}
+            return Report()
+
+    monkeypatch.setattr(main, "InvestmentCommitteeEngine", Committee)
+    client = TestClient(main.app)
+
+    response = client.get("/api/consensus/EURUSD/H4")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["overall_direction"] == "BUY"
+    assert payload["agreement_percent"] == 100
+    assert payload["top_authors"][0]["author"] == "Desk"
+    assert client.get("/api/media").status_code == 200

--- a/tests/test_consensus_engine.py
+++ b/tests/test_consensus_engine.py
@@ -1,0 +1,29 @@
+from app.services.consensus import ConsensusEngine
+
+
+def test_consensus_engine_aggregates_symbol_timeframe():
+    videos = [
+        {"id": "v1", "author": "A", "symbol": "EURUSD", "timeframe": "H4", "published_at": "2026-07-01"},
+        {"id": "v2", "author": "B", "symbol": "EUR/USD", "timeframe": "H4", "published_at": "2026-07-02"},
+        {"id": "v3", "author": "C", "symbol": "EURUSD", "timeframe": "H1", "published_at": "2026-07-02"},
+    ]
+    reviews = {
+        "v1": {"analysis": {"direction": "BUY", "confidence": 80, "entry": 1.1, "sl": 1.09, "targets": [1.12]}, "knowledge": {"agreement_score": 70}},
+        "v2": {"analysis": {"direction": "SELL", "confidence": 60}, "knowledge": {"agreement_score": 40}},
+    }
+    committees = {
+        "v1": {"decision": "BUY", "overall_score": 90, "agreement_score": 80, "committee_verdict": "ACCEPT"},
+        "v2": {"decision": "SELL", "overall_score": 50, "agreement_score": 40, "committee_verdict": "WATCH"},
+    }
+    engine = ConsensusEngine(media_catalog_loader=lambda: videos, review_payload_builder=lambda v: reviews[v["id"]], committee_builder=lambda video_id: committees[video_id])
+
+    report = engine.build("EURUSD", "H4")
+
+    assert report["bullish_count"] == 1
+    assert report["bearish_count"] == 1
+    assert report["neutral_count"] == 0
+    assert report["overall_direction"] == "WAIT"
+    assert report["average_confidence"] == 70
+    assert report["average_committee_score"] == 70
+    assert report["disagreements"] == ["1 authors BUY, 1 authors SELL, 0 WAIT"]
+    assert report["top_authors"][0]["author"] == "A"


### PR DESCRIPTION
### Motivation
- Объединить мнения всех импортированных видео по одному символу/таймфрейму, не изменяя существующие API и повторно используя уже имеющиеся сервисы (Media Catalog, Transcript Engine, Rule Analyzer, Knowledge Layer, LLM Review, Investment Committee). 
- Предоставить фронтенду и API единый provider‑independent отчёт о консенсусе с метриками согласия, средней уверенности и лидером авторов для принятия решений на уровне сцены Stage 8.

### Description
- Добавлен пакет `app/services/consensus` с `ConsensusEngine`, который собирает все видео из каталога, строит opinion для каждого видео (author, published_at, direction, confidence, entry, stop, targets, committee score/verdict, agreement score) и агрегирует статистику (bullish/bearish/neutral %, average confidence, average committee score, author leaderboard, disagreements, summary). 
- Добавлены эндпоинты `GET /api/consensus/{symbol}` и `GET /api/consensus/{symbol}/{timeframe}` и фабрика `create_consensus_engine()` в `app/main.py`, при этом логика переиспользует `_load_tv_video_catalog`, `_build_tv_review_payload` и `InvestmentCommitteeEngine` без дублирования анализа. 
- Добавлена фронтенд-страница `/consensus` с `app/static/consensus.html`, `consensus.js`, стили в `app/static/styles.css` и ссылка в навигации `app/static/nav.js`, а также запись в `README.md` об Stage 8. 
- Добавлены тесты `tests/test_consensus_engine.py` (unit) и `tests/test_consensus_api.py` (integration via `TestClient`) и базовая валидация синтаксиса через `py_compile`.

### Testing
- Запущено `pytest tests/test_consensus_engine.py tests/test_consensus_api.py`, оба теста прошли успешно (`2 passed`).
- Проверена компиляция модулей через `python -m py_compile app/services/consensus/engine.py app/main.py`, ошибок нет.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ebaf4bf808331ac4e425444ddc314)