### PR TITLE
Добавлен Stage 10 — Performance (Truth) Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,3 +560,19 @@ Admin endpoints:
 ## FXPilot TV Stage 8 — AI Consensus Engine
 
 Stage 8 adds `/api/consensus/{symbol}` and `/api/consensus/{symbol}/{timeframe}` plus the `/consensus` page. The consensus engine aggregates all imported Media Catalog videos for the requested market, reusing Transcript Engine, Rule Analyzer, Knowledge Layer, LLM Review, and Investment Committee contracts through existing service builders. It returns bullish/bearish/neutral distribution, average confidence, average committee score, author leaderboard, detected conflicts, and a provider-independent consensus report. Historical author accuracy is intentionally exposed as a placeholder until verified performance data is available.
+
+## FXPilot TV Stage 10 — Performance Engine / Truth Engine
+
+Stage 10 adds a provider-neutral post-analysis engine at `app/services/performance/` for verified YouTube idea outcomes. It reuses Media Catalog, Transcript/Rule/Knowledge/LLM Review, Investment Committee, Consensus and Author Intelligence builders instead of duplicating services.
+
+New endpoints:
+
+- `GET /api/performance` — evaluates imported videos and returns outcomes plus leaderboards.
+- `GET /api/performance/{video_id}` — returns one video outcome.
+- `GET /api/performance/author/{author}` — returns author-level performance summary and evaluated videos.
+
+The engine stores and returns explicit outcome fields: `entry_price`, `stop_loss`, `take_profit`, `entry_time`, `evaluation_start`, `evaluation_end`, `market_high`, `market_low`, `max_profit`, `max_drawdown`, `profit`, `loss`, `rr`, `mfe`, `mae`, `holding_time_hours`, `result`, `status`, provider metadata and Russian warnings. Supported results are `WIN`, `LOSS`, `PARTIAL`, `BREAKEVEN`, `EXPIRED`, and `UNKNOWN`.
+
+Market replay is intentionally provider-neutral: the default adapter uses the existing canonical market service / MT4 bridge path, while the interface can be backed by MT5, Databento, Polygon, TwelveData or future providers. If candles or explicit Entry/SL/TP levels are missing, the engine returns `UNKNOWN` and does not replace real outcomes with proxy metrics.
+
+Frontend page `/performance` shows leaderboard blocks for Best Authors, Worst Authors, Most Accurate and Most Profitable plus per-video Prediction, Reality, Difference, Profit/Loss and Result cards. Completed outcomes call a hook point for refreshing Author Intelligence, Consensus and Institutional Rating without changing existing public APIs.

--- a/app/main.py
+++ b/app/main.py
@@ -50,6 +50,7 @@ from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewPro
 from app.services.investment_committee import InvestmentCommitteeEngine
 from app.services.consensus import ConsensusEngine
 from app.services.author_intelligence import AuthorIntelligenceEngine
+from app.services.performance import PerformanceEngine
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -982,6 +983,42 @@ def create_author_intelligence_engine() -> AuthorIntelligenceEngine:
     )
 
 
+
+def _performance_completion_hook(outcome: dict[str, Any]) -> None:
+    # Hook point for Stage 10: completed outcomes can refresh Author Intelligence,
+    # Consensus and Institutional Rating without changing existing public APIs.
+    logger.info("performance_outcome_finished video_id=%s result=%s", outcome.get("video_id"), outcome.get("result"))
+
+
+def create_performance_engine() -> PerformanceEngine:
+    return PerformanceEngine(
+        media_catalog_loader=_load_tv_video_catalog,
+        review_payload_builder=_build_tv_review_payload,
+        completion_hooks=[_performance_completion_hook],
+    )
+
+
+@app.get("/api/performance")
+def api_performance() -> dict[str, Any]:
+    return create_performance_engine().evaluate_all()
+
+
+@app.get("/api/performance/author/{author}")
+def api_performance_author(author: str) -> dict[str, Any]:
+    try:
+        return create_performance_engine().evaluate_author(author)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.get("/api/performance/{video_id}")
+def api_performance_video(video_id: str) -> dict[str, Any]:
+    try:
+        return create_performance_engine().evaluate_video(video_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @app.get("/api/authors")
 def api_authors(sort: str = "rating") -> list[dict[str, Any]]:
     authors = create_author_intelligence_engine().build_all()
@@ -1036,6 +1073,11 @@ def consensus_page():
 @app.get("/authors", include_in_schema=False)
 def authors_page():
     return FileResponse(STATIC_DIR / "authors.html")
+
+
+@app.get("/performance", include_in_schema=False)
+def performance_page():
+    return FileResponse(STATIC_DIR / "performance.html")
 
 
 @app.get("/committee", include_in_schema=False)

--- a/app/services/performance/__init__.py
+++ b/app/services/performance/__init__.py
@@ -1,0 +1,6 @@
+from .engine import PerformanceEngine
+from .evaluator import PerformanceEvaluator
+from .market_replay import MarketReplay
+from .models import SignalOutcome
+
+__all__ = ["PerformanceEngine", "PerformanceEvaluator", "MarketReplay", "SignalOutcome"]

--- a/app/services/performance/engine.py
+++ b/app/services/performance/engine.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from statistics import mean
+from typing import Any, Callable
+
+from .evaluator import PerformanceEvaluator
+
+class PerformanceEngine:
+    def __init__(self, *, media_catalog_loader: Callable[[], list[dict[str, Any]]], review_payload_builder: Callable[[dict[str, Any]], dict[str, Any]], evaluator: PerformanceEvaluator | None = None, completion_hooks: list[Callable[[dict[str, Any]], None]] | None = None) -> None:
+        self.media_catalog_loader=media_catalog_loader; self.review_payload_builder=review_payload_builder; self.evaluator=evaluator or PerformanceEvaluator(); self.completion_hooks=completion_hooks or []
+
+    def evaluate_all(self) -> dict[str, Any]:
+        outcomes=[self._eval(v).model_dump() for v in self.media_catalog_loader()]
+        return {"items": outcomes, "leaderboard": self.leaderboard(outcomes), "meta": {"count": len(outcomes), "data_label": "real_market_outcomes_when_available_no_proxy_substitution"}}
+
+    def evaluate_video(self, video_id: str) -> dict[str, Any]:
+        for v in self.media_catalog_loader():
+            if str(v.get("id")) == video_id: return self._eval(v).model_dump()
+        raise ValueError("Performance video not found")
+
+    def evaluate_author(self, author: str) -> dict[str, Any]:
+        wanted=author.lower(); items=[self._eval(v).model_dump() for v in self.media_catalog_loader() if str(v.get("author") or v.get("source_id") or "").lower()==wanted]
+        if not items: raise ValueError("Performance author not found")
+        return {"author": author, "items": items, "summary": self._summary(items)}
+
+    def _eval(self, video: dict[str, Any]):
+        outcome=self.evaluator.evaluate(video, self.review_payload_builder(video))
+        if outcome.status == "finished":
+            payload=outcome.model_dump()
+            for hook in self.completion_hooks: hook(payload)
+        return outcome
+
+    def leaderboard(self, items: list[dict[str, Any]]) -> dict[str, Any]:
+        grouped=defaultdict(list)
+        for i in items: grouped[i.get("author") or "Unknown"].append(i)
+        rows=[]
+        for author, arr in grouped.items():
+            s=self._summary(arr); rows.append({"author": author, **s})
+        return {"best_authors": sorted(rows,key=lambda r:(r["win_rate"], r["average_rr"]), reverse=True)[:10], "worst_authors": sorted(rows,key=lambda r:(r["win_rate"], -r["losses"]))[:10], "most_accurate": sorted(rows,key=lambda r:r["win_rate"], reverse=True)[:10], "most_profitable": sorted(rows,key=lambda r:r["total_profit"], reverse=True)[:10]}
+
+    def _summary(self, arr: list[dict[str, Any]]) -> dict[str, Any]:
+        wins=sum(1 for x in arr if x.get("result")=="WIN"); losses=sum(1 for x in arr if x.get("result")=="LOSS"); decided=wins+losses
+        return {"videos":len(arr),"wins":wins,"losses":losses,"win_rate":round(wins/decided*100,2) if decided else 0,"average_rr":round(mean([x["rr"] for x in arr if x.get("rr") is not None]),3) if any(x.get("rr") is not None for x in arr) else 0,"average_holding_time":round(mean([x["holding_time_hours"] for x in arr if x.get("holding_time_hours") is not None]),2) if any(x.get("holding_time_hours") is not None for x in arr) else 0,"total_profit":round(sum(x.get("max_profit") or 0 for x in arr),6),"total_loss":round(sum(x.get("max_drawdown") or 0 for x in arr),6)}

--- a/app/services/performance/evaluator.py
+++ b/app/services/performance/evaluator.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from .market_replay import MarketReplay
+from .models import SignalOutcome, parse_dt
+
+def _num(v: Any) -> float | None:
+    try:
+        if v in (None, "", "Unknown"): return None
+        return float(v)
+    except (TypeError, ValueError): return None
+
+def _dir(v: Any) -> str:
+    t = str(v or "").upper()
+    if "BUY" in t or "LONG" in t or "BULL" in t: return "BUY"
+    if "SELL" in t or "SHORT" in t or "BEAR" in t: return "SELL"
+    return "UNKNOWN"
+
+class PerformanceEvaluator:
+    def __init__(self, market_replay: MarketReplay | None = None) -> None:
+        self.market_replay = market_replay or MarketReplay()
+
+    def evaluate(self, video: dict[str, Any], review: dict[str, Any] | None = None) -> SignalOutcome:
+        review = review or {}
+        analysis = review.get("analysis") or review.get("ai_review") or {}
+        knowledge = review.get("knowledge") or review.get("knowledge_context") or {}
+        symbol = video.get("symbol") or knowledge.get("symbol") or analysis.get("symbol")
+        direction = _dir(analysis.get("direction") or knowledge.get("direction"))
+        targets = analysis.get("targets") or []
+        entry = _num(analysis.get("entry") or analysis.get("entry_price"))
+        stop = _num(analysis.get("sl") or analysis.get("stop_loss"))
+        take = _num(analysis.get("tp") or analysis.get("take_profit") or (targets[0] if targets else None))
+        start = parse_dt(video.get("published_at")) or datetime.now(timezone.utc)
+        end = start + timedelta(days=_horizon_days(video.get("timeframe")))
+        out = SignalOutcome(video_id=str(video.get("id") or ""), author=video.get("author") or video.get("source_id"), symbol=symbol, direction=direction, entry_price=entry, stop_loss=stop, take_profit=take, entry_time=start.isoformat(), evaluation_start=start.isoformat(), evaluation_end=end.isoformat(), prediction={"direction": direction, "entry": entry, "stop_loss": stop, "take_profit": take})
+        if not symbol or direction == "UNKNOWN" or entry is None or stop is None or take is None:
+            out.status = "insufficient_signal"; out.warning_ru = "Недостаточно явных уровней entry/SL/TP; результат не подменяется proxy-метрикой."; return out
+        payload = self.market_replay.replay(str(symbol), str(video.get("timeframe") or "H1"), start, end)
+        candles = payload.get("candles") or []
+        out.provider = payload.get("provider") or payload.get("source"); out.data_status = payload.get("data_status") or ("real" if candles else "unavailable")
+        if not candles:
+            out.status = "market_data_unavailable"; out.warning_ru = "Исторические свечи недоступны у подключенных market data providers."; return out
+        highs = [_num(c.get("high")) for c in candles]; lows = [_num(c.get("low")) for c in candles]
+        highs = [x for x in highs if x is not None]; lows = [x for x in lows if x is not None]
+        if not highs or not lows: return out
+        out.market_high=max(highs); out.market_low=min(lows)
+        favorable = (out.market_high-entry) if direction == "BUY" else (entry-out.market_low)
+        adverse = (entry-out.market_low) if direction == "BUY" else (out.market_high-entry)
+        risk = abs(entry-stop); reward = abs(take-entry)
+        out.mfe=out.max_profit=round(favorable, 6); out.mae=out.max_drawdown=round(adverse, 6); out.rr=round(reward/risk, 3) if risk else None
+        out.profit = round(reward, 6); out.loss = round(risk, 6); out.holding_time_hours = round((end-start).total_seconds()/3600, 2)
+        hit_tp = out.market_high >= take if direction == "BUY" else out.market_low <= take
+        hit_sl = out.market_low <= stop if direction == "BUY" else out.market_high >= stop
+        out.result = "WIN" if hit_tp and not hit_sl else "LOSS" if hit_sl and not hit_tp else "PARTIAL" if hit_tp and hit_sl else "EXPIRED"
+        out.status = "finished" if out.result in {"WIN","LOSS","PARTIAL","EXPIRED"} else "open"
+        out.reality={"market_high":out.market_high,"market_low":out.market_low,"mfe":out.mfe,"mae":out.mae}
+        out.difference={"profit_distance": out.max_profit, "drawdown_distance": out.max_drawdown, "rr": out.rr}
+        return out
+
+def _horizon_days(tf: Any) -> int:
+    t=str(tf or "").upper(); return 14 if t in {"D1","W1"} else 7 if t == "H4" else 3

--- a/app/services/performance/market_replay.py
+++ b/app/services/performance/market_replay.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Protocol
+
+from app.services.market_service_registry import get_canonical_market_service
+
+class CandleProvider(Protocol):
+    def get_candles(self, symbol: str, timeframe: str, limit: int = 120) -> dict[str, Any]: ...
+
+class MarketReplay:
+    """Provider-neutral candle replay adapter for MT5, Databento, Polygon, TwelveData and future providers."""
+
+    def __init__(self, provider: CandleProvider | None = None) -> None:
+        self.provider = provider or get_canonical_market_service()
+
+    def replay(self, symbol: str, timeframe: str, start: datetime | None, end: datetime | None, *, limit: int = 300) -> dict[str, Any]:
+        payload = self.provider.get_candles(symbol, timeframe or "H1", limit)
+        candles = payload.get("candles") or []
+        filtered = []
+        for candle in candles:
+            ts = candle.get("time") or candle.get("timestamp") or candle.get("datetime")
+            cdt = _parse(ts)
+            if start and cdt and cdt < start: continue
+            if end and cdt and cdt > end: continue
+            filtered.append(candle)
+        return {**payload, "candles": filtered or candles}
+
+def _parse(value: Any) -> datetime | None:
+    if not value: return None
+    try: return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError: return None

--- a/app/services/performance/models.py
+++ b/app/services/performance/models.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Any, Literal
+
+Result = Literal["WIN", "LOSS", "PARTIAL", "BREAKEVEN", "EXPIRED", "UNKNOWN"]
+
+@dataclass
+class SignalOutcome:
+    video_id: str
+    author: str | None = None
+    symbol: str | None = None
+    direction: str = "UNKNOWN"
+    entry_price: float | None = None
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    entry_time: str | None = None
+    evaluation_start: str | None = None
+    evaluation_end: str | None = None
+    market_high: float | None = None
+    market_low: float | None = None
+    max_profit: float | None = None
+    max_drawdown: float | None = None
+    profit: float | None = None
+    loss: float | None = None
+    rr: float | None = None
+    mfe: float | None = None
+    mae: float | None = None
+    holding_time_hours: float | None = None
+    result: Result = "UNKNOWN"
+    status: str = "pending"
+    data_status: str = "unavailable"
+    provider: str | None = None
+    warning_ru: str | None = None
+    prediction: dict[str, Any] | None = None
+    reality: dict[str, Any] | None = None
+    difference: dict[str, Any] | None = None
+
+    def model_dump(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def parse_dt(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -36,6 +36,13 @@
     nav.appendChild(consensusLink);
   }
 
+  if (!nav.querySelector('a[href="/performance"]')) {
+    const performanceLink = document.createElement('a');
+    performanceLink.href = '/performance';
+    performanceLink.textContent = '📈 Performance';
+    nav.appendChild(performanceLink);
+  }
+
   if (!nav.querySelector('a[href="/authors"]')) {
     const authorsLink = document.createElement('a');
     authorsLink.href = '/authors';

--- a/app/static/performance.html
+++ b/app/static/performance.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Performance Engine — FXPilot</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <main class="page-shell performance-shell">
+    <nav class="top-nav"><a href="/">Главная</a><a href="/tv">🎥 FXPilot TV</a><a href="/consensus">Consensus</a><a href="/authors">Авторы</a><a href="/performance">Performance</a></nav>
+    <section class="hero panel">
+      <p class="eyebrow">Stage 10 · Performance Engine / Truth Engine</p>
+      <h1>Пост-анализ торговых идей</h1>
+      <p class="lead">Движок сравнивает прогнозы YouTube-авторов с реальными свечами подключенных providers. Если исторические данные или уровни недоступны, результат честно помечается UNKNOWN.</p>
+    </section>
+    <section id="leaderboard" class="authors-grid"><article class="panel">Загрузка leaderboard...</article></section>
+    <section id="performanceRoot" class="authors-grid"><article class="panel">Загрузка сделок...</article></section>
+  </main>
+  <script src="/static/nav.js"></script>
+  <script src="/static/performance.js"></script>
+</body>
+</html>

--- a/app/static/performance.js
+++ b/app/static/performance.js
@@ -1,0 +1,24 @@
+const root = document.getElementById('performanceRoot');
+const board = document.getElementById('leaderboard');
+const esc = (v) => String(v ?? '—').replace(/[&<>"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const pct = (v) => Number.isFinite(Number(v)) ? `${Number(v).toFixed(1)}%` : '—';
+function metric(title, rows) {
+  return `<article class="panel author-card"><p class="eyebrow">${esc(title)}</p>${(rows||[]).slice(0,5).map(r=>`<p><b>${esc(r.author)}</b> · win ${pct(r.win_rate)} · RR ${esc(r.average_rr)} · hold ${esc(r.average_holding_time)}h</p>`).join('') || '<p>Нет завершённых результатов.</p>'}</article>`;
+}
+function card(x) {
+  return `<article class="panel signal-card author-card">
+    <p class="eyebrow">${esc(x.symbol)} · ${esc(x.author)} · ${esc(x.status)}</p><h2>${esc(x.video_id)}</h2>
+    <div class="author-metrics"><span><b>${esc(x.result)}</b>Result</span><span><b>${esc(x.rr)}</b>RR</span><span><b>${esc(x.max_profit)}</b>Profit/MFE</span><span><b>${esc(x.max_drawdown)}</b>Loss/MAE</span></div>
+    <p><b>Prediction:</b> ${esc(x.direction)} entry ${esc(x.entry_price)} / SL ${esc(x.stop_loss)} / TP ${esc(x.take_profit)}</p>
+    <p><b>Reality:</b> high ${esc(x.market_high)} / low ${esc(x.market_low)} / provider ${esc(x.provider)} (${esc(x.data_status)})</p>
+    <p><b>Difference:</b> ${esc(x.difference ? JSON.stringify(x.difference) : x.warning_ru)}</p>
+  </article>`;
+}
+async function load() {
+  const res = await fetch('/api/performance', {headers:{Accept:'application/json'}, cache:'no-store'});
+  const data = await res.json();
+  const lb = data.leaderboard || {};
+  board.innerHTML = metric('Best Authors', lb.best_authors) + metric('Worst Authors', lb.worst_authors) + metric('Most Accurate', lb.most_accurate) + metric('Most Profitable', lb.most_profitable);
+  root.innerHTML = (data.items || []).map(card).join('') || '<article class="panel">Видео пока не найдены.</article>';
+}
+load().catch(() => { root.innerHTML = '<article class="panel">Performance Engine временно недоступен.</article>'; });

--- a/tests/test_performance_engine.py
+++ b/tests/test_performance_engine.py
@@ -1,0 +1,64 @@
+from app.services.performance import MarketReplay, PerformanceEngine, PerformanceEvaluator
+
+
+class FakeProvider:
+    def get_candles(self, symbol: str, timeframe: str, limit: int = 120):
+        return {
+            "provider": "fake_mt5_compatible",
+            "data_status": "real",
+            "candles": [
+                {"time": "2026-07-01T00:00:00+00:00", "high": 1.101, "low": 1.099, "close": 1.1005},
+                {"time": "2026-07-01T01:00:00+00:00", "high": 1.121, "low": 1.105, "close": 1.12},
+            ],
+        }
+
+
+def test_performance_evaluator_calculates_win_rr_mfe_mae():
+    evaluator = PerformanceEvaluator(MarketReplay(FakeProvider()))
+    video = {"id": "v1", "author": "Alpha", "symbol": "EURUSD", "timeframe": "H1", "published_at": "2026-07-01T00:00:00Z"}
+    review = {"analysis": {"direction": "BUY", "entry": 1.1, "sl": 1.09, "targets": [1.12]}}
+
+    outcome = evaluator.evaluate(video, review).model_dump()
+
+    assert outcome["result"] == "WIN"
+    assert outcome["rr"] == 2
+    assert outcome["market_high"] == 1.121
+    assert outcome["market_low"] == 1.099
+    assert outcome["max_profit"] == 0.021
+    assert outcome["max_drawdown"] == 0.001
+
+
+def test_performance_engine_leaderboard_and_unknown_without_levels():
+    videos = [
+        {"id": "v1", "author": "Alpha", "symbol": "EURUSD", "timeframe": "H1", "published_at": "2026-07-01T00:00:00Z"},
+        {"id": "v2", "author": "Beta", "symbol": "GBPUSD", "timeframe": "H1", "published_at": "2026-07-01T00:00:00Z"},
+    ]
+    reviews = {"v1": {"analysis": {"direction": "BUY", "entry": 1.1, "sl": 1.09, "tp": 1.12}}, "v2": {"analysis": {"direction": "BUY"}}}
+    engine = PerformanceEngine(media_catalog_loader=lambda: videos, review_payload_builder=lambda v: reviews[v["id"]], evaluator=PerformanceEvaluator(MarketReplay(FakeProvider())))
+
+    payload = engine.evaluate_all()
+
+    assert payload["items"][0]["result"] == "WIN"
+    assert payload["items"][1]["result"] == "UNKNOWN"
+    assert payload["leaderboard"]["best_authors"][0]["author"] == "Alpha"
+
+
+def test_performance_api_routes_keep_author_route_specific(monkeypatch):
+    from fastapi.testclient import TestClient
+    from app import main
+
+    videos = [{"id": "v1", "author": "Alpha", "symbol": "EURUSD", "timeframe": "H1", "published_at": "2026-07-01T00:00:00Z"}]
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: videos)
+    monkeypatch.setattr(main, "_build_tv_review_payload", lambda video: {"analysis": {"direction": "BUY", "entry": 1.1, "sl": 1.09, "tp": 1.12}})
+
+    class NoDataProvider:
+        def get_candles(self, symbol, timeframe, limit=120):
+            return {"provider": "test", "data_status": "unavailable", "candles": []}
+
+    from app.services.performance import MarketReplay, PerformanceEvaluator, PerformanceEngine
+    monkeypatch.setattr(main, "create_performance_engine", lambda: PerformanceEngine(media_catalog_loader=lambda: videos, review_payload_builder=main._build_tv_review_payload, evaluator=PerformanceEvaluator(MarketReplay(NoDataProvider()))))
+
+    client = TestClient(main.app)
+    assert client.get("/api/performance/author/Alpha").status_code == 200
+    assert client.get("/api/performance/v1").status_code == 200
+    assert client.get("/performance").status_code == 200


### PR DESCRIPTION
### Motivation
- Добавить провайдер-нейтральный пост‑анализатор, который корректно сравнивает прогнозы из Media Catalog/LLM/Committee с реальными свечами и служит основой для рейтингов авторов и институциональной статистики.
- Не дублировать существующие слои: переиспользовать Media Catalog, Transcript, Knowledge, LLM Review, Investment Committee и Consensus для вывода результатов.
- Гарантировать честность данных: не подменять отсутствующие рыночные данные proxy‑метриками и явно помечать состояния с предупреждением на русском.

### Description
- Добавлен пакет `app/services/performance/` с модулями `models.py` (контракт `SignalOutcome`), `market_replay.py` (провайдер‑нейтральный replay adapter), `evaluator.py` (расчёты RR, MFE, MAE, profit/loss, результат), `engine.py` (агрегатор, leaderboard и hooks). 
- Добавлены HTTP endpoints в `app/main.py`: `GET /api/performance`, `GET /api/performance/{video_id}`, `GET /api/performance/author/{author}`, а также UI страница `/performance` и статические файлы `app/static/performance.html` и `app/static/performance.js`, плюс ссылка в глобальной навигации `app/static/nav.js`.
- Внедрён completion hook `_performance_completion_hook` для точки расширения (обновление Author Intelligence / Consensus / Institutional Rating) без изменения существующих публичных API.
- Обновлён `README.md` с описанием Stage 10, политикой «no proxy substitution» и списком новых полей/результатов; добавлены тесты `tests/test_performance_engine.py` для evaluator, engine и совместимости маршрутов.

### Testing
- Запущен unit/API набор: `pytest tests/test_consensus_api.py tests/test_author_intelligence.py tests/test_performance_engine.py -q` и все тесты успешно прошли (`6 passed`, `18 warnings`).
- Локальные тесты `pytest tests/test_performance_engine.py -q` также прошли успешно, проверяя расчёт `WIN`/`RR`/`MFE`/`MAE`, поведение `UNKNOWN` при отсутствии уровней и корректность API маршрутов (вернули HTTP 200).
- Нет изменений существующих API маршрутов в обратной несовместимости; автоматические тесты подтверждают совместимость с Author Intelligence и Consensus.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2a95ab9c8331a1bc62cde17c23ec)