### PR TITLE
Fix media review ID resolution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,7 @@ from app.services.timing import timing_log
 from app.services.ai_runtime_status import get_ai_status, record_ai_request_failure, record_ai_request_start, record_ai_request_success, run_ai_test_request, startup_ai_healthcheck
 from app.services.visitor_counter import get_visit_stats, increment_visit
 from app.services.tv_source_manager import TvSourceConfigError, TvSourceManager
+from app.services.media_identity import canonical_catalog_id, canonical_youtube_id, resolve_media_video as _resolve_media_video_from_catalog
 from app.services.media_import_engine import MediaConfigError, MediaImportEngine
 from app.services.media_automation import MediaAutomationService
 from app.services.transcript import TranscriptEngine, TranscriptStorage
@@ -165,7 +166,7 @@ media_automation_service = MediaAutomationService(
 )
 transcript_engine = TranscriptEngine(storage=TranscriptStorage(BASE_DIR.parent / "data" / "transcripts"))
 ai_analyzer_engine = AIAnalyzerEngine()
-MEDIA_KNOWLEDGE_DEBUG = {"knowledge_requests": 0, "knowledge_errors": 0, "last_knowledge_video_id": None, "last_agreement_score": None}
+MEDIA_KNOWLEDGE_DEBUG = {"knowledge_requests": 0, "knowledge_errors": 0, "last_knowledge_video_id": None, "last_agreement_score": None, "last_review_video_id": None, "last_review_catalog_id": None, "last_review_youtube_id": None, "review_storage_keys_count": 0, "review_lookup_strategy": None}
 LLM_REVIEW_STORAGE = LLMReviewStorage(BASE_DIR.parent / "data" / "llm_reviews")
 
 class _AnalyticsNewsConnector:
@@ -533,6 +534,22 @@ def _load_tv_video_catalog() -> list[dict[str, Any]]:
         logger.warning("media_catalog_unavailable error=%s", exc)
         return []
 
+
+
+def resolve_media_video(video_id: str) -> dict[str, Any] | None:
+    return _resolve_media_video_from_catalog(video_id, _load_tv_video_catalog())
+
+
+def _review_lookup_debug(video_id: str, video: dict[str, Any] | None, strategy: str) -> None:
+    MEDIA_KNOWLEDGE_DEBUG["last_review_video_id"] = video_id
+    MEDIA_KNOWLEDGE_DEBUG["last_review_catalog_id"] = canonical_catalog_id(video or {}) if video else None
+    MEDIA_KNOWLEDGE_DEBUG["last_review_youtube_id"] = canonical_youtube_id(video or {}) if video else None
+    try:
+        MEDIA_KNOWLEDGE_DEBUG["review_storage_keys_count"] = len(list(LLM_REVIEW_STORAGE.base_dir.glob("*.json")))
+    except Exception:
+        MEDIA_KNOWLEDGE_DEBUG["review_storage_keys_count"] = 0
+    MEDIA_KNOWLEDGE_DEBUG["review_lookup_strategy"] = strategy
+
 def _normalize_review_symbol(value: Any) -> str:
     return "".join(ch for ch in str(value or "").upper() if ch.isalnum())
 
@@ -654,7 +671,7 @@ def _review_verdict(model: dict[str, Any], score: int, has_idea: bool) -> str:
 
 
 def _review_transcript_payload(video: dict[str, Any]) -> dict[str, Any]:
-    transcript_id = str(_first_review_value(video.get("youtube_id"), video.get("id")) or "")
+    transcript_id = canonical_youtube_id(video)
     try:
         result = transcript_engine.get(transcript_id)
     except ValueError:
@@ -731,8 +748,9 @@ def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, An
     transcript = _review_transcript_payload(video)
     ai_review = ai_analyzer_engine.analyze(str(transcript.get("text") or ""), {**video, "video_id": video.get("id")})
     analysis = ai_review.to_api_analysis()
-    knowledge_context = _build_knowledge_for_video(str(video.get("id") or ""), market_payload=market_payload).model_dump()
-    llm_review = create_llm_review_engine(market_payload=market_payload).generate(str(video.get("id") or ""))
+    catalog_id = canonical_catalog_id(video)
+    knowledge_context = _build_knowledge_for_video(catalog_id, market_payload=market_payload).model_dump()
+    llm_review = create_llm_review_engine(market_payload=market_payload).generate(catalog_id)
     return {
         "video": video,
         "transcript": transcript,
@@ -763,6 +781,12 @@ def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, An
 
 
 def _build_knowledge_for_video(video_id: str, market_payload: dict[str, Any] | None = None):
+    video = resolve_media_video(video_id)
+    if not video:
+        raise ValueError("TV video not found")
+    catalog_id = canonical_catalog_id(video)
+    _review_lookup_debug(video_id, video, "knowledge_resolve_to_catalog_id")
+
     def _market_payload_loader() -> dict[str, Any]:
         return market_payload if isinstance(market_payload, dict) else ideas_market()
 
@@ -773,9 +797,9 @@ def _build_knowledge_for_video(video_id: str, market_payload: dict[str, Any] | N
         market_payload_loader=_market_payload_loader,
     )
     MEDIA_KNOWLEDGE_DEBUG["knowledge_requests"] += 1
-    MEDIA_KNOWLEDGE_DEBUG["last_knowledge_video_id"] = video_id
+    MEDIA_KNOWLEDGE_DEBUG["last_knowledge_video_id"] = catalog_id
     try:
-        context = engine.build_for_video(video_id)
+        context = engine.build_for_video(catalog_id)
         MEDIA_KNOWLEDGE_DEBUG["last_agreement_score"] = context.agreement_score
         return context
     except Exception:
@@ -873,7 +897,7 @@ def api_media_resolve_all() -> dict[str, Any]:
 
 def _run_automatic_media_pipeline(item: dict[str, Any]) -> dict[str, Any]:
     """Run the automatic Import → Transcript → AI → Knowledge → Review → Committee pipeline for one item."""
-    video_id = str(item.get("id") or item.get("youtube_id") or "")
+    video_id = canonical_catalog_id(item) or canonical_youtube_id(item)
     if not video_id:
         return {"status": "skipped", "reason": "missing_video_id"}
     transcript = _review_transcript_payload(item)
@@ -1020,9 +1044,10 @@ def api_tv_sources_stats() -> dict[str, Any]:
 
 
 def _get_media_review(video_id: str) -> dict[str, Any]:
-    for video in _load_tv_video_catalog():
-        if video.get("id") == video_id:
-            return _build_tv_review_payload(video)
+    video = resolve_media_video(video_id)
+    _review_lookup_debug(video_id, video, "catalog_id|youtube_id|prefixed_id|url_contains")
+    if video:
+        return _build_tv_review_payload(video)
     raise HTTPException(status_code=404, detail="TV video not found")
 
 
@@ -1046,12 +1071,14 @@ def api_media_knowledge(video_id: str) -> dict[str, Any]:
 
 @app.get("/api/media/llm-review/{video_id}")
 def api_media_llm_review(video_id: str, force: bool = False) -> dict[str, Any]:
-    video = next((item for item in _load_tv_video_catalog() if item.get("id") == video_id), None)
+    video = resolve_media_video(video_id)
+    _review_lookup_debug(video_id, video, "llm_review_resolve_to_catalog_id")
     if not video:
         raise HTTPException(status_code=404, detail="TV video not found")
+    catalog_id = canonical_catalog_id(video)
     market_payload = ideas_market()
-    review = create_llm_review_engine(market_payload=market_payload).generate(video_id, force=force)
-    knowledge = _build_knowledge_for_video(video_id, market_payload=market_payload).model_dump()
+    review = create_llm_review_engine(market_payload=market_payload).generate(catalog_id, force=force)
+    knowledge = _build_knowledge_for_video(catalog_id, market_payload=market_payload).model_dump()
     return {
         "video": video,
         "analysis": knowledge.get("ai_analysis", {}),
@@ -1061,9 +1088,13 @@ def api_media_llm_review(video_id: str, force: bool = False) -> dict[str, Any]:
 
 @app.get("/api/media/committee/{video_id}")
 def api_media_committee(video_id: str) -> dict[str, Any]:
+    video = resolve_media_video(video_id)
+    _review_lookup_debug(video_id, video, "committee_resolve_to_catalog_id")
+    if not video:
+        raise HTTPException(status_code=404, detail="TV video not found")
     engine = InvestmentCommitteeEngine(media_catalog_loader=_load_tv_video_catalog, review_payload_builder=_build_tv_review_payload)
     try:
-        return engine.build_for_video(video_id).model_dump()
+        return engine.build_for_video(canonical_catalog_id(video)).model_dump()
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 

--- a/app/services/investment_committee/engine.py
+++ b/app/services/investment_committee/engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from app.services.media_identity import resolve_media_video
+
 from app.services.investment_committee.models import CommitteeInput, InvestmentCommitteeReport
 from app.services.investment_committee.provider import InvestmentCommitteeProvider
 from app.services.investment_committee.rule_provider import RuleCommitteeProvider
@@ -22,7 +24,7 @@ class InvestmentCommitteeEngine:
         self.provider = provider or RuleCommitteeProvider()
 
     def build_for_video(self, video_id: str) -> InvestmentCommitteeReport:
-        video = next((item for item in self.media_catalog_loader() if str(item.get("id")) == str(video_id)), None)
+        video = resolve_media_video(video_id, self.media_catalog_loader())
         if not video:
             raise ValueError("TV video not found")
         warnings: list[str] = []

--- a/app/services/knowledge/knowledge_engine.py
+++ b/app/services/knowledge/knowledge_engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from app.services.media_identity import canonical_catalog_id, canonical_youtube_id, resolve_media_video
+
 from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge.context_builder import build_unified_context
 from app.services.knowledge.market_context import build_market_context
@@ -17,12 +19,13 @@ class KnowledgeEngine:
         self.market_payload_loader = market_payload_loader
 
     def build_for_video(self, video_id: str):
-        video = next((item for item in self.media_catalog_loader() if item.get("id") == video_id), None)
+        video = resolve_media_video(video_id, self.media_catalog_loader())
         if not video:
             raise ValueError("TV video not found")
-        transcript_id = str(video.get("youtube_id") or video.get("id") or video_id)
+        catalog_id = canonical_catalog_id(video)
+        transcript_id = canonical_youtube_id(video)
         transcript = self.transcript_engine.get(transcript_id)
-        ai_review = self.ai_analyzer_engine.analyze(transcript.transcript, {**video, "video_id": video.get("id")})
+        ai_review = self.ai_analyzer_engine.analyze(transcript.transcript, {**video, "video_id": catalog_id})
         media = build_media_context(video, transcript, ai_review)
         market = build_market_context(media.detected_symbol, self.market_payload_loader)
         return build_unified_context(media, market, ai_review.to_api_analysis())

--- a/app/services/llm_review/review_engine.py
+++ b/app/services/llm_review/review_engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from app.services.media_identity import canonical_catalog_id, canonical_youtube_id, resolve_media_video
+
 from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge import KnowledgeEngine
 from app.services.llm_review.models import LLMReview
@@ -29,19 +31,20 @@ class ReviewEngine:
         self.storage = storage or LLMReviewStorage()
 
     def build_context(self, video_id: str) -> dict[str, Any]:
-        video = next((item for item in self.media_catalog_loader() if item.get("id") == video_id), None)
+        video = resolve_media_video(video_id, self.media_catalog_loader())
         if not video:
             raise ValueError("TV video not found")
-        transcript_id = str(video.get("youtube_id") or video.get("id") or video_id)
+        catalog_id = canonical_catalog_id(video)
+        transcript_id = canonical_youtube_id(video)
         transcript = self.transcript_engine.get(transcript_id)
-        ai_review = self.ai_analyzer_engine.analyze(transcript.transcript, {**video, "video_id": video.get("id")})
+        ai_review = self.ai_analyzer_engine.analyze(transcript.transcript, {**video, "video_id": catalog_id})
         market_payload = self.market_payload_loader()
         knowledge = KnowledgeEngine(
             media_catalog_loader=self.media_catalog_loader,
             transcript_engine=self.transcript_engine,
             ai_analyzer_engine=self.ai_analyzer_engine,
             market_payload_loader=lambda: market_payload,
-        ).build_for_video(video_id)
+        ).build_for_video(catalog_id)
         return {
             "video": video,
             "transcript": {"status": transcript.status.value, "text": transcript.transcript, "language": transcript.language, "provider": transcript.source},
@@ -55,12 +58,14 @@ class ReviewEngine:
         }
 
     def generate(self, video_id: str, *, force: bool = False) -> LLMReview:
+        video = resolve_media_video(video_id, self.media_catalog_loader())
+        storage_id = canonical_catalog_id(video) if video else str(video_id)
         if not force:
-            cached = self.storage.get(video_id)
+            cached = self.storage.get(storage_id) or self.storage.get(video_id)
             if cached:
                 return cached
-        review = self.provider.generate_review(self.build_context(video_id))
+        review = self.provider.generate_review(self.build_context(storage_id))
         # Re-validate provider JSON through the explicit contract before caching.
         review = LLMReview.model_validate(review.model_dump())
-        self.storage.set(video_id, review)
+        self.storage.set(storage_id, review)
         return review

--- a/app/services/media_identity.py
+++ b/app/services/media_identity.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+YOUTUBE_PREFIX = "youtube:"
+
+
+def strip_youtube_prefix(value: Any) -> str:
+    text = str(value or "").strip()
+    if text.lower().startswith(YOUTUBE_PREFIX):
+        return text[len(YOUTUBE_PREFIX) :]
+    return text
+
+
+def canonical_catalog_id(item: dict[str, Any]) -> str:
+    return str(item.get("id") or "").strip()
+
+
+def canonical_youtube_id(item: dict[str, Any]) -> str:
+    youtube_id = str(item.get("youtube_id") or "").strip()
+    if youtube_id:
+        return strip_youtube_prefix(youtube_id)
+    return strip_youtube_prefix(item.get("id"))
+
+
+def resolve_media_video(video_id: str, catalog: Iterable[dict[str, Any]]) -> dict[str, Any] | None:
+    raw = str(video_id or "").strip()
+    clean = strip_youtube_prefix(raw)
+    prefixed = f"{YOUTUBE_PREFIX}{clean}" if clean else ""
+    candidates = {raw, clean, prefixed}
+    for item in catalog:
+        item_id = str(item.get("id") or "").strip()
+        item_youtube_id = canonical_youtube_id(item)
+        url = str(item.get("url") or "")
+        if item_id in candidates:
+            return item
+        if item_youtube_id and item_youtube_id in candidates:
+            return item
+        if raw and raw in url:
+            return item
+        if clean and clean in url:
+            return item
+    return None

--- a/tests/test_llm_review.py
+++ b/tests/test_llm_review.py
@@ -152,3 +152,83 @@ def test_automatic_media_pipeline_uses_catalog_id_for_review_generation(monkeypa
 
     assert calls == ["youtube:abc12345678"]
     assert result["video_id"] == "youtube:abc12345678"
+
+
+def test_media_video_resolution_supports_catalog_and_youtube_ids(monkeypatch):
+    import app.main as main
+
+    video = {"id": "youtube:Hf7eX113oIc", "youtube_id": "Hf7eX113oIc", "url": "https://youtube.com/watch?v=Hf7eX113oIc"}
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [video])
+
+    assert main.resolve_media_video("youtube:Hf7eX113oIc") == video
+    assert main.resolve_media_video("Hf7eX113oIc") == video
+
+
+def test_review_engine_lookup_by_youtube_id_and_transcript_uses_clean_id(tmp_path):
+    from app.services.llm_review import LLMReviewStorage, ReviewEngine
+
+    transcript_calls = []
+    video = {"id": "youtube:Hf7eX113oIc", "youtube_id": "Hf7eX113oIc", "symbol": "EURUSD"}
+
+    class FakeTranscriptEngine:
+        def get(self, video_id):
+            transcript_calls.append(video_id)
+            return TranscriptResult(video_id, "en", "cache", "Buy EURUSD", status=TranscriptStatus.FOUND)
+
+    engine = ReviewEngine(
+        media_catalog_loader=lambda: [video],
+        transcript_engine=FakeTranscriptEngine(),
+        ai_analyzer_engine=FakeAnalyzer(),
+        market_payload_loader=lambda: {},
+        provider=MockProvider(),
+        storage=LLMReviewStorage(tmp_path),
+    )
+
+    review = engine.generate("Hf7eX113oIc")
+
+    assert review.provider == "mock"
+    assert transcript_calls == ["Hf7eX113oIc", "Hf7eX113oIc"]
+    assert (tmp_path / "youtubeHf7eX113oIc.json").exists()
+
+
+def test_media_review_endpoint_accepts_catalog_and_youtube_id(monkeypatch):
+    import app.main as main
+
+    video = {"id": "youtube:Hf7eX113oIc", "youtube_id": "Hf7eX113oIc", "symbol": "EURUSD", "title": "Обзор"}
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [video])
+    monkeypatch.setattr(main, "ideas_market", lambda: {})
+    monkeypatch.setattr(main, "_review_transcript_payload", lambda video: {"status": "FOUND", "text": "Buy EURUSD"})
+    monkeypatch.setattr(main.ai_analyzer_engine, "analyze", lambda transcript, metadata: AIReview(video_id=metadata["video_id"], symbol="EURUSD", direction="BUY", summary="Покупка"))
+    monkeypatch.setattr(main, "_build_knowledge_for_video", lambda video_id, market_payload=None: type("Knowledge", (), {"model_dump": lambda self: {"agreement_score": 80, "ai_analysis": {}}})())
+    monkeypatch.setattr(main, "create_llm_review_engine", lambda market_payload=None: type("Engine", (), {"generate": lambda self, video_id, force=False: LLMReview(summary="Generated", provider="mock")})())
+
+    client = TestClient(main.app)
+    assert client.get("/api/media/review/youtube:Hf7eX113oIc").status_code == 200
+    assert client.get("/api/media/review/Hf7eX113oIc").status_code == 200
+
+
+def test_import_now_generates_review_for_imported_youtube_id(monkeypatch):
+    import app.main as main
+
+    calls = []
+    video = {"id": "youtube:Hf7eX113oIc", "youtube_id": "Hf7eX113oIc"}
+
+    class FakeImportEngine:
+        def import_latest(self):
+            return {"success": True, "new_item_ids": ["Hf7eX113oIc"], "imported": 1}
+
+    class FakeReviewEngine:
+        def generate(self, video_id):
+            assert main.resolve_media_video(video_id) == video
+            calls.append(video_id)
+            return LLMReview(summary="Generated after import", provider="mock")
+
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [video])
+    monkeypatch.setattr(main, "create_media_import_engine", lambda: FakeImportEngine())
+    monkeypatch.setattr(main, "create_llm_review_engine", lambda: FakeReviewEngine())
+
+    result = main.api_media_import_now()
+
+    assert calls == ["Hf7eX113oIc"]
+    assert result["review_generation"]["generated"] == 1
+    assert result["review_generation"]["failed"] == 0


### PR DESCRIPTION
### Motivation
- Исправить ошибку «TV video not found» при генерации LLM/Committee/Knowledge review, вызванную несогласованным использованием `id` и `youtube_id` в разных местах.

### Description
- Добавлен общий модуль `app/services/media_identity.py` с хелперами `canonical_catalog_id`, `canonical_youtube_id` и `resolve_media_video` для согласованного поиска по `id`, `youtube_id`, `youtube:`-префиксу и по вхождению в `url`.
- Подключен resolver в `app/main.py` и заменены локальные поиски видео на вызовы `resolve_media_video` и `canonical_*` в ключевых местах: `_get_media_review`, `_build_knowledge_for_video`, `_build_tv_review_payload`, `api_media_llm_review`, `api_media_committee`, `_run_automatic_media_pipeline` и генерация после импорта.
- Обновлён `ReviewEngine` (`app/services/llm_review/review_engine.py`) чтобы: искать элемент через общий resolver, запрашивать транскрипт по чистому YouTube ID (`canonical_youtube_id`), генерировать и хранить review по `catalog_id` (при этом чтение кеша поддерживает и старые ключи для совместимости).
- Обновлены `KnowledgeEngine` и `InvestmentCommitteeEngine` чтобы использовать общий resolver и передавать в анализ контрактный `catalog_id`/чистый `youtube_id` (транскрипт — чистый `youtube_id`, хранилище review — `catalog_id`).
- Добавлен отладочный payload в `MEDIA_KNOWLEDGE_DEBUG` с полями `last_review_video_id`, `last_review_catalog_id`, `last_review_youtube_id`, `review_storage_keys_count`, `review_lookup_strategy`.
- Добавлены регрессионные тесты/корректировки в `tests/test_llm_review.py` на поддержку обоих форматов id, корректный вызов транскрипта и успешную генерацию при `import-now`.

### Testing
- Сборка/проверка синтаксиса выполнена командой `python -m py_compile app/main.py app/services/media_identity.py app/services/knowledge/knowledge_engine.py app/services/llm_review/review_engine.py app/services/investment_committee/engine.py` и прошла успешно.
- Запуск набора тестов: `pytest -q tests/test_media_import_engine.py tests/test_knowledge_layer.py tests/test_investment_committee.py tests/test_llm_review.py` завершился успешно с результатом `49 passed` (есть предупреждения).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff18c28008331953f8022b57c61cf)