### PR TITLE
Автоматический pipeline анализа FXPilot TV

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -52,6 +52,7 @@ from app.services.investment_committee import InvestmentCommitteeEngine
 from app.services.consensus import ConsensusEngine
 from app.services.author_intelligence import AuthorIntelligenceEngine
 from app.services.performance import PerformanceEngine
+from app.services.pipeline import PipelineEngine, PipelineRunner, PipelineStorage
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,7 @@ MEDIA_CATALOG_PATH = BASE_DIR.parent / "data" / "media_catalog.json"
 MEDIA_TV_VIDEOS_PATH = BASE_DIR.parent / "data" / "tv_videos.json"
 MEDIA_MANUAL_YOUTUBE_PATH = BASE_DIR.parent / "data" / "manual_youtube_videos.json"
 MEDIA_DEBUG_PATH = BASE_DIR.parent / "data" / "media_import_debug.json"
+PIPELINE_STORAGE_PATH = BASE_DIR.parent / "data" / "pipeline"
 
 def create_media_import_engine() -> MediaImportEngine:
     manual_path = MEDIA_MANUAL_YOUTUBE_PATH if os.getenv("FXPILOT_DEV_MANUAL_MEDIA", "").strip().lower() in {"1", "true", "yes", "on", "dev"} else None
@@ -853,7 +855,14 @@ def api_media_test_source_now(source_id: str) -> dict[str, Any]:
 @app.post("/api/media/sources/{source_id}/import")
 def api_media_import_source(source_id: str) -> dict[str, Any]:
     try:
-        return create_media_import_engine().import_source(source_id)
+        engine = create_media_import_engine()
+        before_ids = {str(item.get("id") or "") for item in engine.load_catalog() if item.get("id")}
+        result = engine.import_source(source_id)
+        new_ids = [str(item.get("id") or "") for item in engine.load_catalog() if item.get("id") and str(item.get("id")) not in before_ids]
+        pipeline_results = [create_pipeline_runner().run(video_id) for video_id in new_ids]
+        result["pipeline_processed"] = len(pipeline_results)
+        result["pipeline_results"] = pipeline_results
+        return result
     except MediaConfigError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -872,35 +881,26 @@ def api_media_resolve_all() -> dict[str, Any]:
 
 
 def _run_automatic_media_pipeline(item: dict[str, Any]) -> dict[str, Any]:
-    """Run the automatic Import → Transcript → AI → Knowledge → Review → Committee pipeline for one item."""
-    video_id = str(item.get("youtube_id") or item.get("id") or "")
+    """Run the automatic Import → Transcript → Rule AI → Knowledge → Review → Committee pipeline for one item."""
+    video_id = str(item.get("id") or item.get("youtube_id") or "")
     if not video_id:
-        return {"status": "skipped", "reason": "missing_video_id"}
-    transcript = _review_transcript_payload(item)
-    analysis = ai_analyzer_engine.analyze(str(transcript.get("text") or item.get("description") or ""), {**item, "video_id": video_id}).to_dict()
-    knowledge = _build_knowledge_for_video(video_id).model_dump()
-    review = create_llm_review_engine().generate(video_id).model_dump()
-    committee = InvestmentCommitteeEngine(media_catalog_loader=_load_tv_video_catalog, review_payload_builder=_build_tv_review_payload).build_for_video(video_id).model_dump()
-    consensus = create_consensus_engine().build(str(item.get("symbol") or "MARKET"))
-    author = create_author_intelligence_engine().build_for_author(str(item.get("author") or item.get("source_id") or "Unknown"))
-    performance = create_performance_engine().evaluate_video(video_id)
-    return {
-        "status": "published",
-        "video_id": video_id,
-        "steps": ["import", "transcript", "rule_ai", "knowledge", "llm_review", "committee", "consensus", "author_intelligence", "performance", "publish_to_tv"],
-        "transcript_status": transcript.get("status"),
-        "analysis": analysis,
-        "knowledge": knowledge,
-        "llm_review": review,
-        "committee": committee,
-        "consensus": consensus,
-        "author_intelligence": author,
-        "performance": performance,
-    }
+        return {"pipeline_status": "skipped", "reason": "missing_video_id"}
+    return PipelineRunner(create_pipeline_engine()).run(video_id)
 
 def _run_media_import() -> dict[str, Any]:
     engine = create_media_import_engine()
-    return engine.import_latest()
+    before_ids = {str(item.get("id") or "") for item in engine.load_catalog() if item.get("id")}
+    result = engine.import_latest()
+    after = engine.load_catalog()
+    new_ids = [str(item.get("id") or "") for item in after if item.get("id") and str(item.get("id")) not in before_ids]
+    if not new_ids:
+        new_ids = [str(item) for item in result.get("new_item_ids") or [] if item]
+    pipeline_results = []
+    for video_id in new_ids:
+        pipeline_results.append(PipelineRunner(create_pipeline_engine()).run(video_id))
+    result["pipeline_processed"] = len(pipeline_results)
+    result["pipeline_results"] = pipeline_results
+    return result
 
 
 @app.post("/api/media/import")
@@ -941,6 +941,7 @@ def api_media_debug() -> dict[str, Any]:
         payload = create_media_import_engine().debug_sources()
         payload.update(transcript_engine.debug_payload())
         payload.update(MEDIA_KNOWLEDGE_DEBUG)
+        payload.update(PipelineStorage(PIPELINE_STORAGE_PATH).metrics())
         return payload
     except MediaConfigError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -1078,6 +1079,48 @@ def create_performance_engine() -> PerformanceEngine:
         review_payload_builder=_build_tv_review_payload,
         completion_hooks=[_performance_completion_hook],
     )
+
+
+def create_pipeline_engine() -> PipelineEngine:
+    return PipelineEngine(
+        media_catalog_loader=_load_tv_video_catalog,
+        transcript_engine=transcript_engine,
+        ai_analyzer_engine=ai_analyzer_engine,
+        knowledge_engine_factory=lambda: KnowledgeEngine(
+            media_catalog_loader=_load_tv_video_catalog,
+            transcript_engine=transcript_engine,
+            ai_analyzer_engine=ai_analyzer_engine,
+            market_payload_loader=ideas_market,
+        ),
+        review_engine_factory=create_llm_review_engine,
+        committee_engine_factory=lambda: InvestmentCommitteeEngine(
+            media_catalog_loader=_load_tv_video_catalog,
+            review_payload_builder=_build_tv_review_payload,
+        ),
+        consensus_engine_factory=create_consensus_engine,
+        author_intelligence_engine_factory=create_author_intelligence_engine,
+        performance_engine_factory=create_performance_engine,
+        storage=PipelineStorage(PIPELINE_STORAGE_PATH),
+    )
+
+
+def create_pipeline_runner() -> PipelineRunner:
+    return PipelineRunner(create_pipeline_engine())
+
+
+@app.post("/api/pipeline/run/{video_id}")
+def api_pipeline_run(video_id: str) -> dict[str, Any]:
+    return create_pipeline_runner().run(video_id)
+
+
+@app.post("/api/pipeline/run-all")
+def api_pipeline_run_all() -> dict[str, Any]:
+    return create_pipeline_runner().run_all()
+
+
+@app.get("/api/pipeline/{video_id}")
+def api_pipeline_status(video_id: str) -> dict[str, Any]:
+    return create_pipeline_runner().status(video_id)
 
 
 @app.get("/api/performance")

--- a/app/services/pipeline/__init__.py
+++ b/app/services/pipeline/__init__.py
@@ -1,0 +1,6 @@
+from app.services.pipeline.engine import PipelineEngine
+from app.services.pipeline.models import PIPELINE_STEPS, PipelineResult
+from app.services.pipeline.runner import PipelineRunner
+from app.services.pipeline.storage import PipelineStorage
+
+__all__ = ["PIPELINE_STEPS", "PipelineEngine", "PipelineResult", "PipelineRunner", "PipelineStorage"]

--- a/app/services/pipeline/engine.py
+++ b/app/services/pipeline/engine.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable
+
+from app.services.pipeline.models import PipelineResult, utc_now_iso
+from app.services.pipeline.storage import PipelineStorage
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineEngine:
+    """Fault-tolerant orchestrator for existing FXPilot TV engines."""
+
+    def __init__(
+        self,
+        *,
+        media_catalog_loader: Callable[[], list[dict[str, Any]]],
+        transcript_engine: Any,
+        ai_analyzer_engine: Any,
+        knowledge_engine_factory: Callable[[], Any],
+        review_engine_factory: Callable[[], Any],
+        committee_engine_factory: Callable[[], Any],
+        consensus_engine_factory: Callable[[], Any],
+        author_intelligence_engine_factory: Callable[[], Any],
+        performance_engine_factory: Callable[[], Any],
+        storage: PipelineStorage | None = None,
+    ) -> None:
+        self.media_catalog_loader = media_catalog_loader
+        self.transcript_engine = transcript_engine
+        self.ai_analyzer_engine = ai_analyzer_engine
+        self.knowledge_engine_factory = knowledge_engine_factory
+        self.review_engine_factory = review_engine_factory
+        self.committee_engine_factory = committee_engine_factory
+        self.consensus_engine_factory = consensus_engine_factory
+        self.author_intelligence_engine_factory = author_intelligence_engine_factory
+        self.performance_engine_factory = performance_engine_factory
+        self.storage = storage or PipelineStorage()
+
+    def run(self, video_id: str) -> dict[str, Any]:
+        started = time.monotonic()
+        result = PipelineResult(video_id=str(video_id), pipeline_status="running", started_at=utc_now_iso())
+        self.storage.set(result)
+        logger.info("Pipeline started video_id=%s", video_id)
+        video = self._find_video(video_id)
+        if not video:
+            result.pipeline_status = "failed"
+            result.errors.append("TV video not found")
+            result.finished_at = utc_now_iso()
+            result.execution_time = round(time.monotonic() - started, 3)
+            self.storage.set(result)
+            return result.to_dict()
+
+        transcript_text = ""
+        transcript_id = str(video.get("youtube_id") or video.get("id") or video_id)
+
+        transcript = self._stage(result, "transcript", "transcript_status", "Transcript completed", lambda: self.transcript_engine.get(transcript_id))
+        if transcript is not None:
+            transcript_text = str(getattr(transcript, "transcript", "") or "")
+            result.transcript_status = getattr(getattr(transcript, "status", None), "value", result.transcript_status)
+
+        self._stage(result, "rule_ai", "rule_ai_status", "Rule AI completed", lambda: self.ai_analyzer_engine.analyze(transcript_text, {**video, "video_id": video.get("id")}))
+        self._stage(result, "knowledge", "knowledge_status", "Knowledge completed", lambda: self.knowledge_engine_factory().build_for_video(str(video.get("id") or video_id)))
+        self._stage(result, "llm_review", "review_status", "LLM Review completed", lambda: self.review_engine_factory().generate(str(video.get("id") or video_id), force=True))
+        self._stage(result, "committee", "committee_status", "Committee completed", lambda: self.committee_engine_factory().build_for_video(str(video.get("id") or video_id)))
+        self._stage(result, "consensus", "consensus_status", "Consensus completed", lambda: self.consensus_engine_factory().build(str(video.get("symbol") or "MARKET")))
+        self._stage(result, "author_intelligence", "author_status", "Author Intelligence completed", lambda: self.author_intelligence_engine_factory().build_for_author(str(video.get("author") or video.get("source_id") or "Unknown")))
+        self._stage(result, "performance", "performance_status", "Performance completed", lambda: self.performance_engine_factory().evaluate_video(str(video.get("id") or video_id)))
+
+        result.pipeline_status = "completed" if not result.failed_steps else ("completed_with_warnings" if result.completed_steps else "failed")
+        result.finished_at = utc_now_iso()
+        result.execution_time = round(time.monotonic() - started, 3)
+        self.storage.set(result)
+        logger.info("Pipeline finished video_id=%s status=%s execution_time=%s", video_id, result.pipeline_status, result.execution_time)
+        return result.to_dict()
+
+    def status(self, video_id: str) -> dict[str, Any]:
+        stored = self.storage.get(video_id) or PipelineResult.empty(video_id)
+        return stored.to_dict()
+
+    def _stage(self, result: PipelineResult, step: str, status_attr: str, log_message: str, func: Callable[[], Any]) -> Any:
+        try:
+            value = func()
+            setattr(result, status_attr, "completed")
+            result.completed_steps.append(step)
+            result.artifacts[step] = self._compact(value)
+            logger.info("%s video_id=%s", log_message, result.video_id)
+            self.storage.set(result)
+            return value
+        except Exception as exc:
+            setattr(result, status_attr, "failed")
+            result.failed_steps.append(step)
+            message = f"{step}: {exc.__class__.__name__}: {exc}"
+            result.errors.append(message)
+            result.warnings.append(message)
+            logger.exception("pipeline_stage_failed step=%s video_id=%s", step, result.video_id)
+            self.storage.set(result)
+            return None
+
+    def _find_video(self, video_id: str) -> dict[str, Any] | None:
+        wanted = str(video_id)
+        return next((v for v in self.media_catalog_loader() if str(v.get("id")) == wanted or str(v.get("youtube_id")) == wanted), None)
+
+    def _compact(self, value: Any) -> Any:
+        if hasattr(value, "model_dump"):
+            value = value.model_dump()
+        elif hasattr(value, "to_dict"):
+            value = value.to_dict()
+        if isinstance(value, dict):
+            return {k: value.get(k) for k in list(value.keys())[:20]}
+        return str(value)[:500]

--- a/app/services/pipeline/models.py
+++ b/app/services/pipeline/models.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+PIPELINE_STEPS = [
+    "transcript",
+    "rule_ai",
+    "knowledge",
+    "llm_review",
+    "committee",
+    "consensus",
+    "author_intelligence",
+    "performance",
+]
+
+
+@dataclass
+class PipelineResult:
+    video_id: str
+    pipeline_status: str = "pending"
+    transcript_status: str = "pending"
+    rule_ai_status: str = "pending"
+    knowledge_status: str = "pending"
+    review_status: str = "pending"
+    committee_status: str = "pending"
+    consensus_status: str = "pending"
+    author_status: str = "pending"
+    performance_status: str = "pending"
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    completed_steps: list[str] = field(default_factory=list)
+    failed_steps: list[str] = field(default_factory=list)
+    execution_time: float = 0.0
+    started_at: str | None = None
+    finished_at: str | None = None
+    artifacts: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def empty(cls, video_id: str) -> "PipelineResult":
+        return cls(video_id=video_id, pipeline_status="not_started")
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/app/services/pipeline/runner.py
+++ b/app/services/pipeline/runner.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.pipeline.engine import PipelineEngine
+
+
+class PipelineRunner:
+    def __init__(self, engine: PipelineEngine) -> None:
+        self.engine = engine
+
+    def run(self, video_id: str) -> dict[str, Any]:
+        return self.engine.run(video_id)
+
+    def run_all(self) -> dict[str, Any]:
+        results = []
+        for video in self.engine.media_catalog_loader():
+            video_id = str(video.get("id") or video.get("youtube_id") or "")
+            if video_id:
+                results.append(self.run(video_id))
+        return {"processed": len(results), "results": results}
+
+    def status(self, video_id: str) -> dict[str, Any]:
+        return self.engine.status(video_id)

--- a/app/services/pipeline/storage.py
+++ b/app/services/pipeline/storage.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.services.pipeline.models import PipelineResult
+
+
+class PipelineStorage:
+    def __init__(self, root: Path | str = "data/pipeline") -> None:
+        self.root = Path(root)
+
+    def get(self, video_id: str) -> PipelineResult | None:
+        path = self._path(video_id)
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return PipelineResult(**payload)
+
+    def set(self, result: PipelineResult) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        path = self._path(result.video_id)
+        tmp = path.with_name(f".{path.name}.tmp")
+        tmp.write_text(json.dumps(result.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+    def all(self) -> list[PipelineResult]:
+        if not self.root.exists():
+            return []
+        rows: list[PipelineResult] = []
+        for path in self.root.glob("*.json"):
+            try:
+                rows.append(PipelineResult(**json.loads(path.read_text(encoding="utf-8"))))
+            except Exception:
+                continue
+        return rows
+
+    def metrics(self) -> dict[str, Any]:
+        rows = self.all()
+        finished = [r for r in rows if r.pipeline_status in {"completed", "completed_with_warnings", "failed"}]
+        times = [float(r.execution_time or 0) for r in finished if r.execution_time]
+        last = sorted(finished, key=lambda r: r.finished_at or "", reverse=True)[:1]
+        failed = [r for r in rows if r.pipeline_status == "failed" or r.failed_steps]
+        return {
+            "pipeline_running": len([r for r in rows if r.pipeline_status == "running"]),
+            "pipeline_completed": len([r for r in rows if r.pipeline_status in {"completed", "completed_with_warnings"}]),
+            "pipeline_failed": len(failed),
+            "pipeline_average_time": round(sum(times) / len(times), 3) if times else 0,
+            "last_pipeline_video": last[0].video_id if last else None,
+            "last_pipeline_error": (failed[-1].errors[-1] if failed and failed[-1].errors else None),
+        }
+
+    def _path(self, video_id: str) -> Path:
+        safe = "".join(ch for ch in str(video_id) if ch.isalnum() or ch in {"_", "-"}) or "unknown"
+        return self.root / f"{safe}.json"

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -177,7 +177,15 @@
     root.innerHTML = ReviewPage(review, transcript);
   }
 
-  loadReview().catch(() => {
-    root.innerHTML = '<section class="panel"><div class="tv-player-empty">Review не найден. Вернитесь в каталог FXPilot TV и выберите другой обзор.</div></section>';
+  loadReview().catch(async () => {
+    root.innerHTML = '<section class="panel"><div class="tv-player-empty">AI pipeline запускается автоматически. Подождите несколько секунд…</div></section>';
+    try {
+      const videoId = getVideoId();
+      const pipeline = await fetch(`/api/pipeline/run/${encodeURIComponent(videoId)}`, { method: 'POST', headers: { Accept: 'application/json' }, cache: 'no-store' });
+      if (!pipeline.ok) throw new Error('pipeline_failed');
+      await loadReview();
+    } catch (error) {
+      root.innerHTML = '<section class="panel"><div class="tv-player-empty">Review не найден: AI pipeline завершился с ошибкой.</div></section>';
+    }
   });
 })();


### PR DESCRIPTION
### Motivation
- Импортированные видео не обрабатывались автоматически, из‑за чего страницы `/tv/review/{video_id}`, `/committee`, `/consensus`, `/authors` и `/performance` показывали пустые данные; цель — объединить существующие движки в последовательный автоматический pipeline без переписывания бизнес‑логики.

### Description
- Добавлен оркестратор pipeline в `app/services/pipeline/` с файлами `engine.py`, `runner.py`, `models.py`, `storage.py`, реализующий пошаговую последовательность: `transcript` → `rule_ai` → `knowledge` → `llm_review` → `committee` → `consensus` → `author_intelligence` → `performance`.
- Пайплайн повторно использует существующие сервисы без изменений: `TranscriptEngine`, `AIAnalyzerEngine`, `KnowledgeEngine`, `ReviewEngine` (LLM), `InvestmentCommitteeEngine`, `ConsensusEngine`, `AuthorIntelligenceEngine`, `PerformanceEngine`.
- Интеграция автозапуска: после импорта медиаданных pipeline запускается автоматически в `create_media_import_engine`/`_run_media_import()` и для по‑источников через `api_media_import_source`; существующий планировщик (`MediaAutomationService`) передаёт импортированные элементы в `_run_automatic_media_pipeline`, который теперь делегирует `PipelineRunner`.
- Добавлены публичные API‑методы: `POST /api/pipeline/run/{video_id}`, `POST /api/pipeline/run-all`, `GET /api/pipeline/{video_id}` и расширена отладочная выдача `GET /api/media/debug` метриками pipeline через `PipelineStorage`.
- UI: обновлён `app/static/tv-review.js`, чтобы при отсутствии review автоматически вызывать `POST /api/pipeline/run/{video_id}` и отобразить результат только при неудаче.
- Надёжность: каждая стадия обёрнута в защитную обёртку; ошибки/предупреждения/успешные шаги сохраняются в `PipelineResult` и в JSON‑хранилище, выполнение продолжается при падении отдельной стадии.

### Testing
- Скомпилированы изменённые модули: `python3 -m py_compile app/main.py app/services/pipeline/*.py` (успешно).
- Первичный запуск тестов выявил отсутствие `apscheduler` в окружении; зависимость установлена в тестовой среде (`pip install apscheduler`).
- Запущены целевые тесты: `pytest tests/test_transcript_engine.py tests/test_llm_review.py tests/test_consensus_engine.py tests/test_author_intelligence.py tests/test_performance_engine.py` и все тесты прошли успешно (в итоговом прогоне — все указанные тесты `passed`).
- Логирование добавлено для этапов: `Pipeline started`, `Transcript completed`, `Rule AI completed`, `Knowledge completed`, `LLM Review completed`, `Committee completed`, `Consensus completed`, `Author Intelligence completed`, `Performance completed`, `Pipeline finished` (см. записи в `engine.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd995aee88331b7a2a55522ecac2d)