### PR TITLE
Исправление аутентификации OpenRouter и централизация конфигурации LLM

### DIFF
--- a/app/core/env.py
+++ b/app/core/env.py
@@ -24,14 +24,15 @@ def get_env(name: str, default: str | None = None) -> str | None:
 
 
 def get_openrouter_api_key() -> str | None:
-    return get_env("OPENROUTER_API_KEY")
+    return get_env("OPENROUTER_API_KEY") or get_env("OPENAI_API_KEY")
 
 
 def get_openrouter_model() -> str:
-    model = get_env("OPENROUTER_MODEL")
-    logger.info("OPENROUTER MODEL: %s", model)
-    if model:
-        return model
+    for name in ("FXPILOT_OPENAI_MODEL", "OPENAI_MODEL", "OPENROUTER_MODEL", "OPENROUTER_FALLBACK_MODEL"):
+        model = get_env(name)
+        if model:
+            logger.info("OPENROUTER MODEL: %s", model)
+            return model
     return "x-ai/grok-4.3"
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,7 @@ from app.services.media_automation import MediaAutomationService
 from app.services.transcript import TranscriptEngine, TranscriptStorage
 from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge import KnowledgeEngine
+from app.services.llm_config import LLMConfigurationError, llm_debug_payload, resolve_llm_config
 from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewProvider, ReviewEngine
 from app.services.investment_committee import InvestmentCommitteeEngine
 from app.services.consensus import ConsensusEngine
@@ -725,9 +726,12 @@ class ContextOnlyReviewProvider:
 
 
 def create_llm_review_provider():
-    if os.getenv("OPENAI_API_KEY", "").strip():
-        return OpenAIReviewProvider()
-    return ContextOnlyReviewProvider()
+    try:
+        config = resolve_llm_config()
+        return OpenAIReviewProvider(config=config)
+    except LLMConfigurationError as exc:
+        logger.warning("llm_review_provider_configuration_error: %s", exc)
+        return ContextOnlyReviewProvider()
 
 
 def create_llm_review_engine(market_payload: dict[str, Any] | None = None, provider: Any | None = None) -> ReviewEngine:
@@ -990,6 +994,7 @@ def api_media_debug() -> dict[str, Any]:
         payload = create_media_import_engine().debug_sources()
         payload.update(transcript_engine.debug_payload())
         payload.update(MEDIA_KNOWLEDGE_DEBUG)
+        payload.update(llm_debug_payload())
         return payload
     except MediaConfigError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/app/services/ai_gateway.py
+++ b/app/services/ai_gateway.py
@@ -10,12 +10,13 @@ from typing import Any
 import requests
 from openai import AsyncOpenAI
 
-from app.core.env import get_openrouter_api_key, get_openrouter_model
+from app.core.env import get_openrouter_model
+from app.services.llm_config import LLMConfigurationError, resolve_llm_config
 from app.services.ai_runtime_status import record_ai_request_failure, record_ai_request_start, record_ai_request_success
 
 logger = logging.getLogger(__name__)
 
-OPENROUTER_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1").rstrip("/")
+OPENROUTER_URL = "https://openrouter.ai/api/v1"
 
 
 @dataclass
@@ -74,9 +75,16 @@ def model_sequence(primary_model: str | None = None) -> list[str]:
 
 class AIGateway:
     def __init__(self) -> None:
-        self.api_key = (get_openrouter_api_key() or "").strip()
+        try:
+            self.config = resolve_llm_config(provider="openrouter")
+            self.api_key = self.config.api_key
+            self.base_url = (self.config.base_url or OPENROUTER_URL).rstrip("/")
+        except LLMConfigurationError:
+            self.config = None
+            self.api_key = ""
+            self.base_url = OPENROUTER_URL
         self.timeout = float(os.getenv("OPENROUTER_TIMEOUT", os.getenv("OPENAI_TIMEOUT", "30")))
-        self.client = AsyncOpenAI(api_key=self.api_key, base_url=OPENROUTER_URL, timeout=self.timeout) if self.api_key else None
+        self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout) if self.api_key else None
 
     def enabled(self) -> bool:
         return bool(self.api_key)
@@ -108,7 +116,7 @@ class AIGateway:
                 if max_tokens:
                     body["max_tokens"] = max_tokens
                 response = requests.post(
-                    f"{OPENROUTER_URL}/chat/completions",
+                    f"{self.base_url}/chat/completions",
                     headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
                     json=body,
                     timeout=self.timeout,

--- a/app/services/ai_runtime_status.py
+++ b/app/services/ai_runtime_status.py
@@ -9,7 +9,8 @@ from typing import Any
 
 from openai import AsyncOpenAI
 
-from app.core.env import get_openrouter_api_key, get_openrouter_model
+from app.core.env import get_openrouter_model
+from app.services.llm_config import LLMConfigurationError, resolve_llm_config
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ _STATUS: dict[str, Any] = {
     "enabled": os.getenv("USE_OPENROUTER", "true").strip().lower() == "true",
     "provider": PROVIDER_NAME,
     "model": get_openrouter_model(),
-    "api_key_configured": bool(get_openrouter_api_key()),
+    "api_key_configured": bool(resolve_llm_config(provider="openrouter", require_api_key=False).api_key),
     "last_request_time": None,
     "last_success_time": None,
     "last_error": None,
@@ -44,7 +45,7 @@ def get_ai_status() -> dict[str, Any]:
         status = dict(_STATUS)
     status["enabled"] = os.getenv("USE_OPENROUTER", "true").strip().lower() == "true"
     status["model"] = get_openrouter_model()
-    status["api_key_configured"] = bool(get_openrouter_api_key())
+    status["api_key_configured"] = bool(resolve_llm_config(provider="openrouter", require_api_key=False).api_key)
     status["llm_available"] = bool(status["enabled"] and status["api_key_configured"] and status["last_success_time"] and not status["last_error"])
     return status
 
@@ -55,7 +56,7 @@ def record_ai_request_start(*, model: str | None = None) -> float:
     with _LOCK:
         _STATUS["enabled"] = os.getenv("USE_OPENROUTER", "true").strip().lower() == "true"
         _STATUS["model"] = model or get_openrouter_model()
-        _STATUS["api_key_configured"] = bool(get_openrouter_api_key())
+        _STATUS["api_key_configured"] = bool(resolve_llm_config(provider="openrouter", require_api_key=False).api_key)
         _STATUS["last_request_time"] = now
         _STATUS["total_requests"] = int(_STATUS.get("total_requests") or 0) + 1
     logger.info("llm_request_start provider=%s model=%s time=%s", PROVIDER_NAME, model or get_openrouter_model(), now)
@@ -91,20 +92,22 @@ def record_ai_request_failure(*, error: Any, model: str | None = None, started_a
 
 
 async def run_ai_test_request(prompt: str = "Reply with OK") -> dict[str, Any]:
-    model = get_openrouter_model()
-    api_key = (get_openrouter_api_key() or "").strip()
+    try:
+        config = resolve_llm_config(provider="openrouter")
+    except LLMConfigurationError as exc:
+        model = get_openrouter_model()
+        error = str(exc)
+        record_ai_request_failure(error=error, model=model)
+        return {"success": False, "provider": PROVIDER_NAME, "model": model, "response": "", "latency_ms": 0, "error": error}
+    model = config.model
+    api_key = config.api_key
     if os.getenv("USE_OPENROUTER", "true").strip().lower() != "true":
         error = "OpenRouter disabled by USE_OPENROUTER=false"
         record_ai_request_failure(error=error, model=model)
         return {"success": False, "provider": PROVIDER_NAME, "model": model, "response": "", "latency_ms": 0, "error": error}
-    if not api_key:
-        error = "missing_openrouter_api_key"
-        record_ai_request_failure(error=error, model=model)
-        return {"success": False, "provider": PROVIDER_NAME, "model": model, "response": "", "latency_ms": 0, "error": error}
-
     client = AsyncOpenAI(
         api_key=api_key,
-        base_url=OPENROUTER_BASE_URL,
+        base_url=config.base_url or OPENROUTER_BASE_URL,
         timeout=float(os.getenv("OPENROUTER_HEALTH_TIMEOUT", "10")),
         default_headers={"HTTP-Referer": OPENROUTER_SITE_URL, "X-Title": OPENROUTER_APP_TITLE},
     )

--- a/app/services/idea_narrative_llm.py
+++ b/app/services/idea_narrative_llm.py
@@ -10,7 +10,8 @@ from typing import Any
 
 import requests
 
-from app.core.env import get_openrouter_api_key, get_openrouter_model
+from app.core.env import get_openrouter_model
+from app.services.llm_config import LLMConfigurationError, resolve_llm_config
 from app.signal_aggregator import SignalAggregator
 
 
@@ -88,8 +89,15 @@ class IdeaNarrativeLLMService:
     """
 
     def __init__(self) -> None:
-        self.api_key = (get_openrouter_api_key() or "").strip()
-        self.model = get_openrouter_model()
+        try:
+            config = resolve_llm_config(provider="openrouter")
+            self.api_key = config.api_key
+            self.base_url = (config.base_url or "https://openrouter.ai/api/v1").rstrip("/")
+            self.model = config.model
+        except LLMConfigurationError:
+            self.api_key = ""
+            self.base_url = "https://openrouter.ai/api/v1"
+            self.model = get_openrouter_model()
         self.fallback_model = (os.getenv("OPENROUTER_FALLBACK_MODEL", "") or "").strip()
         self.timeout = float(os.getenv("OPENROUTER_TIMEOUT", "30"))
         self._last_llm_rejection_reason: str | None = None
@@ -162,7 +170,7 @@ class IdeaNarrativeLLMService:
             logger.info("LLM model used: %s", model_used)
             try:
                 response = requests.post(
-                    OPENROUTER_URL,
+                    f"{self.base_url}/chat/completions",
                     headers={
                         "Authorization": f"Bearer {self.api_key}",
                         "Content-Type": "application/json",
@@ -229,7 +237,7 @@ class IdeaNarrativeLLMService:
             logger.info("LLM model used: %s", model_used)
             try:
                 response = requests.post(
-                    OPENROUTER_URL,
+                    f"{self.base_url}/chat/completions",
                     headers={
                         "Authorization": f"Bearer {self.api_key}",
                         "Content-Type": "application/json",

--- a/app/services/llm_config.py
+++ b/app/services/llm_config.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OPENAI_MODEL = "gpt-4.1"
+DEFAULT_OPENROUTER_MODEL = "x-ai/grok-4.3"
+DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class LLMConfigurationError(RuntimeError):
+    """Raised when the selected LLM provider cannot be configured safely."""
+
+
+@dataclass(frozen=True)
+class LLMConfig:
+    provider: str
+    api_key: str
+    base_url: str | None
+    model: str
+
+    @property
+    def api_key_present(self) -> bool:
+        return bool(self.api_key.strip())
+
+
+def _env(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _selected_provider(provider: str | None = None) -> str:
+    return (provider or _env("FXPILOT_LLM_PROVIDER") or "openai").strip().lower()
+
+
+def _resolve_model(provider: str) -> str:
+    ordered_names = ["FXPILOT_OPENAI_MODEL", "OPENAI_MODEL", "OPENROUTER_MODEL"]
+    for name in ordered_names:
+        value = _env(name)
+        if value:
+            return value
+    if provider == "openrouter":
+        return _env("OPENROUTER_FALLBACK_MODEL") or DEFAULT_OPENROUTER_MODEL
+    return DEFAULT_OPENAI_MODEL
+
+
+def resolve_llm_config(*, provider: str | None = None, require_api_key: bool = True) -> LLMConfig:
+    selected = _selected_provider(provider)
+    if selected == "openrouter":
+        api_key = _env("OPENROUTER_API_KEY") or _env("OPENAI_API_KEY") or ""
+        base_url = _env("OPENAI_BASE_URL") or _env("OPENROUTER_BASE_URL") or DEFAULT_OPENROUTER_BASE_URL
+    elif selected == "openai":
+        api_key = _env("OPENAI_API_KEY") or ""
+        base_url = _env("OPENAI_BASE_URL")
+    else:
+        raise LLMConfigurationError(f"Unsupported LLM provider: {selected}")
+
+    config = LLMConfig(provider=selected, api_key=api_key.strip(), base_url=base_url.rstrip("/") if base_url else None, model=_resolve_model(selected))
+    if require_api_key and not config.api_key_present:
+        key_name = "OPENROUTER_API_KEY or OPENAI_API_KEY" if selected == "openrouter" else "OPENAI_API_KEY"
+        raise LLMConfigurationError(f"LLM configuration error: {key_name} is required for provider {selected}")
+
+    logger.info("LLM provider selected: %s", config.provider)
+    logger.info("LLM base URL: %s", config.base_url or "default")
+    logger.info("LLM model: %s", config.model)
+    logger.info("LLM API key present: %s", str(config.api_key_present).lower())
+    return config
+
+
+def llm_debug_payload() -> dict[str, object]:
+    try:
+        config = resolve_llm_config(require_api_key=False)
+        valid = config.api_key_present
+        return {
+            "llm_provider": config.provider,
+            "llm_base_url": config.base_url,
+            "llm_model": config.model,
+            "llm_api_key_present": config.api_key_present,
+            "llm_configuration_valid": valid,
+        }
+    except LLMConfigurationError as exc:
+        return {
+            "llm_provider": _selected_provider(),
+            "llm_base_url": None,
+            "llm_model": None,
+            "llm_api_key_present": False,
+            "llm_configuration_valid": False,
+            "llm_configuration_error": str(exc),
+        }

--- a/app/services/llm_review/openai_provider.py
+++ b/app/services/llm_review/openai_provider.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from openai import OpenAI
 
+from app.services.llm_config import LLMConfig, resolve_llm_config
 from app.services.llm_review.models import LLMReview
 from app.services.llm_review.prompt_builder import PromptBuilder
 
@@ -14,18 +15,21 @@ from app.services.llm_review.prompt_builder import PromptBuilder
 class OpenAIReviewProvider:
     provider_name = "openai"
 
-    def __init__(self, *, api_key: str | None = None, model: str | None = None, timeout: float | None = None, retries: int = 2, prompt_builder: PromptBuilder | None = None) -> None:
-        self.api_key = api_key if api_key is not None else os.getenv("OPENAI_API_KEY", "")
-        self.model = model or os.getenv("FXPILOT_OPENAI_MODEL", "gpt-4.1")
+    def __init__(self, *, api_key: str | None = None, model: str | None = None, base_url: str | None = None, timeout: float | None = None, retries: int = 2, prompt_builder: PromptBuilder | None = None, config: LLMConfig | None = None) -> None:
+        resolved = config or resolve_llm_config()
+        self.api_key = (api_key if api_key is not None else resolved.api_key).strip()
+        self.base_url = base_url if base_url is not None else resolved.base_url
+        self.model = model or resolved.model
+        self.provider_name = resolved.provider
         self.timeout = timeout if timeout is not None else float(os.getenv("FXPILOT_LLM_TIMEOUT", "30"))
         self.retries = max(0, int(retries))
         self.prompt_builder = prompt_builder or PromptBuilder()
 
     def generate_review(self, context: dict[str, Any]) -> LLMReview:
-        if not self.api_key:
-            raise RuntimeError("OPENAI_API_KEY is not configured")
+        if not self.api_key.strip():
+            raise RuntimeError(f"LLM configuration error: API key is required for provider {self.provider_name}")
         prompt = self.prompt_builder.build(context)
-        client = OpenAI(api_key=self.api_key, timeout=self.timeout, max_retries=self.retries)
+        client = OpenAI(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout, max_retries=self.retries)
         started = time.perf_counter()
         response = client.chat.completions.create(
             model=self.model,
@@ -37,4 +41,4 @@ class OpenAIReviewProvider:
         content = response.choices[0].message.content or "{}"
         payload = json.loads(content)
         tokens = getattr(getattr(response, "usage", None), "total_tokens", 0) or 0
-        return LLMReview.from_payload(payload, provider=f"openai:{self.model}", tokens_used=int(tokens), latency_ms=latency_ms)
+        return LLMReview.from_payload(payload, provider=f"{self.provider_name}:{self.model}", tokens_used=int(tokens), latency_ms=latency_ms)

--- a/app/services/trade_idea_service.py
+++ b/app/services/trade_idea_service.py
@@ -12,6 +12,7 @@ from typing import Any
 import requests
 
 from app.core.env import get_openrouter_api_key, get_openrouter_model
+from app.services.llm_config import LLMConfigurationError, resolve_llm_config
 from app.services.chart_data_service import ChartDataService
 from app.services.chart_snapshot_service import ChartSnapshotService
 from app.services.idea_narrative_llm import IdeaNarrativeLLMService, NarrativeResult
@@ -1243,8 +1244,15 @@ class TradeIdeaService:
         return list(DEFAULT_IDEA_TIMEFRAMES)
 
     def build_openrouter_api_ideas(self) -> list[dict[str, Any]]:
-        api_key = get_openrouter_api_key()
-        model = get_openrouter_model()
+        try:
+            llm_config = resolve_llm_config(provider="openrouter")
+            api_key = llm_config.api_key
+            model = llm_config.model
+            openrouter_url = f"{(llm_config.base_url or 'https://openrouter.ai/api/v1').rstrip('/')}/chat/completions"
+        except LLMConfigurationError:
+            api_key = get_openrouter_api_key()
+            model = get_openrouter_model()
+            openrouter_url = OPENROUTER_URL
 
         if not api_key:
             logger.warning("openrouter_missing_api_key")
@@ -1271,7 +1279,7 @@ class TradeIdeaService:
 
         try:
             logger.info("AI request started model=%s", model)
-            response = requests.post(OPENROUTER_URL, headers=headers, json=payload, timeout=30)
+            response = requests.post(openrouter_url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
             logger.info("AI response received status=%s", getattr(response, "status_code", "unknown"))
         except requests.RequestException as exc:

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.services.llm_config import LLMConfigurationError, llm_debug_payload, resolve_llm_config
+from app.services.llm_review.openai_provider import OpenAIReviewProvider
+
+
+def clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "FXPILOT_LLM_PROVIDER",
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENROUTER_BASE_URL",
+        "FXPILOT_OPENAI_MODEL",
+        "OPENAI_MODEL",
+        "OPENROUTER_MODEL",
+        "OPENROUTER_FALLBACK_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_openrouter_uses_openrouter_api_key(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openrouter.ai/api/v1")
+
+    config = resolve_llm_config()
+
+    assert config.provider == "openrouter"
+    assert config.api_key == "or-secret"
+    assert config.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_openrouter_falls_back_to_openai_key(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+
+    config = resolve_llm_config()
+
+    assert config.api_key == "oa-secret"
+    assert config.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_direct_openai_uses_openai_api_key(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+
+    config = resolve_llm_config()
+
+    assert config.provider == "openai"
+    assert config.api_key == "oa-secret"
+
+
+def test_missing_key_raises_clear_configuration_error(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+
+    with pytest.raises(LLMConfigurationError, match="OPENROUTER_API_KEY or OPENAI_API_KEY"):
+        resolve_llm_config()
+
+
+def test_client_receives_non_empty_api_key(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-secret")
+
+    provider = OpenAIReviewProvider()
+
+    assert provider.api_key == "or-secret"
+    assert provider.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_no_secret_appears_in_logs_or_debug_response(monkeypatch, caplog):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "super-secret-openrouter-key")
+    monkeypatch.setenv("OPENROUTER_MODEL", "x-ai/test")
+
+    with caplog.at_level(logging.INFO):
+        config = resolve_llm_config()
+    payload = llm_debug_payload()
+
+    assert config.api_key == "super-secret-openrouter-key"
+    assert payload["llm_api_key_present"] is True
+    assert payload["llm_configuration_valid"] is True
+    assert "super-secret-openrouter-key" not in caplog.text
+    assert "super-secret-openrouter-key" not in str(payload)


### PR DESCRIPTION
### Motivation
- В продакшене при `FXPILOT_LLM_PROVIDER=openrouter` клиент инициализировался без правильного ключа/base_url, что вызывало 401 "Missing Authentication header" при обращении к OpenRouter. 
- Нужно централизовать разрешение провайдера, ключа, base_url и модели, чтобы все точки создания клиентов использовали единый безопасный контракт и не создавали клиент с пустым ключом. 
- Также требуется добавить безопасную диагностику для отладки без раскрытия секретов.

### Description
- Добавлен общий резолвер `app/services/llm_config.py`, который определяет `provider`, `api_key`, `base_url` и `model`, реализует приоритет ключей (для `openrouter`: `OPENROUTER_API_KEY` затем `OPENAI_API_KEY`) и бросает `LLMConfigurationError` при обязательном отсутствии ключа. 
- Обновлены места инициализации LLM-клиентов: `OpenAIReviewProvider` теперь использует общий `LLMConfig` и передаёт `api_key` и `base_url` в `OpenAI(...)`, а фабрика review-провайдера в `app/main.py` использует резолвер. 
- Исправлены OpenRouter-совместимые компоненты (`app/services/ai_gateway.py`, `app/services/ai_runtime_status.py`, `app/services/idea_narrative_llm.py`, `app/services/trade_idea_service.py`) чтобы брать ключ/base_url/model из резолвера и не дергать эндпоинт без ключа; добавлен безопасный `llm_debug_payload` и его включение в `/api/media/debug`. 
- Добавлены тесты `tests/test_llm_config.py` проверяющие приоритет ключей, fallback, поведение для прямого OpenAI, ошибку при отсутствии ключа, передачу непустого ключа в клиент и отсутствие секретов в логах/диагностике.

### Testing
- Запущен `pytest tests/test_llm_config.py` и все новые тесты прошли успешно (`6 passed`).
- Скомпилированы изменённые модули через `python -m compileall` и выполнен частичный прогон (`tests/test_llm_config.py` и `tests/test_media_import_engine.py::test_debug_sources_exposes_ytdlp_provider_without_api_key`), который также прошёл успешно (`7 passed` в этой прогонке).
- При запуске более широкого набора тестов (`tests/test_llm_config.py tests/test_idea_narrative.py tests/narrative/test_idea_narrative_llm.py ...`) возникли 4 падения в существующих тестах narrative, которые связаны с ожидаемым значением `source`/поведением fallback в `IdeaNarrativeLLMService` и не относятся к аутентификации OpenRouter; новые LLM-конфигурационные тесты продолжают проходить.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50763872b88331a2ee82520c3e2096)