### PR TITLE
Stabilize TV frontend, YouTube provider migration and defensive AI services

### DIFF
--- a/app/services/author_intelligence/engine.py
+++ b/app/services/author_intelligence/engine.py
@@ -80,11 +80,20 @@ class AuthorIntelligenceEngine:
         return dict(grouped)
 
     def _opinion(self, video: dict[str, Any]) -> dict[str, Any]:
-        payload = self.review_payload_builder(video)
+        warnings: list[str] = []
+        try:
+            payload = self.review_payload_builder(video)
+        except Exception as exc:
+            payload = {}
+            warnings.append(f"review_unavailable: {exc.__class__.__name__}: {exc}")
         analysis = payload.get("analysis") or payload.get("ai_review") or {}
         knowledge = payload.get("knowledge") or payload.get("knowledge_context") or {}
         llm = payload.get("llm_review") or {}
-        committee = self.committee_builder(str(video.get("id") or ""))
+        try:
+            committee = self.committee_builder(str(video.get("id") or ""))
+        except Exception as exc:
+            committee = {"decision": "WAIT", "overall_score": 0, "agreement_score": 0, "risk_level": "HIGH", "committee_verdict": "WATCH", "institutional_bias": "NEUTRAL"}
+            warnings.append(f"committee_unavailable: {exc.__class__.__name__}: {exc}")
         direction = _direction(committee.get("decision") or analysis.get("direction") or knowledge.get("direction") or llm.get("direction"))
         confidence = int(_number(analysis.get("confidence") or llm.get("confidence") or knowledge.get("confidence") or committee.get("overall_score")) or 0)
         risk_text = str(committee.get("risk_level") or "MEDIUM").upper()
@@ -106,6 +115,9 @@ class AuthorIntelligenceEngine:
             "institutional_bias": committee.get("institutional_bias") or "NEUTRAL",
             "committee_verdict": committee.get("committee_verdict") or "WATCH",
             "outcome": outcome,
+            "warnings": warnings,
+            "errors_count": len(warnings),
+            "review_status": "review_unavailable" if any(w.startswith("review_unavailable") for w in warnings) else "ok",
         }
 
     def _build_author(self, author: str, videos: list[dict[str, Any]], *, include_opinions: bool = False) -> dict[str, Any]:
@@ -116,6 +128,8 @@ class AuthorIntelligenceEngine:
         successful = sum(1 for item in outcomes if item.get("status") == "success")
         failed = sum(1 for item in outcomes if item.get("status") == "failed")
         neutral = total - successful - failed
+        warnings_count = sum(len(item.get("warnings") or []) for item in opinions)
+        errors_count = sum(int(item.get("errors_count") or 0) for item in opinions)
         avg_conf = _avg([item["confidence"] for item in opinions])
         avg_committee = _avg([item["committee_score"] for item in opinions])
         avg_agreement = _avg([item["agreement_score"] for item in opinions])
@@ -142,6 +156,8 @@ class AuthorIntelligenceEngine:
             "neutral_signals": neutral,
             "accuracy": proxy_accuracy,
             "accuracy_label": "proxy_committee_accuracy_until_real_market_outcomes_available",
+            "warnings_count": warnings_count,
+            "errors_count": errors_count,
             "win_rate": win_rate,
             "average_confidence": avg_conf,
             "average_committee_score": avg_committee,
@@ -168,6 +184,8 @@ class AuthorIntelligenceEngine:
                 "bullish_bias": round((directions.get("BUY", 0) / total) * 100) if total else 0,
                 "bearish_bias": round((directions.get("SELL", 0) / total) * 100) if total else 0,
                 "risk_profile": "HIGH" if avg_risk >= 66 else "MEDIUM" if avg_risk >= 40 else "LOW",
+                "warnings_count": warnings_count,
+                "errors_count": errors_count,
             },
         }
         if include_opinions:

--- a/app/services/consensus/engine.py
+++ b/app/services/consensus/engine.py
@@ -69,7 +69,13 @@ class ConsensusEngine:
         wanted_timeframe = _norm_timeframe(timeframe)
         start = _date(date_from)
         end = _date(date_to)
-        videos = [v for v in self.media_catalog_loader() if _norm_symbol(v.get("symbol")) == wanted_symbol]
+        catalog = self.media_catalog_loader()
+        available_symbols = sorted({_norm_symbol(v.get("symbol")) or "MARKET" for v in catalog})
+        if wanted_symbol in {"", "ALL", "MARKET"}:
+            videos = list(catalog)
+            wanted_symbol = "MARKET"
+        else:
+            videos = [v for v in catalog if _norm_symbol(v.get("symbol")) == wanted_symbol]
         if wanted_timeframe:
             videos = [v for v in videos if _norm_timeframe(v.get("timeframe")) == wanted_timeframe]
         if start or end:
@@ -112,7 +118,9 @@ class ConsensusEngine:
             "opinions": opinions,
             "top_authors": self._leaderboard(opinions),
             "disagreements": self._disagreements(counts),
-            "market_summary": self._summary(wanted_symbol, wanted_timeframe or "все TF", overall, agreement, counts),
+            "market_summary": self._summary(wanted_symbol, wanted_timeframe or "все TF", overall, agreement, counts) if total else f"Нет видео по этому символу. Доступные символы: {', '.join(available_symbols) or 'нет'}",
+            "available_symbols": available_symbols,
+            "empty_message": None if total else f"Нет видео по этому символу. Доступные символы: {', '.join(available_symbols) or 'нет'}",
         }
 
     def _opinion(self, video: dict[str, Any]) -> dict[str, Any]:

--- a/app/services/investment_committee/engine.py
+++ b/app/services/investment_committee/engine.py
@@ -25,7 +25,16 @@ class InvestmentCommitteeEngine:
         video = next((item for item in self.media_catalog_loader() if str(item.get("id")) == str(video_id)), None)
         if not video:
             raise ValueError("TV video not found")
-        review_payload = self.review_payload_builder(video)
+        warnings: list[str] = []
+        try:
+            review_payload = self.review_payload_builder(video)
+        except Exception as exc:
+            review_payload = {"video": video}
+            warnings.append(f"review_payload_unavailable: {exc.__class__.__name__}: {exc}")
+        for key in ("transcript", "knowledge_context", "knowledge", "llm_review"):
+            value = review_payload.get(key)
+            if isinstance(value, dict) and (value.get("error") or value.get("status") in {"unavailable", "error"}):
+                warnings.append(f"{key}_warning: {value.get('error') or value.get('status')}")
         context = CommitteeInput(
             video=review_payload.get("video") or video,
             transcript=review_payload.get("transcript") or {},
@@ -33,4 +42,26 @@ class InvestmentCommitteeEngine:
             knowledge_layer=review_payload.get("knowledge_context") or review_payload.get("knowledge") or {},
             llm_review=review_payload.get("llm_review") or {},
         )
-        return self.provider.evaluate(context)
+        try:
+            report = self.provider.evaluate(context)
+        except Exception as exc:
+            warnings.append(f"committee_provider_unavailable: {exc.__class__.__name__}: {exc}")
+            report = InvestmentCommitteeReport(
+                video=video,
+                summary="Investment Committee работает в деградированном режиме: часть AI/knowledge слоёв недоступна.",
+                overall_score=0,
+                decision="WAIT",
+                signal_quality="D",
+                risk_level="HIGH",
+                agreement_score=0,
+                institutional_bias="NEUTRAL",
+                pros=[],
+                cons=["Недостаточно данных для полноценного committee review."],
+                conflicts=[],
+                committee_verdict="WATCH",
+                provider="rule-committee-degraded",
+            )
+        if warnings:
+            report.warnings.extend(warnings)
+            report.degraded = True
+        return report

--- a/app/services/investment_committee/models.py
+++ b/app/services/investment_committee/models.py
@@ -38,6 +38,8 @@ class InvestmentCommitteeReport(BaseModel):
     conflicts: list[str] = Field(default_factory=list)
     committee_verdict: CommitteeVerdict = "WATCH"
     provider: str = "rule-committee"
+    warnings: list[str] = Field(default_factory=list)
+    degraded: bool = False
     created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
     @field_validator("overall_score", "agreement_score", mode="before")

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -20,7 +20,7 @@ from app.services.youtube_source_resolver import YouTubeSourceResolver
 logger = logging.getLogger(__name__)
 
 SUPPORTED_SOURCE_TYPES = {"youtube", "telegram", "rss", "website", "podcast", "manual"}
-SUPPORTED_MEDIA_PROVIDERS = {"youtube_api", "youtube_ytdlp", "telegram_public", "telegram_bot", "rss_feed", "manual", "youtube", "youtube_manual", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
+SUPPORTED_MEDIA_PROVIDERS = {"youtube_api", "youtube_ytdlp", "auto", "telegram_public", "telegram_bot", "rss_feed", "manual", "youtube", "youtube_manual", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
 SYMBOLS = ("EURUSD", "GBPUSD", "USDJPY", "USDCHF", "USDCAD", "AUDUSD", "NZDUSD", "XAUUSD", "XAGUSD", "BTCUSD", "ETHUSD", "DXY", "US500", "NASDAQ", "GER40", "UK100")
 YOUTUBE_RSS_BY_CHANNEL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
 YOUTUBE_RSS_BY_USER = "https://www.youtube.com/feeds/videos.xml?user={user}"
@@ -348,7 +348,25 @@ class MediaImportEngine:
     def load_sources(self) -> list[MediaSource]:
         try: payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
         except FileNotFoundError: return []
+        payload = self._migrate_youtube_providers(payload)
         return self._validate_sources(payload)
+
+    def _migrate_youtube_providers(self, payload: Any) -> Any:
+        if not isinstance(payload, list):
+            return payload
+        should_migrate = bool(os.getenv("YOUTUBE_API_KEY")) or str(os.getenv("FXPILOT_YOUTUBE_PROVIDER") or "auto").strip().lower() == "auto"
+        if not should_migrate:
+            return payload
+        changed = False
+        migrated: list[Any] = []
+        for item in payload:
+            if isinstance(item, dict) and str(item.get("source_type") or self._infer_source_type(str(item.get("provider") or ""))).lower() == "youtube" and str(item.get("provider") or "").lower() == "youtube_ytdlp":
+                item = {**item, "provider": "auto"}
+                changed = True
+            migrated.append(item)
+        if changed:
+            self._atomic_write_json(self.sources_path, migrated)
+        return migrated
     def list_sources(self) -> list[dict[str, Any]]:
         catalog = self.load_catalog()
         debug_rows: dict[str, dict[str, Any]] = {}
@@ -481,6 +499,7 @@ class MediaImportEngine:
                     "skipped_reasons": active_diag.get("skipped_reasons", {}),
                     "skipped_items": active_diag.get("skipped_items", [])[:20],
                     "youtube_api_enabled": bool(os.getenv("YOUTUBE_API_KEY")),
+                    "api_key_detected": bool(os.getenv("YOUTUBE_API_KEY")),
                     "youtube_api_quota_used": api_diag.get("quota_used") if api_diag else result.quota_used,
                     "youtube_api_remaining_estimate": max(0, 10000 - int((api_diag.get("quota_used") if api_diag else result.quota_used) or 0)),
                     "resolved_channel_id": api_diag.get("resolved_channel_id") or result.source.channel_id,
@@ -614,6 +633,7 @@ class MediaImportEngine:
                 "provider_used": last_source_run.get("provider_used") or resolved.get("provider", source.provider),
                 "provider_fallback": bool(last_source_run.get("provider_fallback") or last_source_run.get("fallback_used")),
                 "youtube_api_enabled": bool(os.getenv("YOUTUBE_API_KEY")),
+                "api_key_detected": bool(os.getenv("YOUTUBE_API_KEY")),
                 "youtube_api_quota_used": last_source_run.get("youtube_api_quota_used") or last_source_run.get("quota_used"),
                 "youtube_api_remaining_estimate": last_source_run.get("youtube_api_remaining_estimate"),
                 "resolved_channel_id": last_source_run.get("resolved_channel_id") or channel_id,
@@ -669,6 +689,7 @@ class MediaImportEngine:
                     "provider_used": last_source_run.get("provider_used"),
                     "provider_fallback": bool(last_source_run.get("provider_fallback") or last_source_run.get("fallback_used")),
                     "youtube_api_enabled": bool(os.getenv("YOUTUBE_API_KEY")),
+                    "api_key_detected": bool(os.getenv("YOUTUBE_API_KEY")),
                     "youtube_api_quota_used": last_source_run.get("youtube_api_quota_used") or last_source_run.get("quota_used"),
                     "youtube_api_remaining_estimate": last_source_run.get("youtube_api_remaining_estimate"),
                     "resolved_channel_id": last_source_run.get("resolved_channel_id") or last_source_run.get("channel_id"),
@@ -762,11 +783,22 @@ class MediaImportEngine:
             return getattr(self.youtube_provider, "resolve")(channel_url)
         return self.youtube_provider.resolver.resolve(channel_url, validate_rss=True)
 
+    def _default_provider_for_source_type(self, source_type: str | None, provider: str | None = None) -> str:
+        explicit = str(provider or "").strip().lower()
+        stype = str(source_type or self._infer_source_type(explicit)).strip().lower()
+        if explicit:
+            if stype == "youtube" and explicit == "youtube_ytdlp" and (bool(os.getenv("YOUTUBE_API_KEY")) or str(os.getenv("FXPILOT_YOUTUBE_PROVIDER") or "auto").strip().lower() == "auto"):
+                return "auto"
+            return explicit
+        if stype == "youtube":
+            return "auto"
+        return explicit or "manual"
+
     def add_source(self, payload: dict[str, Any]) -> dict[str, Any]:
         name = self._required_str(payload, "name", 0)
         raw_id = str(payload.get("id") or name).strip().lower()
         source_id = re.sub(r"[^a-z0-9_]+", "_", raw_id).strip("_") or f"source_{len(self._read_json_list(self.sources_path))+1}"
-        provider = self._required_str(payload, "provider", 0).lower()
+        provider = self._default_provider_for_source_type(str(payload.get("source_type") or ""), str(payload.get("provider") or ""))
         source_type = str(payload.get("source_type") or self._infer_source_type(provider)).lower()
         if provider not in SUPPORTED_MEDIA_PROVIDERS:
             raise MediaConfigError(f"unsupported media provider: {provider}")
@@ -833,9 +865,11 @@ class MediaImportEngine:
 
     def resolve_provider(self, provider: str) -> MediaProvider:
         provider = (provider or "").lower()
-        if provider == "youtube":
+        if provider in {"youtube", "auto"}:
             mode = str(os.getenv("FXPILOT_YOUTUBE_PROVIDER") or "auto").strip().lower()
-            if not self._custom_youtube_provider and (mode == "ytdlp" or (mode == "auto" and not os.getenv("YOUTUBE_API_KEY"))):
+            if provider == "auto" and mode not in {"api", "youtube_api", "ytdlp", "youtube_ytdlp", "auto"}:
+                mode = "auto"
+            if not self._custom_youtube_provider and (mode in {"ytdlp", "youtube_ytdlp"} or (mode == "auto" and not os.getenv("YOUTUBE_API_KEY"))):
                 return self.ytdlp_provider
             return self.youtube_provider
         if provider == "youtube_api":
@@ -881,7 +915,7 @@ class MediaImportEngine:
             if not isinstance(item, dict): raise MediaConfigError(f"source #{index} must be an object")
             source_id = self._required_str(item, "id", index)
             if source_id in seen: raise MediaConfigError(f"duplicate media source id: {source_id}")
-            seen.add(source_id); provider = self._required_str(item, "provider", index).lower()
+            seen.add(source_id); provider = self._default_provider_for_source_type(str(item.get("source_type") or ""), str(item.get("provider") or ""))
             if provider not in SUPPORTED_MEDIA_PROVIDERS: raise MediaConfigError(f"unsupported media provider: {provider}")
             categories = item.get("categories")
             if not isinstance(categories, list) or not all(isinstance(v, str) and v.strip() for v in categories): raise MediaConfigError(f"source {source_id} categories must be strings")
@@ -905,7 +939,7 @@ class MediaImportEngine:
 
     @staticmethod
     def _infer_source_type(provider: str) -> str:
-        if provider.startswith("youtube") or provider == "youtube": return "youtube"
+        if provider.startswith("youtube") or provider in {"youtube", "auto"}: return "youtube"
         if provider.startswith("telegram"): return "telegram"
         if provider in {"rss", "rss_feed"}: return "rss"
         if provider in {"manual", "youtube_manual"}: return "manual"
@@ -972,7 +1006,7 @@ class MediaImportEngine:
         provider = str(item.get("provider") or "")
         if not allow_manual and (item.get("status") == "manual_demo" or provider in {"youtube_manual", "youtube-manual"}):
             return False
-        if provider in {"youtube", "youtube_api", "youtube_ytdlp", "youtube-rss"} or item.get("youtube_id"):
+        if provider in {"youtube", "youtube_api", "youtube_ytdlp", "auto", "youtube-rss"} or item.get("youtube_id"):
             youtube_id = str(item.get("youtube_id") or "").strip()
             return bool(youtube_id and not youtube_id.upper().startswith("DEMO"))
         return bool(str(item.get("url") or item.get("id") or "").strip())

--- a/app/services/performance/engine.py
+++ b/app/services/performance/engine.py
@@ -5,6 +5,7 @@ from statistics import mean
 from typing import Any, Callable
 
 from .evaluator import PerformanceEvaluator
+from .models import SignalOutcome
 
 class PerformanceEngine:
     def __init__(self, *, media_catalog_loader: Callable[[], list[dict[str, Any]]], review_payload_builder: Callable[[dict[str, Any]], dict[str, Any]], evaluator: PerformanceEvaluator | None = None, completion_hooks: list[Callable[[dict[str, Any]], None]] | None = None) -> None:
@@ -25,7 +26,14 @@ class PerformanceEngine:
         return {"author": author, "items": items, "summary": self._summary(items)}
 
     def _eval(self, video: dict[str, Any]):
-        outcome=self.evaluator.evaluate(video, self.review_payload_builder(video))
+        try:
+            review = self.review_payload_builder(video)
+        except Exception as exc:
+            return SignalOutcome(video_id=str(video.get("id") or ""), author=video.get("author") or video.get("source_id"), symbol=video.get("symbol"), status="review_unavailable", data_status="unavailable", warning_ru=f"Review слой недоступен: {exc.__class__.__name__}: {exc}", prediction={"direction": "UNKNOWN"})
+        try:
+            outcome=self.evaluator.evaluate(video, review)
+        except Exception as exc:
+            return SignalOutcome(video_id=str(video.get("id") or ""), author=video.get("author") or video.get("source_id"), symbol=video.get("symbol"), status="review_unavailable", data_status="unavailable", warning_ru=f"Performance evaluation failed: {exc.__class__.__name__}: {exc}", prediction={"direction": "UNKNOWN"})
         if outcome.status == "finished":
             payload=outcome.model_dump()
             for hook in self.completion_hooks: hook(payload)

--- a/app/static/consensus.html
+++ b/app/static/consensus.html
@@ -14,7 +14,7 @@
       <h1>Консенсус аналитиков по импортированным видео</h1>
       <p class="lead">Агрегация всех мнений по символу и таймфрейму с учётом Rule Analyzer, Knowledge Layer, LLM Review и Investment Committee.</p>
       <form id="consensusForm" class="consensus-form">
-        <label>Символ <input id="symbolInput" value="EURUSD" /></label>
+        <label>Символ <select id="symbolInput"><option value="MARKET">All / MARKET</option></select></label>
         <label>Таймфрейм <input id="timeframeInput" value="H4" /></label>
         <button type="submit">Обновить</button>
       </form>

--- a/app/static/consensus.js
+++ b/app/static/consensus.js
@@ -2,12 +2,14 @@ const root = document.getElementById('consensusRoot');
 const form = document.getElementById('consensusForm');
 const symbolInput = document.getElementById('symbolInput');
 const timeframeInput = document.getElementById('timeframeInput');
+const symbolSelect = symbolInput;
 const fmt = (v) => (v === null || v === undefined || v === '' ? '—' : v);
 function card(title, value, extra = '') { return `<article class="panel consensus-card"><p class="eyebrow">${title}</p><h2>${value}</h2>${extra}</article>`; }
 function render(data) {
   const authors = (data.top_authors || []).map((a) => `<tr><td>${a.author}</td><td>${a.historical_accuracy_label || 'placeholder'}</td><td>${a.current_confidence}%</td><td>${a.committee_score}</td><td>${a.latest_opinion}</td></tr>`).join('');
   const conflicts = (data.disagreements || []).map((x) => `<li>${x}</li>`).join('') || '<li>Явных конфликтов нет</li>';
   root.innerHTML = `
+    ${data.empty_message ? `<article class="panel consensus-wide"><strong>${data.empty_message}</strong></article>` : ''}
     ${card('Overall Consensus', data.overall_direction, `<p>Сила: ${data.consensus_strength}</p>`)}
     ${card('Agreement %', `${data.agreement_percent}%`)}
     ${card('Bullish %', `${data.bullish_percent}%`, `<p>${data.bullish_count} мнений</p>`)}
@@ -17,13 +19,21 @@ function render(data) {
     <article class="panel consensus-wide"><h2>Top Analysts</h2><table><thead><tr><th>Автор</th><th>Historical accuracy</th><th>Confidence</th><th>Committee</th><th>Latest</th></tr></thead><tbody>${authors || '<tr><td colspan="5">Нет данных</td></tr>'}</tbody></table></article>
     <article class="panel consensus-wide"><h2>Conflicts</h2><ul>${conflicts}</ul><p>${data.market_summary}</p></article>`;
 }
+async function initSymbols() {
+  const res = await fetch('/api/media', { headers: { Accept: 'application/json' }, cache: 'no-store' });
+  const payload = await res.json();
+  const videos = Array.isArray(payload) ? payload : (Array.isArray(payload.items) ? payload.items : []);
+  const symbols = [...new Set(videos.map((v) => (v.symbol || 'MARKET').toString().toUpperCase()).filter(Boolean))].sort();
+  symbolSelect.innerHTML = '<option value="MARKET">All / MARKET</option>' + symbols.map((s) => `<option value="${s}">${s}</option>`).join('');
+  symbolSelect.value = symbols.includes('MARKET') ? 'MARKET' : (symbols[0] || 'MARKET');
+}
 async function load() {
   root.innerHTML = '<article class="panel">Загрузка...</article>';
-  const symbol = encodeURIComponent(symbolInput.value.trim() || 'EURUSD');
+  const symbol = encodeURIComponent(symbolInput.value.trim() || 'MARKET');
   const tf = timeframeInput.value.trim();
   const url = tf ? `/api/consensus/${symbol}/${encodeURIComponent(tf)}` : `/api/consensus/${symbol}`;
   const res = await fetch(url);
   render(await res.json());
 }
 form.addEventListener('submit', (e) => { e.preventDefault(); load(); });
-load().catch(() => { root.innerHTML = '<article class="panel">Consensus временно недоступен.</article>'; });
+initSymbols().then(load).catch((error) => { console.error('Consensus init failed:', error); load().catch(() => { root.innerHTML = '<article class="panel">Consensus временно недоступен.</article>'; }); });

--- a/app/static/tv.html
+++ b/app/static/tv.html
@@ -89,7 +89,7 @@
       <footer class="tv-footer"><strong>FXPilot 2.0</strong><span>Not just signals.<br />Understanding the market.</span></footer>
     </div>
     <script src="/static/nav.js"></script>
-    <script src="/static/tv-components.js"></script>
-    <script src="/static/tv.js"></script>
+    <script src="/static/tv-components.js?v=media-v2"></script>
+    <script src="/static/tv.js?v=media-v2"></script>
   </body>
 </html>

--- a/app/static/tv.js
+++ b/app/static/tv.js
@@ -33,6 +33,17 @@
     { title: 'Options', match: (video) => isSameCategory(video, 'options') },
   ];
   const getNextVideo = () => { const index = filteredVideos.findIndex((video) => video.id === selectedId); return filteredVideos[index + 1] || filteredVideos[0] || null; };
+  const normalizeMediaPayload = (payload) => {
+    const raw = Array.isArray(payload) ? payload : (Array.isArray(payload?.items) ? payload.items : (Array.isArray(payload?.videos) ? payload.videos : (Array.isArray(payload?.data) ? payload.data : [])));
+    return raw.filter((video) => video && video.status === 'imported' && video.youtube_id);
+  };
+  const showRenderError = (error) => {
+    console.error('FXPilot TV render failed:', error);
+    const message = error?.message || String(error || 'unknown render error');
+    playerEl.innerHTML = `<div class="tv-player-empty"><strong>Ошибка отрисовки каталога</strong><span>${escapeHtml(message)}</span></div>`;
+    detailsEl.innerHTML = `<p class="section-text">JS exception: ${escapeHtml(message)}</p>`;
+    listEl.innerHTML = `<div class="tv-player-empty">Ошибка интерфейса: ${escapeHtml(message)}</div>`;
+  };
 
   function renderPlayer(video) {
     playerEl.innerHTML = PlayerSkeleton('Загрузка выбранного обзора...');
@@ -158,13 +169,18 @@
   fetch('/api/media', { headers: { Accept: 'application/json' }, cache: 'no-store' })
     .then((response) => { if (!response.ok) throw new Error('videos_unavailable'); return response.json(); })
     .then((payload) => {
-      videos = (Array.isArray(payload) ? payload : []).sort(byNewest);
+      videos = normalizeMediaPayload(payload).sort(byNewest);
+      console.log(`FXPilot TV loaded media items: ${videos.length}`);
       filteredVideos = videos;
-      renderFilters();
-      document.getElementById('tvVideoSearch')?.addEventListener('input', (event) => { query = event.target.value; renderList(); });
-      document.getElementById('tvCategoryFilter')?.addEventListener('change', (event) => { category = event.target.value; renderList(); selectVideo(filteredVideos[0]?.id); });
-      if (!videos.length) { renderList(); renderPlayer(null); renderDetails(null); return; }
-      selectVideo(videos[0] && videos[0].id);
+      try {
+        renderFilters();
+        document.getElementById('tvVideoSearch')?.addEventListener('input', (event) => { query = event.target.value; renderList(); });
+        document.getElementById('tvCategoryFilter')?.addEventListener('change', (event) => { category = event.target.value; renderList(); selectVideo(filteredVideos[0]?.id); });
+        if (!videos.length) { renderList(); renderPlayer(null); renderDetails(null); return; }
+        selectVideo(videos[0] && videos[0].id);
+      } catch (error) {
+        showRenderError(error);
+      }
     })
-    .catch(() => { videos = []; filteredVideos = []; if (countEl) countEl.textContent = '0 видео'; playerEl.innerHTML = '<div class="tv-player-empty"><strong>Каталог временно недоступен</strong><span>Не удалось загрузить локальный список видео. Попробуйте обновить страницу.</span></div>'; detailsEl.innerHTML = '<p class="section-text">Видеообзоры не загружены. Реальные рыночные данные не подменяются демо-контентом.</p>'; listEl.innerHTML = '<div class="tv-player-empty">Нет доступных видео.</div>'; });
+    .catch((error) => { console.error('FXPilot TV media load failed:', error); videos = []; filteredVideos = []; if (countEl) countEl.textContent = '0 из 0 видео'; playerEl.innerHTML = `<div class="tv-player-empty"><strong>Каталог временно недоступен</strong><span>${escapeHtml(error?.message || 'Не удалось загрузить локальный список видео.')}</span></div>`; detailsEl.innerHTML = '<p class="section-text">Видеообзоры не загружены. Реальные рыночные данные не подменяются демо-контентом.</p>'; listEl.innerHTML = '<div class="tv-player-empty">Нет доступных видео.</div>'; });
 })();

--- a/data/media_sources.json
+++ b/data/media_sources.json
@@ -2,7 +2,7 @@
   {
     "id": "gerchik",
     "name": "Gerchik & Co",
-    "provider": "youtube_ytdlp",
+    "provider": "auto",
     "channel_url": "https://www.youtube.com/@gerchikco9785",
     "language": "ru",
     "priority": 1,
@@ -16,7 +16,7 @@
   {
     "id": "instaforex",
     "name": "InstaForex",
-    "provider": "youtube_ytdlp",
+    "provider": "auto",
     "channel_url": "https://www.youtube.com/@instaforex",
     "language": "ru",
     "priority": 2,
@@ -30,7 +30,7 @@
   {
     "id": "traderevo",
     "name": "TraderEVO",
-    "provider": "youtube_ytdlp",
+    "provider": "auto",
     "channel_url": "https://www.youtube.com/@traderevo",
     "language": "ru",
     "priority": 2,
@@ -43,7 +43,7 @@
   {
     "id": "prosto_crypto",
     "name": "PROSTO КРИПТО",
-    "provider": "youtube_ytdlp",
+    "provider": "auto",
     "channel_url": "https://www.youtube.com/@prosto_kripto",
     "language": "ru",
     "priority": 2,
@@ -56,7 +56,7 @@
   {
     "id": "market_vector",
     "name": "Market Vector",
-    "provider": "youtube_ytdlp",
+    "provider": "auto",
     "channel_url": "https://www.youtube.com/@market_vector",
     "language": "ru",
     "priority": 2,
@@ -69,7 +69,7 @@
   {
     "id": "bazylev",
     "name": "Aleksandr Bazylev",
-    "provider": "youtube_ytdlp",
+    "provider": "auto",
     "channel_url": "https://www.youtube.com/@AleksandrBazylev",
     "language": "ru",
     "priority": 2,


### PR DESCRIPTION
### Motivation
- Устранить проблему, когда страница `/tv` не отображает импортированные видео и скрывает ошибки, а также обеспечить корректную миграцию/выбор YouTube-провайдера и защиту AI-слоёв от краха при недоступных зависимостях. 

### Description
- Добавлен cache-busting для `tv-components.js` и `tv.js` в `tv.html` и улучшен `tv.js`: нормализация `/api/media` (поддержка array/object payload), фильтрация только `status === 'imported'` c наличием `youtube_id`, лог `FXPilot TV loaded media items: N`, счётчик `N из N видео` и видимая обработка JS-исключений с выводом ошибки в UI. 
- В `media_import_engine` введён провайдер `auto`, одна-сторонняя миграция `youtube_ytdlp -> auto` при обнаружении `YOUTUBE_API_KEY` или режиме `auto`, добавлен `default_provider` для новых источников и расширен отладочный вывод (`provider_selected`, `provider_used`, `youtube_api_enabled`, `api_key_detected`, `fallback_reason`). 
- Защитил `InvestmentCommitteeEngine` чтобы он никогда не 500: при ошибках review/LLM/knowledge возвращается деградированный `InvestmentCommitteeReport` с `warnings` и `degraded=true`. 
- Защитил `AuthorIntelligenceEngine` от падений по одному видео: ловятся исключения при сборе payload/committee, формируются per-video `warnings` и поля агрегата `warnings_count`/`errors_count`. 
- Защитил `PerformanceEngine` так, чтобы ошибки review/evaluation не ломали `/api/performance`, а возвращался элемент со статусом `review_unavailable` и понятным `warning_ru`. 
- Обновлён `Consensus` и фронт: по умолчанию поддержка `MARKET`/All flow, backend возвращает `available_symbols` и понятное `empty_message` если нет совпадений, а `consensus` frontend получает селект `All / MARKET` и динамически заполняет символы из `/api/media`.

### Testing
- Выполнена компиляция Python модулей: `python3 -m compileall app` (успешно). 
- Проверка синтаксиса фронтенда: `node --check app/static/tv.js` и `node --check app/static/consensus.js` (успешно). 
- Автоматизированные «smoke» проверки поведений движков (дефенсивные сценарии): скрипты, которые имитируют недоступность review/committee/evaluator и проверяют, что Committee помечается `degraded`, Authors возвращают fallback `WAIT`, Performance помечает `review_unavailable`, Consensus возвращает понятное `empty_message` — все проверки прошли. 
- Проверка отладочного вывода `media_import_engine.debug_sources()` показала корректный выбор провайдера (`auto`) и вывод полей провайдера/фоллбэка; в этом окружении импорт приложения отмечает отсутствие системной зависимости `apscheduler`, что не связано с внесёнными изменениями (предупреждение окружения).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbde1c1b08331b67bb1d1324423f1)