### PR TITLE
Добавить Author Intelligence Engine (Stage 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Stage 9 — Author Intelligence Engine
+
+- Добавлен пакет `app/services/author_intelligence/` с `AuthorIntelligenceEngine`: он агрегирует Media Catalog, Transcript/Review payload, Knowledge Layer, LLM Review, Investment Committee и Consensus-compatible метрики по каждому YouTube автору.
+- Новые endpoint’ы `GET /api/authors` и `GET /api/authors/{author}` возвращают leaderboard и полный author report с rating, tier, proxy accuracy, win rate placeholder, activity, consistency, institutional score, favorite symbols/timeframes и latest opinion.
+- Добавлена страница `/authors` с тёмным responsive leaderboard UI и сортировками Highest Accuracy, Highest Rating, Most Active и Best Institutional Score. Accuracy явно помечена как proxy metric до подключения реальных market outcomes.
+
 
 ## FXPilot TV Stage 7: Institutional Investment Committee
 

--- a/app/main.py
+++ b/app/main.py
@@ -49,6 +49,7 @@ from app.services.knowledge import KnowledgeEngine
 from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewProvider, ReviewEngine
 from app.services.investment_committee import InvestmentCommitteeEngine
 from app.services.consensus import ConsensusEngine
+from app.services.author_intelligence import AuthorIntelligenceEngine
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -970,6 +971,43 @@ def create_consensus_engine() -> ConsensusEngine:
     )
 
 
+def create_author_intelligence_engine() -> AuthorIntelligenceEngine:
+    return AuthorIntelligenceEngine(
+        media_catalog_loader=_load_tv_video_catalog,
+        review_payload_builder=_build_tv_review_payload,
+        committee_builder=lambda video_id: InvestmentCommitteeEngine(
+            media_catalog_loader=_load_tv_video_catalog,
+            review_payload_builder=_build_tv_review_payload,
+        ).build_for_video(video_id).model_dump(),
+    )
+
+
+@app.get("/api/authors")
+def api_authors(sort: str = "rating") -> list[dict[str, Any]]:
+    authors = create_author_intelligence_engine().build_all()
+    sort_key = sort.strip().lower().replace("-", "_")
+    keys = {
+        "accuracy": "accuracy",
+        "highest_accuracy": "accuracy",
+        "rating": "rating",
+        "highest_rating": "rating",
+        "active": "activity_score",
+        "most_active": "activity_score",
+        "institutional": "institutional_score",
+        "best_institutional_score": "institutional_score",
+    }
+    key = keys.get(sort_key, "rating")
+    return sorted(authors, key=lambda row: row.get(key) or 0, reverse=True)
+
+
+@app.get("/api/authors/{author}")
+def api_author_report(author: str) -> dict[str, Any]:
+    try:
+        return create_author_intelligence_engine().build_for_author(author)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @app.get("/api/consensus/{symbol}")
 def api_consensus_symbol(symbol: str, timeframe: str | None = None, date_from: str | None = None, date_to: str | None = None) -> dict[str, Any]:
     return create_consensus_engine().build(symbol, timeframe, date_from=date_from, date_to=date_to)
@@ -993,6 +1031,11 @@ def api_tv_review(video_id: str) -> dict[str, Any]:
 @app.get("/consensus", include_in_schema=False)
 def consensus_page():
     return FileResponse(STATIC_DIR / "consensus.html")
+
+
+@app.get("/authors", include_in_schema=False)
+def authors_page():
+    return FileResponse(STATIC_DIR / "authors.html")
 
 
 @app.get("/committee", include_in_schema=False)

--- a/app/services/author_intelligence/__init__.py
+++ b/app/services/author_intelligence/__init__.py
@@ -1,0 +1,3 @@
+from app.services.author_intelligence.engine import AuthorIntelligenceEngine
+
+__all__ = ["AuthorIntelligenceEngine"]

--- a/app/services/author_intelligence/engine.py
+++ b/app/services/author_intelligence/engine.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+_DIRECTION_MAP = {"BUY": "BUY", "BULLISH": "BUY", "LONG": "BUY", "SELL": "SELL", "BEARISH": "SELL", "SHORT": "SELL", "WAIT": "WAIT", "HOLD": "WAIT", "NEUTRAL": "WAIT", "IGNORE": "WAIT"}
+
+
+def _direction(value: Any) -> str:
+    text = str(value or "").strip().upper()
+    if text in _DIRECTION_MAP:
+        return _DIRECTION_MAP[text]
+    if "BUY" in text or "BULL" in text or "LONG" in text:
+        return "BUY"
+    if "SELL" in text or "BEAR" in text or "SHORT" in text:
+        return "SELL"
+    return "WAIT"
+
+
+def _number(value: Any) -> float | None:
+    try:
+        if value in (None, "", "Unknown"):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _avg(values: list[float]) -> int:
+    return round(sum(values) / len(values)) if values else 0
+
+
+def _date(value: Any) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value or "").replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+class AuthorIntelligenceEngine:
+    """Evaluates YouTube authors using the existing TV intelligence layers.
+
+    Real market-outcome performance is intentionally isolated in ``outcome_provider`` for
+    future stages. Until such data exists, success/failure/accuracy fields are explicit
+    proxy metrics derived from committee verdicts, agreement and consistency rather than
+    fabricated market outcomes.
+    """
+
+    def __init__(
+        self,
+        *,
+        media_catalog_loader: Callable[[], list[dict[str, Any]]],
+        review_payload_builder: Callable[[dict[str, Any]], dict[str, Any]],
+        committee_builder: Callable[[str], dict[str, Any]],
+        outcome_provider: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
+    ) -> None:
+        self.media_catalog_loader = media_catalog_loader
+        self.review_payload_builder = review_payload_builder
+        self.committee_builder = committee_builder
+        self.outcome_provider = outcome_provider
+
+    def build_all(self) -> list[dict[str, Any]]:
+        reports = [self._build_author(author, videos) for author, videos in self._group_videos().items()]
+        return sorted(reports, key=lambda row: (row["rating"], row["accuracy"], row["activity_score"]), reverse=True)
+
+    def build_for_author(self, author: str) -> dict[str, Any]:
+        wanted = author.strip().lower()
+        for name, videos in self._group_videos().items():
+            if name.lower() == wanted:
+                return self._build_author(name, videos, include_opinions=True)
+        raise ValueError("Author not found")
+
+    def _group_videos(self) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for video in self.media_catalog_loader():
+            author = str(video.get("author") or video.get("channel") or video.get("source_id") or "Unknown").strip() or "Unknown"
+            grouped[author].append(video)
+        return dict(grouped)
+
+    def _opinion(self, video: dict[str, Any]) -> dict[str, Any]:
+        payload = self.review_payload_builder(video)
+        analysis = payload.get("analysis") or payload.get("ai_review") or {}
+        knowledge = payload.get("knowledge") or payload.get("knowledge_context") or {}
+        llm = payload.get("llm_review") or {}
+        committee = self.committee_builder(str(video.get("id") or ""))
+        direction = _direction(committee.get("decision") or analysis.get("direction") or knowledge.get("direction") or llm.get("direction"))
+        confidence = int(_number(analysis.get("confidence") or llm.get("confidence") or knowledge.get("confidence") or committee.get("overall_score")) or 0)
+        risk_text = str(committee.get("risk_level") or "MEDIUM").upper()
+        risk_score = 80 if risk_text == "HIGH" else 50 if risk_text == "MEDIUM" else 25
+        outcome = self.outcome_provider(video) if self.outcome_provider else None
+        return {
+            "video_id": video.get("id"),
+            "title": video.get("title"),
+            "author": video.get("author") or video.get("channel") or video.get("source_id") or "Unknown",
+            "channel_id": video.get("channel_id") or video.get("source_id"),
+            "published_at": video.get("published_at"),
+            "symbol": knowledge.get("symbol") or analysis.get("symbol") or video.get("symbol"),
+            "timeframe": video.get("timeframe") or knowledge.get("timeframe") or analysis.get("timeframe"),
+            "direction": direction,
+            "confidence": max(0, min(100, confidence)),
+            "committee_score": int(_number(committee.get("overall_score")) or 0),
+            "agreement_score": int(_number(committee.get("agreement_score") or knowledge.get("agreement_score") or llm.get("agreement_score")) or 0),
+            "risk_score": risk_score,
+            "institutional_bias": committee.get("institutional_bias") or "NEUTRAL",
+            "committee_verdict": committee.get("committee_verdict") or "WATCH",
+            "outcome": outcome,
+        }
+
+    def _build_author(self, author: str, videos: list[dict[str, Any]], *, include_opinions: bool = False) -> dict[str, Any]:
+        opinions = [self._opinion(video) for video in videos]
+        total = len(opinions)
+        directions = Counter(item["direction"] for item in opinions)
+        outcomes = [item.get("outcome") for item in opinions if item.get("outcome")]
+        successful = sum(1 for item in outcomes if item.get("status") == "success")
+        failed = sum(1 for item in outcomes if item.get("status") == "failed")
+        neutral = total - successful - failed
+        avg_conf = _avg([item["confidence"] for item in opinions])
+        avg_committee = _avg([item["committee_score"] for item in opinions])
+        avg_agreement = _avg([item["agreement_score"] for item in opinions])
+        avg_risk = _avg([item["risk_score"] for item in opinions])
+        signal_count = sum(1 for item in opinions if item["direction"] in {"BUY", "SELL"})
+        dominant = max(directions.values(), default=0)
+        consistency = round((dominant / total) * 100) if total else 0
+        activity = min(100, total * 12 + signal_count * 5)
+        institutional = _avg([item["committee_score"] * 0.6 + item["agreement_score"] * 0.4 for item in opinions])
+        proxy_accuracy = _avg([item["committee_score"] * 0.55 + item["agreement_score"] * 0.30 + item["confidence"] * 0.15 for item in opinions])
+        win_rate = round((successful / (successful + failed)) * 100) if successful + failed else None
+        rating = _avg([proxy_accuracy * 0.35, institutional * 0.25, consistency * 0.20, activity * 0.20])
+        latest = sorted(opinions, key=lambda x: _date(x.get("published_at")), reverse=True)[0] if opinions else {}
+        favorite_symbols = Counter(str(item.get("symbol") or "Unknown") for item in opinions if item.get("symbol")).most_common(5)
+        favorite_timeframes = Counter(str(item.get("timeframe") or "Unknown") for item in opinions if item.get("timeframe")).most_common(5)
+        strengths, weaknesses = self._strengths(avg_conf, avg_committee, avg_agreement, consistency, activity)
+        row = {
+            "author": author,
+            "channel_id": next((item.get("channel_id") for item in opinions if item.get("channel_id")), None),
+            "videos": total,
+            "signals": signal_count,
+            "successful_signals": successful,
+            "failed_signals": failed,
+            "neutral_signals": neutral,
+            "accuracy": proxy_accuracy,
+            "accuracy_label": "proxy_committee_accuracy_until_real_market_outcomes_available",
+            "win_rate": win_rate,
+            "average_confidence": avg_conf,
+            "average_committee_score": avg_committee,
+            "average_agreement": avg_agreement,
+            "signal_frequency": round((signal_count / total) * 100) if total else 0,
+            "bullish_count": directions.get("BUY", 0),
+            "bearish_count": directions.get("SELL", 0),
+            "neutral_count": directions.get("WAIT", 0),
+            "average_risk": avg_risk,
+            "institutional_score": institutional,
+            "consistency_score": consistency,
+            "activity_score": activity,
+            "rating": rating,
+            "tier": self._tier(rating),
+            "latest_opinion": latest.get("direction", "WAIT"),
+            "latest_video": latest,
+            "report": {
+                "summary": f"{author}: рейтинг {rating}/100, tier {self._tier(rating)}, proxy accuracy {proxy_accuracy}% на базе {total} видео. Реальные market outcomes будут подключены отдельным outcome_provider.",
+                "strengths": strengths,
+                "weaknesses": weaknesses,
+                "favorite_markets": [symbol for symbol, _ in favorite_symbols],
+                "favorite_symbols": [symbol for symbol, _ in favorite_symbols],
+                "favorite_timeframes": [tf for tf, _ in favorite_timeframes],
+                "bullish_bias": round((directions.get("BUY", 0) / total) * 100) if total else 0,
+                "bearish_bias": round((directions.get("SELL", 0) / total) * 100) if total else 0,
+                "risk_profile": "HIGH" if avg_risk >= 66 else "MEDIUM" if avg_risk >= 40 else "LOW",
+            },
+        }
+        if include_opinions:
+            row["opinions"] = opinions
+        return row
+
+    def _strengths(self, confidence: int, committee: int, agreement: int, consistency: int, activity: int) -> tuple[list[str], list[str]]:
+        strengths = []
+        weaknesses = []
+        for label, value in (("Высокая уверенность", confidence), ("Сильный Committee Score", committee), ("Хорошее согласие слоёв", agreement), ("Последовательный bias", consistency), ("Высокая активность", activity)):
+            (strengths if value >= 70 else weaknesses if value < 45 else []).append(label)
+        return strengths or ["Стабильная база наблюдений"], weaknesses or ["Критичных слабых зон не выявлено"]
+
+    def _tier(self, rating: int) -> str:
+        if rating >= 85:
+            return "Elite"
+        if rating >= 72:
+            return "Professional"
+        if rating >= 60:
+            return "Advanced"
+        if rating >= 45:
+            return "Average"
+        return "Watchlist"

--- a/app/static/authors.html
+++ b/app/static/authors.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Author Intelligence — FXPilot TV</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <main class="page-shell authors-shell">
+    <nav class="top-nav"><a href="/">Главная</a><a href="/tv">🎥 FXPilot TV</a><a href="/committee">Committee</a><a href="/consensus">AI Consensus</a><a href="/authors">Авторы</a><a href="/analytics">Аналитика</a></nav>
+    <section class="hero panel">
+      <p class="eyebrow">Stage 9 · Author Intelligence Engine</p>
+      <h1>Рейтинг YouTube авторов</h1>
+      <p class="lead">Leaderboard оценивает авторов через Consensus, Committee, LLM Review, Knowledge Layer, Transcript и Media Catalog. Accuracy сейчас является proxy-метрикой до подключения реальных market outcomes.</p>
+      <label class="authors-sort">Сортировка
+        <select id="authorsSort">
+          <option value="highest_accuracy">Highest Accuracy</option>
+          <option value="highest_rating" selected>Highest Rating</option>
+          <option value="most_active">Most Active</option>
+          <option value="best_institutional_score">Best Institutional Score</option>
+        </select>
+      </label>
+    </section>
+    <section id="authorsRoot" class="authors-grid"><article class="panel">Загрузка...</article></section>
+  </main>
+  <script src="/static/nav.js"></script>
+  <script src="/static/authors.js"></script>
+</body>
+</html>

--- a/app/static/authors.js
+++ b/app/static/authors.js
@@ -1,0 +1,20 @@
+const root = document.getElementById('authorsRoot');
+const sort = document.getElementById('authorsSort');
+const esc = (v) => String(v ?? '—').replace(/[&<>"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+function row(a) {
+  return `<article class="panel author-card">
+    <div><p class="eyebrow">${esc(a.tier)}</p><h2>${esc(a.author)}</h2><p>${esc(a.report?.summary)}</p></div>
+    <div class="author-metrics">
+      <span><b>${esc(a.rating)}</b>Rating</span><span><b>${esc(a.accuracy)}%</b>Accuracy*</span><span><b>${esc(a.average_committee_score)}</b>Committee</span><span><b>${esc(a.latest_opinion)}</b>Latest</span>
+    </div>
+    <a class="author-link" href="/api/authors/${encodeURIComponent(a.author)}" target="_blank" rel="noopener">Полный JSON отчёт</a>
+  </article>`;
+}
+async function load() {
+  root.innerHTML = '<article class="panel">Загрузка...</article>';
+  const res = await fetch(`/api/authors?sort=${encodeURIComponent(sort.value)}`, { headers: { Accept: 'application/json' }, cache: 'no-store' });
+  const data = await res.json();
+  root.innerHTML = `<article class="panel authors-wide"><h2>Leaderboard</h2><p class="muted">*Accuracy — proxy metric, не реальный market win rate.</p></article>${(Array.isArray(data) && data.length ? data.map(row).join('') : '<article class="panel">Авторы пока не найдены.</article>')}`;
+}
+sort.addEventListener('change', load);
+load().catch(() => { root.innerHTML = '<article class="panel">Author Intelligence временно недоступен.</article>'; });

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -36,6 +36,13 @@
     nav.appendChild(consensusLink);
   }
 
+  if (!nav.querySelector('a[href="/authors"]')) {
+    const authorsLink = document.createElement('a');
+    authorsLink.href = '/authors';
+    authorsLink.textContent = '🧠 Авторы';
+    nav.appendChild(authorsLink);
+  }
+
   if (!nav.querySelector('a[href="/tv"]')) {
     const tvLink = document.createElement('a');
     tvLink.href = '/tv';

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3618,3 +3618,7 @@ body[data-page="tv-sources"] {
 .consensus-wide th { color: var(--text); }
 @media (max-width: 860px) { .consensus-grid { grid-template-columns: 1fr; } }
 @keyframes signalPulse { from { opacity: 0; transform: translateY(12px) scale(0.98); } to { opacity: 1; transform: none; } }
+.authors-sort{display:grid;gap:8px;max-width:360px;margin-top:18px;color:var(--muted)}
+.authors-sort select{border:1px solid rgba(76,201,240,.22);border-radius:14px;padding:12px 14px;color:var(--text);background:rgba(8,18,34,.9)}
+.authors-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px;margin-top:18px}.authors-wide{grid-column:1/-1}.author-card{display:grid;gap:18px;animation:signalPulse .7s ease both;border-color:rgba(76,201,240,.20)}.author-card h2{margin:.2rem 0;color:#eaf6ff}.author-card p{color:var(--muted)}.author-metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}.author-metrics span{border:1px solid rgba(76,201,240,.16);background:rgba(76,201,240,.07);border-radius:16px;padding:12px;color:var(--muted);font-size:.8rem}.author-metrics b{display:block;color:#eaf6ff;font-size:1.35rem}.author-link{justify-self:start;color:#06111f;background:linear-gradient(135deg,var(--accent),#9bf6ff);border-radius:999px;padding:10px 14px;font-weight:800;text-decoration:none}.muted{color:var(--muted)}
+@media(max-width:900px){.authors-grid{grid-template-columns:1fr}.author-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}}

--- a/tests/test_author_intelligence.py
+++ b/tests/test_author_intelligence.py
@@ -1,0 +1,39 @@
+from app.services.author_intelligence import AuthorIntelligenceEngine
+
+
+def test_author_intelligence_aggregates_author_stats():
+    videos = [
+        {"id": "v1", "author": "Alpha", "channel_id": "UC1", "symbol": "EURUSD", "timeframe": "H4", "published_at": "2026-07-01T00:00:00Z"},
+        {"id": "v2", "author": "Alpha", "channel_id": "UC1", "symbol": "GBPUSD", "timeframe": "H1", "published_at": "2026-07-02T00:00:00Z"},
+        {"id": "v3", "author": "Beta", "channel_id": "UC2", "symbol": "XAUUSD", "timeframe": "D1", "published_at": "2026-07-03T00:00:00Z"},
+    ]
+    reviews = {
+        "v1": {"analysis": {"direction": "BUY", "confidence": 80}, "knowledge": {"symbol": "EURUSD", "agreement_score": 70}},
+        "v2": {"analysis": {"direction": "BUY", "confidence": 60}, "knowledge": {"symbol": "GBPUSD", "agreement_score": 50}},
+        "v3": {"analysis": {"direction": "SELL", "confidence": 40}, "knowledge": {"symbol": "XAUUSD", "agreement_score": 40}},
+    }
+    committees = {
+        "v1": {"decision": "BUY", "overall_score": 90, "agreement_score": 80, "risk_level": "LOW", "institutional_bias": "BULLISH", "committee_verdict": "ACCEPT"},
+        "v2": {"decision": "BUY", "overall_score": 70, "agreement_score": 60, "risk_level": "MEDIUM", "institutional_bias": "BULLISH", "committee_verdict": "WATCH"},
+        "v3": {"decision": "SELL", "overall_score": 35, "agreement_score": 35, "risk_level": "HIGH", "institutional_bias": "BEARISH", "committee_verdict": "REJECT"},
+    }
+    engine = AuthorIntelligenceEngine(media_catalog_loader=lambda: videos, review_payload_builder=lambda v: reviews[v["id"]], committee_builder=lambda video_id: committees[video_id])
+    alpha = engine.build_for_author("Alpha")
+    assert alpha["videos"] == 2
+    assert alpha["signals"] == 2
+    assert alpha["bullish_count"] == 2
+    assert alpha["average_confidence"] == 70
+    assert alpha["average_committee_score"] == 80
+    assert alpha["latest_opinion"] == "BUY"
+    assert alpha["accuracy_label"] == "proxy_committee_accuracy_until_real_market_outcomes_available"
+    assert alpha["report"]["favorite_symbols"] == ["EURUSD", "GBPUSD"]
+
+
+def test_author_intelligence_reports_missing_author():
+    engine = AuthorIntelligenceEngine(media_catalog_loader=lambda: [], review_payload_builder=lambda v: {}, committee_builder=lambda video_id: {})
+    try:
+        engine.build_for_author("Nobody")
+    except ValueError as exc:
+        assert "Author not found" in str(exc)
+    else:
+        raise AssertionError("expected missing author")


### PR DESCRIPTION
### Motivation
- Добавить движок оценки YouTube‑авторов, который агрегирует существующие слои (Media Catalog, Transcript, Rule AI, Knowledge Layer, LLM Review, Investment Committee) и готовит структуру для будущего сравнения прогнозов с реальными рыночными исходами. 

### Description
- Добавлен пакет `app/services/author_intelligence/` с `AuthorIntelligenceEngine`, который собирает per‑author статистику и proxy‑метрики (accuracy, rating, tier, consistency, activity, institutional score и др.).
- Добавлены HTTP API `GET /api/authors` и `GET /api/authors/{author}` и helper `create_author_intelligence_engine()` в `app/main.py` для возврата leaderboard и полного author report. 
- Добавлена фронтенд-страница `/authors` (`app/static/authors.html`, `app/static/authors.js`) и стили в `app/static/styles.css`, а также ссылка в навигации `app/static/nav.js`.
- Обновлён `README.md` описанием Stage 9 и добавлены unit‑тесты `tests/test_author_intelligence.py` для проверки агрегации и поведения при отсутствии автора.

### Testing
- Запущены unit‑тесты: `python -m pytest tests/test_author_intelligence.py tests/test_consensus_engine.py tests/test_investment_committee.py`, все тесты прошли (`6 passed`).
- Проверена компиляция модулей через `python -m py_compile app/services/author_intelligence/engine.py app/main.py`, ошибок нет.
- Выполнены базовые статические проверки через `git diff --check` без обнаруженных проблем.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f23450fa08331b3f97849c114f05f)