### PR TITLE
Исправить генерацию AI Review после импорта медиа

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -873,7 +873,7 @@ def api_media_resolve_all() -> dict[str, Any]:
 
 def _run_automatic_media_pipeline(item: dict[str, Any]) -> dict[str, Any]:
     """Run the automatic Import → Transcript → AI → Knowledge → Review → Committee pipeline for one item."""
-    video_id = str(item.get("youtube_id") or item.get("id") or "")
+    video_id = str(item.get("id") or item.get("youtube_id") or "")
     if not video_id:
         return {"status": "skipped", "reason": "missing_video_id"}
     transcript = _review_transcript_payload(item)
@@ -898,9 +898,34 @@ def _run_automatic_media_pipeline(item: dict[str, Any]) -> dict[str, Any]:
         "performance": performance,
     }
 
+def _generate_reviews_for_imported_items(video_ids: list[str]) -> dict[str, Any]:
+    """Generate cached AI Reviews for freshly imported catalog items using the existing ReviewEngine."""
+    unique_ids = [video_id for video_id in dict.fromkeys(str(item or "") for item in video_ids) if video_id]
+    result: dict[str, Any] = {"requested": len(unique_ids), "generated": 0, "failed": 0, "items": []}
+    if not unique_ids:
+        return result
+
+    engine = create_llm_review_engine()
+    for video_id in unique_ids:
+        logger.info("media_import_review_generation_start video_id=%s", video_id)
+        try:
+            review = engine.generate(video_id)
+        except Exception as exc:
+            logger.exception("media_import_review_generation_failed video_id=%s", video_id)
+            result["failed"] += 1
+            result["items"].append({"video_id": video_id, "status": "failed", "error": str(exc), "exception_type": exc.__class__.__name__})
+            continue
+        result["generated"] += 1
+        result["items"].append({"video_id": video_id, "status": "generated", "provider": review.provider})
+        logger.info("media_import_review_generation_done video_id=%s provider=%s", video_id, review.provider)
+    return result
+
+
 def _run_media_import() -> dict[str, Any]:
     engine = create_media_import_engine()
-    return engine.import_latest()
+    result = engine.import_latest()
+    result["review_generation"] = _generate_reviews_for_imported_items(result.get("new_item_ids") or [])
+    return result
 
 
 @app.post("/api/media/import")

--- a/tests/test_llm_review.py
+++ b/tests/test_llm_review.py
@@ -102,3 +102,53 @@ def test_review_endpoint_includes_llm_review(monkeypatch, tmp_path):
     response = TestClient(main.app).get("/api/media/review/v1")
     assert response.status_code == 200
     assert response.json()["llm_review"]["provider"] == "mock"
+
+
+def test_media_import_generates_reviews_for_new_catalog_items(monkeypatch):
+    import app.main as main
+
+    calls = []
+
+    class FakeImportEngine:
+        def import_latest(self):
+            return {"success": True, "new_item_ids": ["youtube:abc12345678"], "imported": 1}
+
+    class FakeReviewEngine:
+        def generate(self, video_id):
+            calls.append(video_id)
+            return LLMReview(summary="Generated after import", provider="mock")
+
+    monkeypatch.setattr(main, "create_media_import_engine", lambda: FakeImportEngine())
+    monkeypatch.setattr(main, "create_llm_review_engine", lambda: FakeReviewEngine())
+
+    result = main._run_media_import()
+
+    assert calls == ["youtube:abc12345678"]
+    assert result["review_generation"]["generated"] == 1
+    assert result["review_generation"]["items"][0]["video_id"] == "youtube:abc12345678"
+
+
+def test_automatic_media_pipeline_uses_catalog_id_for_review_generation(monkeypatch):
+    import app.main as main
+
+    item = {"id": "youtube:abc12345678", "youtube_id": "abc12345678", "description": "Buy EURUSD", "symbol": "EURUSD", "author": "Desk"}
+    calls = []
+
+    class FakeReviewEngine:
+        def generate(self, video_id):
+            calls.append(video_id)
+            return LLMReview(summary="Generated", provider="mock")
+
+    monkeypatch.setattr(main, "_review_transcript_payload", lambda video: {"status": "FOUND", "text": "Buy EURUSD"})
+    monkeypatch.setattr(main.ai_analyzer_engine, "analyze", lambda transcript, metadata: AIReview(video_id=metadata["video_id"], symbol="EURUSD", direction="BUY"))
+    monkeypatch.setattr(main, "_build_knowledge_for_video", lambda video_id: type("Knowledge", (), {"model_dump": lambda self: {"agreement_score": 80}})())
+    monkeypatch.setattr(main, "create_llm_review_engine", lambda: FakeReviewEngine())
+    monkeypatch.setattr(main, "InvestmentCommitteeEngine", lambda **kwargs: type("Committee", (), {"build_for_video": lambda self, video_id: type("Report", (), {"model_dump": lambda self: {}})()})())
+    monkeypatch.setattr(main, "create_consensus_engine", lambda: type("Consensus", (), {"build": lambda self, symbol: {}})())
+    monkeypatch.setattr(main, "create_author_intelligence_engine", lambda: type("Author", (), {"build_for_author": lambda self, author: {}})())
+    monkeypatch.setattr(main, "create_performance_engine", lambda: type("Performance", (), {"evaluate_video": lambda self, video_id: {}})())
+
+    result = main._run_automatic_media_pipeline(item)
+
+    assert calls == ["youtube:abc12345678"]
+    assert result["video_id"] == "youtube:abc12345678"


### PR DESCRIPTION
### Motivation
- После импорта новых видео (`/api/media/import-now`) кэшированные AI-ревью не создавались, поэтому страница `/tv/review/{video_id}` всегда показывала «Review not found». 
- При трассировке показано, что поток выполнения останавливался после `MediaImportEngine.import_latest()` и не вызывал уже существующий `ReviewEngine`.
- Нужно минимально подключить существующую логику генерации review после импорта без изменения архитектуры или контрактов API.

### Description
- Добавлена функция `_generate_reviews_for_imported_items(video_ids)` в `app/main.py`, которая вызывает существующий `ReviewEngine` для списка новых `video_id` и логирует начало/успех/ошибки по каждому видео. 
- Обновлён `_run_media_import()` в `app/main.py`, чтобы после `engine.import_latest()` выполнять генерацию review и возвращать результат в поле `review_generation` в ответе, сохраняя обратносовместимость. 
- Исправлен выбор `video_id` в автоматическом пайплайне `_run_automatic_media_pipeline()` так, чтобы сначала использовать каталожный `id` (совпадает с ключом хранения review), а затем `youtube_id`, чтобы избежать несоответствия ключей при генерации/поиске review. 
- Добавлены регрессионные тесты в `tests/test_llm_review.py`, проверяющие генерацию review после импорта и использование catalog `id` в автоматическом пайплайне.

### Testing
- Запущены `pytest tests/test_llm_review.py` и `pytest tests/test_media_import_engine.py`, оба набора тестов прошли успешно. 
- Тесты покрывают: вызов `ReviewEngine.generate()` для `new_item_ids` после импорта и корректную передачу `id` в `_run_automatic_media_pipeline()`; все новые и существующие проверки прошли. 
- Локальная зависимость `apscheduler` установлена для корректного запуска полного тестового набора в окружении сборки.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd86c5a9c8331a8d638b3bda10add)