### PR TITLE
YouTube Data API как основной провайдер с прозрачным fallback на yt-dlp (Stage 12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+## Stage 12 — YouTube Data API Primary Provider
+
+- FXPilot TV теперь использует официальный YouTube Data API v3 как первичный YouTube-провайдер при наличии `YOUTUBE_API_KEY`; `yt-dlp` остаётся автоматическим fallback только для источников, где API-импорт завершился ошибкой или ключ отсутствует.
+- Новый модуль `app/services/providers/youtube_api_provider.py` поддерживает `channelId`, `@handle`, legacy `username`, playlist URL и uploads playlist из `provider_config`, резолвит `https://youtube.com/@xxx` в `channel_id` и кэширует результат.
+- Импорт строится на `channels.list`, `search.list`, `videos.list` и `playlistItems.list`, возвращает тот же `MediaItem`-контракт для `/api/media`, а существующий каталог не очищается при ошибке провайдера.
+- `/api/media/debug` расширен полями `provider_selected`, `provider_used`, `provider_fallback`, `youtube_api_enabled`, `youtube_api_quota_used`, `youtube_api_remaining_estimate`, `resolved_channel_id`, `api_errors`, `fallback_reason`; `/api/media/stats` считает videos per provider, quota usage, API latency и fallback count.
+- Админ-панель `/admin/media` показывает диагностику API / yt-dlp / RSS / Telegram и фактический provider used без изменения публичных API routes.
+
+```mermaid
+flowchart TD
+  A[Admin Import Now / Scheduler] --> B[MediaImportEngine]
+  B --> C{YouTube source?}
+  C -->|YOUTUBE_API_KEY exists| D[YouTubeApiProvider]
+  C -->|No key| E[YouTubeYtDlpProvider]
+  D --> F[channels.list / search.list / videos.list / playlistItems.list]
+  F --> G{API success?}
+  G -->|yes| H[Normalize to MediaItem]
+  G -->|no| E
+  E --> I[yt-dlp metadata fallback]
+  I --> H
+  B --> J[RSS Provider]
+  B --> K[Telegram Provider]
+  H --> L[Deduplicate + merge catalog]
+  J --> L
+  K --> L
+  L --> M[/api/media compatible catalog]
+  B --> N[/api/media/debug + /api/media/stats diagnostics]
+```
+
 ## Stage 9 — Author Intelligence Engine
 
 - Добавлен пакет `app/services/author_intelligence/` с `AuthorIntelligenceEngine`: он агрегирует Media Catalog, Transcript/Review payload, Knowledge Layer, LLM Review, Investment Committee и Consensus-compatible метрики по каждому YouTube автору.

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -440,7 +440,8 @@ class MediaImportEngine:
                 result = provider.fetch_latest(source)
                 fallback_used = False
                 fallback_reason = None
-                if result.error and source.provider == "youtube_api" and str(os.getenv("FXPILOT_YOUTUBE_PROVIDER") or "auto").lower() == "auto":
+                selected_name = getattr(provider, "provider_name", source.provider)
+                if result.error and selected_name == "youtube_api" and str(os.getenv("FXPILOT_YOUTUBE_PROVIDER") or "auto").lower() == "auto":
                     fallback_reason = result.error
                     logger.warning("youtube_api_fallback_to_ytdlp source_id=%s reason=%s", source.id, fallback_reason)
                     fallback_result = self.ytdlp_provider.fetch_latest(replace(source, provider="youtube_ytdlp"))
@@ -449,7 +450,12 @@ class MediaImportEngine:
                         fallback_used = True
                 source_log["fallback_used"] = fallback_used
                 source_log["fallback_reason"] = fallback_reason
-                source_log["provider_selected"] = getattr(provider, "provider_name", source.provider)
+                source_log["provider_selected"] = selected_name
+                source_log["provider_used"] = getattr(self.ytdlp_provider if fallback_used else provider, "provider_name", source.provider)
+                source_log["provider_fallback"] = fallback_used
+                api_diag = getattr(provider, "last_diagnostic", {}) if selected_name == "youtube_api" else {}
+                fallback_diag = getattr(self.ytdlp_provider, "last_diagnostic", {}) if fallback_used else {}
+                active_diag = fallback_diag if fallback_used else api_diag
                 run_log["steps"].append(f"HTTP {result.response_status if result.response_status is not None else result.request_status}")
                 run_log["steps"].append("Parsing...")
                 logger.info("HTTP %s", result.response_status if result.response_status is not None else result.request_status)
@@ -467,13 +473,18 @@ class MediaImportEngine:
                     "channel_title": result.channel_title or result.source.feed_title,
                     "channel_url": source.channel_url,
                     "resolved_url": result.source.rss_url or result.source.feed_url,
-                    "yt_dlp_version": getattr(provider, "last_diagnostic", {}).get("yt_dlp_version") if source.provider == "youtube_ytdlp" else None,
-                    "execution_time": getattr(provider, "last_diagnostic", {}).get("execution_time") if source.provider == "youtube_ytdlp" else (datetime.now(timezone.utc) - source_started).total_seconds(),
-                    "fetched_raw_count": getattr(provider, "last_diagnostic", {}).get("fetched_raw_count", result.videos_found) if source.provider == "youtube_ytdlp" else result.videos_found,
-                    "valid_items": getattr(provider, "last_diagnostic", {}).get("valid_items", len(result.items)) if source.provider == "youtube_ytdlp" else len(result.items),
-                    "skipped_invalid": getattr(provider, "last_diagnostic", {}).get("skipped_invalid", 0) if source.provider == "youtube_ytdlp" else 0,
-                    "skipped_reasons": getattr(provider, "last_diagnostic", {}).get("skipped_reasons", {}) if source.provider == "youtube_ytdlp" else {},
-                    "skipped_items": getattr(provider, "last_diagnostic", {}).get("skipped_items", [])[:20] if source.provider == "youtube_ytdlp" else [],
+                    "yt_dlp_version": active_diag.get("yt_dlp_version"),
+                    "execution_time": active_diag.get("execution_time") or (datetime.now(timezone.utc) - source_started).total_seconds(),
+                    "fetched_raw_count": active_diag.get("fetched_raw_count", result.videos_found),
+                    "valid_items": active_diag.get("valid_items", len(result.items)),
+                    "skipped_invalid": active_diag.get("skipped_invalid", 0),
+                    "skipped_reasons": active_diag.get("skipped_reasons", {}),
+                    "skipped_items": active_diag.get("skipped_items", [])[:20],
+                    "youtube_api_enabled": bool(os.getenv("YOUTUBE_API_KEY")),
+                    "youtube_api_quota_used": api_diag.get("quota_used") if api_diag else result.quota_used,
+                    "youtube_api_remaining_estimate": max(0, 10000 - int((api_diag.get("quota_used") if api_diag else result.quota_used) or 0)),
+                    "resolved_channel_id": api_diag.get("resolved_channel_id") or result.source.channel_id,
+                    "api_errors": api_diag.get("api_errors", []),
                     "updated_count": 0,
                 })
                 if result.error:
@@ -599,6 +610,15 @@ class MediaImportEngine:
                 "source_id": source.id,
                 "channel_url": source.channel_url,
                 "provider": resolved.get("provider", source.provider),
+                "provider_selected": last_source_run.get("provider_selected") or getattr(provider, "provider_name", source.provider),
+                "provider_used": last_source_run.get("provider_used") or resolved.get("provider", source.provider),
+                "provider_fallback": bool(last_source_run.get("provider_fallback") or last_source_run.get("fallback_used")),
+                "youtube_api_enabled": bool(os.getenv("YOUTUBE_API_KEY")),
+                "youtube_api_quota_used": last_source_run.get("youtube_api_quota_used") or last_source_run.get("quota_used"),
+                "youtube_api_remaining_estimate": last_source_run.get("youtube_api_remaining_estimate"),
+                "resolved_channel_id": last_source_run.get("resolved_channel_id") or channel_id,
+                "api_errors": last_source_run.get("api_errors") or [],
+                "fallback_reason": last_source_run.get("fallback_reason"),
                 "quota_used": last_source_run.get("quota_used"),
                 "rss_url": resolved.get("rss_url") or resolved.get("resolved_url") or source.rss_url,
                 "resolved_url": resolved.get("resolved_url") or resolved.get("rss_url") or source.rss_url,
@@ -645,6 +665,15 @@ class MediaImportEngine:
                     "channel_url": source.channel_url,
                     "resolved_url": last_source_run.get("resolved_url") or resolved.get("resolved_url"),
                     "execution_time": last_source_run.get("execution_time") or resolved.get("execution_time"),
+                    "provider_selected": last_source_run.get("provider_selected"),
+                    "provider_used": last_source_run.get("provider_used"),
+                    "provider_fallback": bool(last_source_run.get("provider_fallback") or last_source_run.get("fallback_used")),
+                    "youtube_api_enabled": bool(os.getenv("YOUTUBE_API_KEY")),
+                    "youtube_api_quota_used": last_source_run.get("youtube_api_quota_used") or last_source_run.get("quota_used"),
+                    "youtube_api_remaining_estimate": last_source_run.get("youtube_api_remaining_estimate"),
+                    "resolved_channel_id": last_source_run.get("resolved_channel_id") or last_source_run.get("channel_id"),
+                    "api_errors": last_source_run.get("api_errors") or [],
+                    "fallback_reason": last_source_run.get("fallback_reason"),
                 },
             })
         return {"last_import_run": last_run, "sources": rows}
@@ -692,6 +721,10 @@ class MediaImportEngine:
             "sources_online": len([s for s in sources if s.enabled and not s.last_error]), "sources_failed": len(failed),
             "videos_analyzed": videos_analyzed, "videos_awaiting_ai": awaiting_ai,
             "average_import_duration": avg_duration, "provider_usage": dict(sorted(by_provider.items())),
+            "videos_per_provider": dict(sorted(by_provider.items())),
+            "quota_usage": sum(int((r.get("youtube_api_quota_used") or r.get("quota_used") or 0)) for r in (last_run.get("sources") or []) if isinstance(r, dict)),
+            "api_latency": round(sum(float(r.get("execution_time") or 0) for r in (last_run.get("sources") or []) if isinstance(r, dict) and r.get("provider_selected") == "youtube_api") / max(1, len([r for r in (last_run.get("sources") or []) if isinstance(r, dict) and r.get("provider_selected") == "youtube_api"])), 3),
+            "fallback_count": len([r for r in (last_run.get("sources") or []) if isinstance(r, dict) and (r.get("provider_fallback") or r.get("fallback_used"))]),
             "real_videos": real_videos,
             "manual_demo": manual_demo,
             "sources_with_videos": len(videos_by_source),
@@ -801,6 +834,9 @@ class MediaImportEngine:
     def resolve_provider(self, provider: str) -> MediaProvider:
         provider = (provider or "").lower()
         if provider == "youtube":
+            mode = str(os.getenv("FXPILOT_YOUTUBE_PROVIDER") or "auto").strip().lower()
+            if not self._custom_youtube_provider and (mode == "ytdlp" or (mode == "auto" and not os.getenv("YOUTUBE_API_KEY"))):
+                return self.ytdlp_provider
             return self.youtube_provider
         if provider == "youtube_api":
             if self._custom_youtube_provider:

--- a/app/services/providers/youtube_api_provider.py
+++ b/app/services/providers/youtube_api_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
 from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any, Callable
@@ -14,6 +15,7 @@ from app.services.media_import_engine import ImportSourceResult, MediaImportErro
 
 YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
 CHANNEL_ID_RE = re.compile(r"UC[A-Za-z0-9_-]{4,30}")
+RESOLVE_CACHE_TTL_SECONDS = 24 * 60 * 60
 
 
 class YouTubeApiError(RuntimeError):
@@ -31,27 +33,33 @@ class YouTubeApiProvider:
     MediaSource, fetch latest videos, and normalize them into MediaItem objects.
     """
 
-    provider_name = "youtube"
+    provider_name = "youtube_api"
+    _resolve_cache: dict[str, tuple[float, dict[str, Any]]] = {}
 
     def __init__(self, api_key: str | None = None, requester: Callable[[str, dict[str, Any]], dict[str, Any]] | None = None, page_size: int = 25) -> None:
         self.api_key = api_key if api_key is not None else os.getenv("YOUTUBE_API_KEY")
         self.requester = requester or self._request
         self.page_size = max(1, min(int(page_size or 25), 50))
         self.quota_used = 0
+        self.last_diagnostic: dict[str, Any] = {}
         self._latest_imported_at_by_source: dict[str, str | None] = {}
 
     def set_latest_imported_at(self, source_id: str, published_at: str | None) -> None:
         self._latest_imported_at_by_source[source_id] = published_at
 
     def fetch_latest(self, source: MediaSource) -> ImportSourceResult:
+        started = time.perf_counter()
+        quota_before = self.quota_used
+        self.last_diagnostic = {"provider": self.provider_name, "api_enabled": bool(self.api_key), "api_errors": [], "resolved_channel_id": None, "quota_used": 0, "execution_time": None}
         try:
             resolved = self.resolve_source(source)
             if not resolved.get("ok"):
                 return ImportSourceResult(source, [], "config_error", None, 0, str(resolved.get("error")), quota_used=self.quota_used)
             channel_id = str(resolved["channel_id"])
+            self.last_diagnostic["resolved_channel_id"] = channel_id
             channel_title = str(resolved.get("channel_title") or source.name)
             latest_imported_at = self._latest_imported_at_by_source.get(source.id)
-            videos = self._fetch_channel_videos(channel_id, latest_imported_at)
+            videos = self._fetch_source_videos(source, channel_id, latest_imported_at)
             seen: set[str] = set()
             items: list[MediaItem] = []
             for video in videos:
@@ -72,11 +80,16 @@ class YouTubeApiProvider:
                 last_resolve_error=None,
                 rss_validation_status="api_ok",
             )
-            return ImportSourceResult(resolved_source, items, "ok", 200, len(videos), channel_title=channel_title, quota_used=self.quota_used)
+            return ImportSourceResult(resolved_source, items, "ok", 200, len(videos), channel_title=channel_title, quota_used=self.quota_used - quota_before)
         except YouTubeQuotaExceededError as exc:
-            return ImportSourceResult(source, [], "quota_exceeded", 403, 0, str(exc), quota_used=self.quota_used)
+            self.last_diagnostic.setdefault("api_errors", []).append(str(exc))
+            return ImportSourceResult(source, [], "quota_exceeded", 403, 0, str(exc), quota_used=self.quota_used - quota_before)
         except YouTubeApiError as exc:
-            return ImportSourceResult(source, [], "api_error", None, 0, str(exc), quota_used=self.quota_used)
+            self.last_diagnostic.setdefault("api_errors", []).append(str(exc))
+            return ImportSourceResult(source, [], "api_error", None, 0, str(exc), quota_used=self.quota_used - quota_before)
+        finally:
+            self.last_diagnostic["quota_used"] = self.quota_used - quota_before
+            self.last_diagnostic["execution_time"] = round(time.perf_counter() - started, 3)
 
     def resolve_source(self, source: MediaSource) -> dict[str, Any]:
         return self.resolve(source.channel_url, source.channel_id)
@@ -85,6 +98,10 @@ class YouTubeApiProvider:
         if not self.api_key:
             return {"ok": False, "provider": self.provider_name, "error": "YOUTUBE_API_KEY is required for YouTube Data API import", "channel_id": channel_id}
         normalized = self.normalize_url(channel_url)
+        cache_key = f"{channel_id or ''}|{normalized}"
+        cached = self._resolve_cache.get(cache_key)
+        if cached and time.time() - cached[0] < RESOLVE_CACHE_TTL_SECONDS:
+            return dict(cached[1], cache_hit=True)
         found_id = channel_id or self._extract_channel_id_from_url(normalized)
         resolved_from = "saved_channel_id" if channel_id else ("url_channel_path" if found_id else None)
         if not found_id:
@@ -96,7 +113,7 @@ class YouTubeApiProvider:
                 found_id, title = self._first_channel(data)
                 resolved_from = "api_forHandle"
                 if found_id:
-                    return self._resolved(found_id, title, resolved_from)
+                    return self._cache_resolved(cache_key, self._resolved(found_id, title, resolved_from))
                 query = handle.lstrip("@")
             elif path.startswith("user/"):
                 username = path.split("/", 2)[1]
@@ -104,7 +121,7 @@ class YouTubeApiProvider:
                 found_id, title = self._first_channel(data)
                 resolved_from = "api_forUsername"
                 if found_id:
-                    return self._resolved(found_id, title, resolved_from)
+                    return self._cache_resolved(cache_key, self._resolved(found_id, title, resolved_from))
                 query = username
             else:
                 query = path.split("/", 1)[-1] if path else normalized
@@ -114,13 +131,22 @@ class YouTubeApiProvider:
             title = ((item.get("snippet") or {}).get("channelTitle")) or ((item.get("snippet") or {}).get("title"))
             resolved_from = resolved_from or "api_channel_search"
             if found_id:
-                return self._resolved(found_id, title, resolved_from)
+                return self._cache_resolved(cache_key, self._resolved(found_id, title, resolved_from))
             return {"ok": False, "provider": self.provider_name, "error": "Unable to resolve YouTube channel_id with YouTube Data API", "channel_id": None, "normalized_url": normalized}
         data = self._api_get("channels", {"part": "snippet", "id": found_id})
         checked_id, title = self._first_channel(data)
         if not checked_id:
             return {"ok": False, "provider": self.provider_name, "error": f"YouTube channel not found: {found_id}", "channel_id": found_id, "normalized_url": normalized}
-        return self._resolved(checked_id, title, resolved_from or "api_channels_id")
+        return self._cache_resolved(cache_key, self._resolved(checked_id, title, resolved_from or "api_channels_id"))
+
+    def _fetch_source_videos(self, source: MediaSource, channel_id: str, published_after: str | None) -> list[dict[str, Any]]:
+        playlist_id = self._playlist_id(source.channel_url) or str(source.provider_config.get("playlist_id") or "")
+        uploads_playlist = str(source.provider_config.get("uploads_playlist_id") or "")
+        if uploads_playlist:
+            return self._fetch_playlist_videos(uploads_playlist, published_after)
+        if playlist_id:
+            return self._fetch_playlist_videos(playlist_id, published_after)
+        return self._fetch_channel_videos(channel_id, published_after)
 
     def _fetch_channel_videos(self, channel_id: str, published_after: str | None) -> list[dict[str, Any]]:
         found: list[dict[str, Any]] = []
@@ -147,6 +173,27 @@ class YouTubeApiProvider:
                     found.append({"id": vid, "snippet": snippet, "contentDetails": item.get("contentDetails") or {}})
             page_token = data.get("nextPageToken")
             stop = not page_token or bool(published_after)
+        return found
+
+
+    def _fetch_playlist_videos(self, playlist_id: str, published_after: str | None) -> list[dict[str, Any]]:
+        found: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while True:
+            params: dict[str, Any] = {"part": "snippet,contentDetails", "playlistId": playlist_id, "maxResults": self.page_size}
+            if page_token:
+                params["pageToken"] = page_token
+            data = self._api_get("playlistItems", params)
+            ids = [str(((item.get("contentDetails") or {}).get("videoId")) or ((item.get("snippet") or {}).get("resourceId") or {}).get("videoId") or "") for item in data.get("items") or []]
+            ids = [video_id for video_id in ids if video_id]
+            if ids:
+                details = self._api_get("videos", {"part": "snippet,contentDetails", "id": ",".join(ids)})
+                for item in details.get("items") or []:
+                    if not published_after or str((item.get("snippet") or {}).get("publishedAt") or "") > self._as_rfc3339(published_after):
+                        found.append({"id": str(item.get("id") or ""), "snippet": item.get("snippet") or {}, "contentDetails": item.get("contentDetails") or {}})
+            page_token = data.get("nextPageToken")
+            if not page_token or published_after:
+                break
         return found
 
     def _api_get(self, endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -191,7 +238,7 @@ class YouTubeApiProvider:
         thumbnails = snippet.get("thumbnails") or {}
         thumb = YouTubeApiProvider._best_thumbnail(thumbnails, video_id)
         return MediaItem(
-            id=f"youtube:{video_id}", provider="youtube", source_id=source.id, title=title, author=str(snippet.get("channelTitle") or channel_title or source.name),
+            id=f"youtube:{video_id}", provider=YouTubeApiProvider.provider_name, source_id=source.id, title=title, author=str(snippet.get("channelTitle") or channel_title or source.name),
             youtube_id=video_id, url=f"https://www.youtube.com/watch?v={video_id}", thumbnail=thumb, published_at=str(snippet.get("publishedAt") or "")[:10] or None,
             duration=(video.get("contentDetails") or {}).get("duration"), category=source.categories[0] if source.categories else "Market Analysis", symbol=symbol,
             language=source.language, description=description, tags=[*source.categories, symbol], imported_at=datetime.now(timezone.utc).isoformat()
@@ -213,6 +260,8 @@ class YouTubeApiProvider:
         if not re.match(r"^https?://", value, re.I):
             value = "https://" + value
         parsed = urlparse(value)
+        if "youtu.be" in parsed.netloc.lower():
+            return parsed._replace(scheme="https", netloc="www.youtube.com", path="/watch", query=f"v={parsed.path.strip('/')}", fragment="").geturl()
         if "youtube.com" not in parsed.netloc.lower():
             raise YouTubeApiError("Only youtube.com channel URLs are supported")
         return parsed._replace(scheme="https", netloc=parsed.netloc.lower().replace("m.youtube.com", "www.youtube.com"), fragment="").geturl().rstrip("/")
@@ -235,7 +284,21 @@ class YouTubeApiProvider:
 
     @staticmethod
     def _resolved(channel_id: str, title: str | None, resolved_from: str | None) -> dict[str, Any]:
-        return {"ok": True, "provider": "youtube", "channel_id": channel_id, "channel_title": title, "feed_title": title, "resolved_from": resolved_from, "rss_url": None, "rss_validation_status": "api_ok", "error": None}
+        return {"ok": True, "provider": YouTubeApiProvider.provider_name, "channel_id": channel_id, "channel_title": title, "feed_title": title, "resolved_from": resolved_from, "rss_url": None, "rss_validation_status": "api_ok", "error": None}
+
+    @classmethod
+    def _cache_resolved(cls, cache_key: str, payload: dict[str, Any]) -> dict[str, Any]:
+        cls._resolve_cache[cache_key] = (time.time(), payload)
+        return payload
+
+    @staticmethod
+    def _playlist_id(url: str) -> str | None:
+        parsed = urlparse(str(url or ""))
+        playlist_id = parse_qs(parsed.query).get("list", [None])[0]
+        if playlist_id:
+            return str(playlist_id)
+        match = re.search(r"/playlist/([^/?#]+)", parsed.path)
+        return match.group(1) if match else None
 
     @staticmethod
     def _error_reason(error: Any) -> str | None:
@@ -255,3 +318,6 @@ class YouTubeApiProvider:
         if text.endswith("+00:00"):
             return text.replace("+00:00", "Z")
         return text
+
+
+# Backwards-compatible helper methods attached after class definition are intentionally avoided.

--- a/app/static/media-admin.js
+++ b/app/static/media-admin.js
@@ -15,7 +15,7 @@
   const formPayload = () => { const fd = new FormData(sourceForm); return { id: fd.get('id'), name: fd.get('name'), source_type: fd.get('source_type') || 'youtube', provider: fd.get('provider') || 'youtube_api', url: fd.get('channel_url'), channel_url: fd.get('channel_url'), language: fd.get('language') || 'ru', categories: String(fd.get('categories') || '').split(',').map((v) => v.trim()).filter(Boolean), symbols: String(fd.get('symbols') || '').split(',').map((v) => v.trim()).filter(Boolean), priority: Number(fd.get('priority') || 1), enabled: Boolean(fd.get('enabled')) }; };
   const showResolve = (payload) => { if (resolveResult) resolveResult.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2); };
   function implementationNotice(action, sourceName) { window.alert(`${action}: Implementation in next sprint${sourceName ? ` для ${sourceName}` : ''}.`); }
-  const providerLabel = (provider) => provider === 'youtube_ytdlp' ? 'YouTube (yt-dlp)' : (provider === 'youtube_api' ? 'YouTube API' : provider);
+  const providerLabel = (provider) => provider === 'youtube_ytdlp' ? 'YouTube (yt-dlp)' : (provider === 'youtube_api' ? 'YouTube API' : provider === 'rss_feed' ? 'RSS' : provider === 'telegram_public' ? 'Telegram' : provider);
   const statusLabel = (source) => { if (source.provider === 'youtube_ytdlp' && source.status === 'online') return 'Online'; if (source.status === 'manual_source' || source.provider === 'youtube_manual') return 'Manual source — API not connected'; if (source.status === 'needs_channel_id' || (source.provider === 'youtube' && !source.channel_id)) return 'Нужен YouTube channel_id для RSS-импорта'; return source.enabled ? 'Online' : 'Disabled'; };
   const sourceDuration = (source) => source.last_run?.execution_time ? `${source.last_run.execution_time}s` : (source.import_duration ? `${source.import_duration}s` : '—');
   const sourceErrors = (source) => source.last_error || (source.last_run?.errors || []).filter(Boolean).join('; ') || '—';
@@ -30,7 +30,7 @@
       <tr>
         <td><strong>${escapeHtml(source.name)}</strong><span>${escapeHtml(source.url || source.channel_url || '')}</span></td>
         <td>${escapeHtml(source.source_type || 'youtube')}</td>
-        <td><span class="tv-provider-pill">${escapeHtml(providerLabel(source.provider))}</span></td>
+        <td><span class="tv-provider-pill">${escapeHtml(providerLabel(source.provider))}</span><span>used: ${escapeHtml(providerLabel(source.provider_used || source.last_run?.provider_used || source.provider))}${source.provider_fallback || source.last_run?.provider_fallback ? ' · fallback yt-dlp' : ''}</span></td>
         <td><span class="tv-status-pill ${statusClass}">${escapeHtml(source.enabled ? 'Enabled' : 'Disabled')}</span></td>
         <td>${formatValue(source.last_success || source.last_import)}</td>
         <td>${escapeHtml(source.items_count ?? source.videos_count ?? 0)}</td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,6 @@ dependencies = [
   "ta",
   "python-dotenv",
   "yt-dlp",
-  "feedparser"
+  "feedparser",
+  "APScheduler==3.10.4"
 ]

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -320,30 +320,46 @@ def test_youtube_source_with_channel_id_uses_channel_rss(tmp_path: Path):
     assert requested == ["https://www.youtube.com/feeds/videos.xml?channel_id=UCexplicit"]
 
 
-def test_youtube_source_without_api_key_returns_config_error(tmp_path: Path):
+def test_youtube_source_without_api_key_uses_ytdlp_fallback(tmp_path: Path, monkeypatch):
     sources_path = tmp_path / "media_sources.json"
     catalog_path = tmp_path / "media_catalog.json"
     sources_path.write_text(json.dumps([
         {"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/@demo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
     ]), encoding="utf-8")
     catalog_path.write_text("[]", encoding="utf-8")
-    result = MediaImportEngine(sources_path, catalog_path).import_latest()
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+    class GoodYtDlp:
+        provider_name = "youtube_ytdlp"
+        last_diagnostic = {"execution_time": 0.01, "fetched_raw_count": 1, "valid_items": 1}
+        def fetch_latest(self, source):
+            item = MediaItem("youtube:NoKey000001", "youtube_ytdlp", source.id, "EURUSD", "Demo", "NoKey000001", "https://youtube.com/watch?v=NoKey000001", None, "2026-07-07", None, "Forex", "EURUSD", "ru", "")
+            return ImportSourceResult(source, [item], "ok", 200, 1)
+        def resolve_source(self, source):
+            return {"ok": True, "provider": "youtube_ytdlp", "resolved_url": source.channel_url}
+    result = MediaImportEngine(sources_path, catalog_path, ytdlp_provider=GoodYtDlp()).import_latest()
     source = json.loads(sources_path.read_text(encoding="utf-8"))[0]
-    assert result["failed"] == 1
-    assert source["status"] == "error"
-    assert "YOUTUBE_API_KEY" in source["last_error"]
+    assert result["failed"] == 0
+    assert source.get("last_error") is None
+    assert json.loads(catalog_path.read_text(encoding="utf-8"))[0]["provider"] == "youtube_ytdlp"
 
 
-def test_debug_sources_exposes_api_key_blocking_reason(tmp_path: Path):
+def test_debug_sources_exposes_ytdlp_provider_without_api_key(tmp_path: Path, monkeypatch):
     sources_path = tmp_path / "media_sources.json"
     catalog_path = tmp_path / "media_catalog.json"
     sources_path.write_text(json.dumps([
         {"id":"demo","name":"Demo","provider":"youtube","channel_url":"https://www.youtube.com/@demo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
     ]), encoding="utf-8")
     catalog_path.write_text("[]", encoding="utf-8")
-    row = MediaImportEngine(sources_path, catalog_path).debug_sources()["sources"][0]
-    assert row["can_import"] is False
-    assert "YOUTUBE_API_KEY" in row["blocking_reason"]
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+    class DiagnosticYtDlp:
+        provider_name = "youtube_ytdlp"
+        def resolve_source(self, source):
+            return {"ok": True, "provider": "youtube_ytdlp", "resolved_url": source.channel_url}
+        def fetch_latest(self, source):
+            return ImportSourceResult(source, [], "ok", 200, 0)
+    row = MediaImportEngine(sources_path, catalog_path, ytdlp_provider=DiagnosticYtDlp()).debug_sources()["sources"][0]
+    assert row["can_import"] is True
+    assert row["provider_selected"] == "youtube_ytdlp"
 
 
 def test_rss_test_returns_headers_preview_feed_title_and_entry_count(tmp_path: Path):
@@ -505,3 +521,51 @@ def test_media_review_endpoint_returns_fxpilot_context(monkeypatch):
     assert payload["comparison"]["video_says"] == "No transcript yet. AI summary will appear later."
     assert payload["confluence_score"] == 95
     assert payload["preliminary_verdict"] == "FXPilot currently supports this market context."
+
+
+def test_youtube_api_failure_falls_back_to_ytdlp_for_failed_source(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "key")
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    sources_path.write_text(json.dumps([{"id":"demo","name":"Demo","provider":"youtube_api","channel_url":"https://youtube.com/@demo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}]), encoding="utf-8")
+    catalog_path.write_text("[]", encoding="utf-8")
+
+    class FailingApi:
+        provider_name = "youtube_api"
+        last_diagnostic = {"quota_used": 1, "api_errors": ["boom"], "resolved_channel_id": None, "execution_time": 0.01}
+        def set_latest_imported_at(self, *_): pass
+        def fetch_latest(self, source):
+            return ImportSourceResult(source, [], "api_error", None, 0, "boom", quota_used=1)
+        def resolve_source(self, source):
+            return {"ok": False, "provider": "youtube_api", "error": "boom"}
+
+    class GoodYtDlp:
+        provider_name = "youtube_ytdlp"
+        last_diagnostic = {"yt_dlp_version": "test", "execution_time": 0.02, "fetched_raw_count": 1, "valid_items": 1}
+        def fetch_latest(self, source):
+            item = MediaItem("youtube:AbC12345678", "youtube_ytdlp", source.id, "EURUSD", "Demo", "AbC12345678", "https://youtube.com/watch?v=AbC12345678", None, "2026-07-07", None, "Forex", "EURUSD", "ru", "")
+            return ImportSourceResult(source, [item], "ok", 200, 1)
+
+    engine = MediaImportEngine(sources_path, catalog_path, youtube_provider=FailingApi(), ytdlp_provider=GoodYtDlp())
+    result = engine.import_latest()
+    debug = json.loads((tmp_path / "media_import_debug.json").read_text(encoding="utf-8"))
+    row = debug["sources"][0]
+    assert result["success"] is True
+    assert row["provider_selected"] == "youtube_api"
+    assert row["provider_used"] == "youtube_ytdlp"
+    assert row["provider_fallback"] is True
+    assert row["fallback_reason"] == "boom"
+
+
+def test_stats_include_provider_quota_latency_and_fallback_count(tmp_path: Path):
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    debug_path = tmp_path / "debug.json"
+    sources_path.write_text(json.dumps([]), encoding="utf-8")
+    catalog_path.write_text(json.dumps([{"id":"youtube:AbC12345678","provider":"youtube_api","source_id":"demo","youtube_id":"AbC12345678"}]), encoding="utf-8")
+    debug_path.write_text(json.dumps({"sources":[{"provider_selected":"youtube_api","youtube_api_quota_used":102,"execution_time":0.5,"provider_fallback":True}]}), encoding="utf-8")
+    stats = MediaImportEngine(sources_path, catalog_path, debug_path=debug_path).stats()
+    assert stats["videos_per_provider"]["youtube_api"] == 1
+    assert stats["quota_usage"] == 102
+    assert stats["api_latency"] == 0.5
+    assert stats["fallback_count"] == 1

--- a/tests/test_youtube_api_provider.py
+++ b/tests/test_youtube_api_provider.py
@@ -93,3 +93,35 @@ def test_incremental_import_uses_latest_catalog_date(tmp_path: Path):
     catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
     assert result["imported"] == 1
     assert any(item.get("youtube_id") == "v2" for item in catalog)
+
+
+def test_playlist_import_uses_playlist_items_and_videos_list():
+    calls = []
+    def requester(endpoint, params):
+        calls.append((endpoint, params))
+        if endpoint == "channels":
+            return {"items": [{"id": "UCdemo12345", "snippet": {"title": "Demo"}}]}
+        if endpoint == "playlistItems":
+            assert params["playlistId"] == "PLdemo"
+            return {"items": [{"contentDetails": {"videoId": "PlV00000001"}}]}
+        if endpoint == "videos":
+            return {"items": [{"id": "PlV00000001", "snippet": {"title": "GBPUSD", "publishedAt": "2026-07-07T00:00:00Z", "channelTitle": "Demo"}, "contentDetails": {"duration": "PT7M"}}]}
+        raise AssertionError(endpoint)
+    result = YouTubeApiProvider(api_key="key", requester=requester).fetch_latest(source("https://youtube.com/playlist?list=PLdemo", channel_id="UCdemo12345"))
+    assert result.error is None
+    assert result.items[0].youtube_id == "PlV00000001"
+    assert result.items[0].provider == "youtube_api"
+    assert [call[0] for call in calls] == ["channels", "playlistItems", "videos"]
+
+
+def test_handle_resolution_is_cached():
+    calls = []
+    def requester(endpoint, params):
+        calls.append((endpoint, params))
+        return {"items": [{"id": "UCcache12345", "snippet": {"title": "Cached"}}]}
+    provider = YouTubeApiProvider(api_key="key", requester=requester)
+    first = provider.resolve("https://youtube.com/@cache-test")
+    second = provider.resolve("https://youtube.com/@cache-test")
+    assert first["channel_id"] == second["channel_id"] == "UCcache12345"
+    assert second["cache_hit"] is True
+    assert len(calls) == 1


### PR DESCRIPTION
### Motivation
- Сделать официальный YouTube Data API v3 основным провайдером импорта видео при наличии `YOUTUBE_API_KEY` и сохранить `yt-dlp` как автоматический fallback для стабильности и покрыть сценарии без ключа или при ошибках API. 
- Обеспечить поддержку современных форматов ссылок (`@handle`, `channelId`, `username`, playlist и uploads playlist), кеширование резолвинга и метрики по квоте для оперативной диагностики и операций в проде.

### Description
- Добавлен новый провайдер `YouTubeApiProvider` в `app/services/providers/youtube_api_provider.py`, реализующий запросы к `channels.list`, `search.list`, `videos.list` и `playlistItems.list`, нормализующий ответ в существующий `MediaItem`-контракт и кеширующий резолв `@handle` (`RESOLVE_CACHE_TTL_SECONDS`).
- Обновлён движок импорта `MediaImportEngine` (`app/services/media_import_engine.py`) для выбора провайдера: если доступен `YOUTUBE_API_KEY` — выбирается `youtube_api`, иначе — `youtube_ytdlp`; при ошибке API для конкретного источника выполняется прозрачный fallback на `yt-dlp` и результат логируется как `provider_used`/`provider_fallback`.
- Расширена отладка/статистика и админ-диагностика: добавлены поля `provider_selected`, `provider_used`, `provider_fallback`, `youtube_api_enabled`, `youtube_api_quota_used`, `youtube_api_remaining_estimate`, `resolved_channel_id`, `api_errors`, `fallback_reason`, а в `stats()` добавлены `videos_per_provider`, `quota_usage`, `api_latency` и `fallback_count`.
- Небольшие фронтенд-правки в `app/static/media-admin.js` для отображения фактически используемого провайдера и пометки fallback; обновлён `README.md` с диаграммой архитектуры Stage 12 и добавлен `APScheduler` в `pyproject.toml` для согласования зависимостей.
- Добавлены юнит-тесты и сценарии: кеширование резолвинга, playlist-import, поведение без API-ключа (автопереключение на `yt-dlp`), fallback при ошибках API и учёт квоты/латентности в статистике (`tests/test_youtube_api_provider.py`, `tests/test_media_import_engine.py`).

### Testing
- Запущены тесты: `pytest tests/test_youtube_api_provider.py tests/test_media_import_engine.py -q` — все тесты прошли успешно (`38 passed`, предупреждения имеются). 
- Локальные smoke-проверки эндпоинтов администратора и debug/statistics контрактов выполнены через тестовые сценарии в `tests/` и показали корректную сериализацию дополнительных полей и корректный fallback на `yt-dlp`.
- Компоненты сохранены обратносуместимыми: публичные API `GET /api/media`, `GET /api/media/import-now`, `GET /api/media/debug` и админ-интерфейс остались совместимыми с прежними контрактами.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f8a9d80ac8331904749e1c9f243ed)