### PR TITLE
Исправление аутентификации OpenRouter: диагностика, жёсткая нормализация конфигурации и явный Authorization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -48,8 +48,9 @@ from app.services.media_automation import MediaAutomationService
 from app.services.transcript import TranscriptEngine, TranscriptStorage
 from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge import KnowledgeEngine
-from app.services.llm_config import LLMConfigurationError, llm_debug_payload, resolve_llm_config
+from app.services.llm_config import LLMConfigurationError, llm_debug_payload, log_llm_startup_config, resolve_llm_config
 from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewProvider, ReviewEngine
+from app.services.openrouter_diagnostics import run_openrouter_diagnostic
 from app.services.investment_committee import InvestmentCommitteeEngine
 from app.services.consensus import ConsensusEngine
 from app.services.author_intelligence import AuthorIntelligenceEngine
@@ -458,6 +459,7 @@ if STATIC_DIR.exists():
 
 @app.on_event("startup")
 def startup() -> None:
+    log_llm_startup_config()
     twelvedata_ws_service.start()
     media_automation_service.start()
     asyncio.create_task(startup_ai_healthcheck())
@@ -978,6 +980,11 @@ def api_media_import_now() -> dict[str, Any]:
     except Exception as exc:
         logger.exception("media_import_failed_before_completion")
         raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
+
+
+@app.get("/api/ai/openrouter-test")
+def api_ai_openrouter_test() -> dict[str, Any]:
+    return run_openrouter_diagnostic()
 
 
 @app.get("/api/media/stats")

--- a/app/services/llm_config.py
+++ b/app/services/llm_config.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_OPENAI_MODEL = "gpt-4.1"
 DEFAULT_OPENROUTER_MODEL = "x-ai/grok-4.3"
 DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_KEY_PREFIXES = ("sk-or-",)
+_INVALID_KEY_VALUES = {"", "none", "null", "undefined"}
 
 
 class LLMConfigurationError(RuntimeError):
@@ -21,18 +25,43 @@ class LLMConfig:
     api_key: str
     base_url: str | None
     model: str
+    api_key_source: str = "missing"
 
     @property
     def api_key_present(self) -> bool:
         return bool(self.api_key.strip())
 
+    @property
+    def api_key_prefix_valid(self) -> bool:
+        if self.provider != "openrouter":
+            return self.api_key_present
+        if self.api_key_source == "OPENAI_API_KEY":
+            return self.api_key_present
+        return self.api_key.startswith(OPENROUTER_KEY_PREFIXES)
 
-def _env(name: str) -> str | None:
-    value = os.getenv(name)
+    @property
+    def configuration_valid(self) -> bool:
+        return self.api_key_present and (self.provider != "openrouter" or self.api_key_prefix_valid)
+
+
+def _clean_scalar(value: str | None) -> str | None:
     if value is None:
         return None
-    value = value.strip()
-    return value or None
+    cleaned = value.strip().strip('"').strip("'").strip()
+    return cleaned or None
+
+
+def _env(name: str) -> str | None:
+    return _clean_scalar(os.getenv(name))
+
+
+def _normalize_api_key(value: str | None) -> str:
+    cleaned = _clean_scalar(value) or ""
+    if cleaned.lower().startswith("bearer "):
+        cleaned = cleaned[7:].strip()
+    if cleaned.lower() in _INVALID_KEY_VALUES:
+        return ""
+    return cleaned
 
 
 def _selected_provider(provider: str | None = None) -> str:
@@ -50,39 +79,82 @@ def _resolve_model(provider: str) -> str:
     return DEFAULT_OPENAI_MODEL
 
 
+def _normalize_base_url(value: str | None, *, provider: str) -> str | None:
+    cleaned = _clean_scalar(value)
+    if provider == "openrouter" and not cleaned:
+        cleaned = DEFAULT_OPENROUTER_BASE_URL
+    if not cleaned:
+        return None
+    cleaned = cleaned.rstrip("/")
+    lower = cleaned.lower()
+    if lower.endswith("/chat/completions"):
+        cleaned = cleaned[: -len("/chat/completions")].rstrip("/")
+    if provider == "openrouter":
+        parts = urlsplit(cleaned)
+        if parts.netloc == "openrouter.ai" and not parts.path.rstrip("/").endswith("/api/v1"):
+            cleaned = urlunsplit((parts.scheme or "https", parts.netloc, "/api/v1", "", ""))
+    return cleaned.rstrip("/")
+
+
+def _resolve_api_key(selected: str) -> tuple[str, str]:
+    if selected == "openrouter":
+        for name in ("OPENROUTER_API_KEY", "OPENAI_API_KEY"):
+            key = _normalize_api_key(os.getenv(name))
+            if key:
+                return key, name
+        return "", "missing"
+    key = _normalize_api_key(os.getenv("OPENAI_API_KEY"))
+    return key, "OPENAI_API_KEY" if key else "missing"
+
+
 def resolve_llm_config(*, provider: str | None = None, require_api_key: bool = True) -> LLMConfig:
     selected = _selected_provider(provider)
-    if selected == "openrouter":
-        api_key = _env("OPENROUTER_API_KEY") or _env("OPENAI_API_KEY") or ""
-        base_url = _env("OPENAI_BASE_URL") or _env("OPENROUTER_BASE_URL") or DEFAULT_OPENROUTER_BASE_URL
-    elif selected == "openai":
-        api_key = _env("OPENAI_API_KEY") or ""
-        base_url = _env("OPENAI_BASE_URL")
-    else:
+    if selected not in {"openrouter", "openai"}:
         raise LLMConfigurationError(f"Unsupported LLM provider: {selected}")
-
-    config = LLMConfig(provider=selected, api_key=api_key.strip(), base_url=base_url.rstrip("/") if base_url else None, model=_resolve_model(selected))
+    api_key, source = _resolve_api_key(selected)
+    raw_base = (_env("OPENAI_BASE_URL") or _env("OPENROUTER_BASE_URL")) if selected == "openrouter" else _env("OPENAI_BASE_URL")
+    config = LLMConfig(provider=selected, api_key=api_key, base_url=_normalize_base_url(raw_base, provider=selected), model=_resolve_model(selected), api_key_source=source)
     if require_api_key and not config.api_key_present:
         key_name = "OPENROUTER_API_KEY or OPENAI_API_KEY" if selected == "openrouter" else "OPENAI_API_KEY"
         raise LLMConfigurationError(f"LLM configuration error: {key_name} is required for provider {selected}")
+    if require_api_key and selected == "openrouter" and not config.api_key_prefix_valid:
+        raise LLMConfigurationError("LLM configuration error: OPENROUTER_API_KEY must use an accepted OpenRouter key prefix")
+    log_llm_startup_config(config)
+    return config
 
+
+def openai_sdk_version() -> str:
+    try:
+        return version("openai")
+    except PackageNotFoundError:
+        return "not_installed"
+
+
+def log_llm_startup_config(config: LLMConfig | None = None) -> None:
+    config = config or resolve_llm_config(require_api_key=False)
     logger.info("LLM provider selected: %s", config.provider)
     logger.info("LLM base URL: %s", config.base_url or "default")
     logger.info("LLM model: %s", config.model)
     logger.info("LLM API key present: %s", str(config.api_key_present).lower())
-    return config
+    logger.info("LLM API key source: %s", config.api_key_source)
+    logger.info("LLM API key length: %s", len(config.api_key))
+    if config.provider == "openrouter" and not config.configuration_valid:
+        logger.error("LLM configuration error: OpenRouter API key is missing or invalid")
 
 
 def llm_debug_payload() -> dict[str, object]:
     try:
         config = resolve_llm_config(require_api_key=False)
-        valid = config.api_key_present
         return {
             "llm_provider": config.provider,
             "llm_base_url": config.base_url,
             "llm_model": config.model,
             "llm_api_key_present": config.api_key_present,
-            "llm_configuration_valid": valid,
+            "llm_api_key_length": len(config.api_key),
+            "llm_api_key_prefix_valid": config.api_key_prefix_valid,
+            "llm_api_key_source": config.api_key_source,
+            "openai_sdk_version": openai_sdk_version(),
+            "llm_configuration_valid": config.configuration_valid,
         }
     except LLMConfigurationError as exc:
         return {
@@ -90,6 +162,10 @@ def llm_debug_payload() -> dict[str, object]:
             "llm_base_url": None,
             "llm_model": None,
             "llm_api_key_present": False,
+            "llm_api_key_length": 0,
+            "llm_api_key_prefix_valid": False,
+            "llm_api_key_source": "missing",
+            "openai_sdk_version": openai_sdk_version(),
             "llm_configuration_valid": False,
             "llm_configuration_error": str(exc),
         }

--- a/app/services/llm_review/openai_provider.py
+++ b/app/services/llm_review/openai_provider.py
@@ -25,11 +25,26 @@ class OpenAIReviewProvider:
         self.retries = max(0, int(retries))
         self.prompt_builder = prompt_builder or PromptBuilder()
 
+    def _default_headers(self) -> dict[str, str] | None:
+        if self.provider_name != "openrouter":
+            return None
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "HTTP-Referer": "https://fxpilot.ru",
+            "X-Title": "FXPilot",
+        }
+
     def generate_review(self, context: dict[str, Any]) -> LLMReview:
         if not self.api_key.strip():
             raise RuntimeError(f"LLM configuration error: API key is required for provider {self.provider_name}")
         prompt = self.prompt_builder.build(context)
-        client = OpenAI(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout, max_retries=self.retries)
+        client = OpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            default_headers=self._default_headers(),
+            timeout=self.timeout,
+            max_retries=self.retries,
+        )
         started = time.perf_counter()
         response = client.chat.completions.create(
             model=self.model,

--- a/app/services/openrouter_diagnostics.py
+++ b/app/services/openrouter_diagnostics.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from openai import OpenAI
+
+from app.services.llm_config import LLMConfigurationError, resolve_llm_config
+
+
+def _preview(value: Any, limit: int = 500) -> str:
+    text = str(value)
+    return text[:limit]
+
+
+def build_openrouter_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://fxpilot.ru",
+        "X-Title": "FXPilot",
+    }
+
+
+def run_openrouter_diagnostic() -> dict[str, Any]:
+    try:
+        config = resolve_llm_config(provider="openrouter", require_api_key=False)
+    except LLMConfigurationError as exc:
+        return {"success": False, "error": str(exc), "provider": "openrouter"}
+
+    payload: dict[str, Any] = {
+        "model": config.model,
+        "messages": [{"role": "user", "content": "Return only OK"}],
+        "max_tokens": 10,
+    }
+    result: dict[str, Any] = {
+        "success": False,
+        "status_code": None,
+        "provider": config.provider,
+        "base_url": config.base_url,
+        "model": config.model,
+        "api_key_present": config.api_key_present,
+        "api_key_source": config.api_key_source,
+        "response_preview": None,
+        "error": None,
+        "direct_http_success": False,
+        "sdk_success": False,
+        "direct_http_status": None,
+        "sdk_error": None,
+    }
+    if not config.api_key_present:
+        result["error"] = "missing_openrouter_api_key"
+        return result
+
+    url = f"{(config.base_url or 'https://openrouter.ai/api/v1').rstrip('/')}/chat/completions"
+    try:
+        response = requests.post(url, headers=build_openrouter_headers(config.api_key), json=payload, timeout=30)
+        result["status_code"] = response.status_code
+        result["direct_http_status"] = response.status_code
+        result["response_preview"] = _preview(response.text)
+        result["direct_http_success"] = 200 <= response.status_code < 300
+    except Exception as exc:  # pragma: no cover - network diagnostics
+        result["error"] = f"{type(exc).__name__}: {exc}"
+
+    try:
+        client = OpenAI(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            default_headers={
+                "Authorization": f"Bearer {config.api_key}",
+                "HTTP-Referer": "https://fxpilot.ru",
+                "X-Title": "FXPilot",
+            },
+            timeout=30,
+            max_retries=0,
+        )
+        client.chat.completions.create(**payload)
+        result["sdk_success"] = True
+    except Exception as exc:  # pragma: no cover - SDK diagnostics
+        result["sdk_error"] = _preview(f"{type(exc).__name__}: {exc}")
+
+    result["success"] = bool(result["direct_http_success"] and result["sdk_success"])
+    return result

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -26,14 +26,14 @@ def clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_openrouter_uses_openrouter_api_key(monkeypatch):
     clear_env(monkeypatch)
     monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
-    monkeypatch.setenv("OPENROUTER_API_KEY", "or-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-secret")
     monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
     monkeypatch.setenv("OPENAI_BASE_URL", "https://openrouter.ai/api/v1")
 
     config = resolve_llm_config()
 
     assert config.provider == "openrouter"
-    assert config.api_key == "or-secret"
+    assert config.api_key == "sk-or-secret"
     assert config.base_url == "https://openrouter.ai/api/v1"
 
 
@@ -51,7 +51,7 @@ def test_openrouter_falls_back_to_openai_key(monkeypatch):
 def test_direct_openai_uses_openai_api_key(monkeypatch):
     clear_env(monkeypatch)
     monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openai")
-    monkeypatch.setenv("OPENROUTER_API_KEY", "or-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-secret")
     monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
 
     config = resolve_llm_config()
@@ -71,26 +71,59 @@ def test_missing_key_raises_clear_configuration_error(monkeypatch):
 def test_client_receives_non_empty_api_key(monkeypatch):
     clear_env(monkeypatch)
     monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
-    monkeypatch.setenv("OPENROUTER_API_KEY", "or-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-secret")
 
     provider = OpenAIReviewProvider()
 
-    assert provider.api_key == "or-secret"
+    assert provider.api_key == "sk-or-secret"
     assert provider.base_url == "https://openrouter.ai/api/v1"
 
 
 def test_no_secret_appears_in_logs_or_debug_response(monkeypatch, caplog):
     clear_env(monkeypatch)
     monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
-    monkeypatch.setenv("OPENROUTER_API_KEY", "super-secret-openrouter-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-super-secret-openrouter-key")
     monkeypatch.setenv("OPENROUTER_MODEL", "x-ai/test")
 
     with caplog.at_level(logging.INFO):
         config = resolve_llm_config()
     payload = llm_debug_payload()
 
-    assert config.api_key == "super-secret-openrouter-key"
+    assert config.api_key == "sk-or-super-secret-openrouter-key"
     assert payload["llm_api_key_present"] is True
     assert payload["llm_configuration_valid"] is True
-    assert "super-secret-openrouter-key" not in caplog.text
-    assert "super-secret-openrouter-key" not in str(payload)
+    assert "sk-or-super-secret-openrouter-key" not in caplog.text
+    assert "sk-or-super-secret-openrouter-key" not in str(payload)
+
+
+def test_openrouter_api_key_selected_before_openai(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", " sk-or-primary ")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-fallback")
+
+    config = resolve_llm_config()
+
+    assert config.api_key == "sk-or-primary"
+    assert config.api_key_source == "OPENROUTER_API_KEY"
+
+
+def test_openrouter_key_whitespace_quotes_and_bearer_are_normalized(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", " 'Bearer sk-or-quoted' ")
+
+    config = resolve_llm_config()
+
+    assert config.api_key == "sk-or-quoted"
+
+
+def test_openrouter_full_chat_completions_url_normalized(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-secret")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openrouter.ai/api/v1/chat/completions")
+
+    config = resolve_llm_config()
+
+    assert config.base_url == "https://openrouter.ai/api/v1"

--- a/tests/test_openrouter_diagnostics.py
+++ b/tests/test_openrouter_diagnostics.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.services.openrouter_diagnostics import build_openrouter_headers
+
+
+def test_direct_http_request_includes_authorization_header():
+    headers = build_openrouter_headers("sk-or-secret")
+
+    assert headers["Authorization"] == "Bearer sk-or-secret"
+    assert headers["HTTP-Referer"] == "https://fxpilot.ru"
+    assert headers["X-Title"] == "FXPilot"
+
+
+def test_openrouter_test_endpoint_returns_safe_diagnostics(monkeypatch):
+    monkeypatch.setenv("FXPILOT_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-secret")
+    monkeypatch.setattr(main, "run_openrouter_diagnostic", lambda: {
+        "success": False,
+        "status_code": 401,
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "model": "x-ai/test",
+        "api_key_present": True,
+        "api_key_source": "OPENROUTER_API_KEY",
+        "response_preview": "Missing Authentication header",
+        "error": None,
+        "direct_http_success": False,
+        "sdk_success": False,
+        "direct_http_status": 401,
+        "sdk_error": "AuthenticationError",
+    })
+
+    payload = TestClient(main.app).get("/api/ai/openrouter-test").json()
+
+    assert payload["api_key_present"] is True
+    assert payload["api_key_source"] == "OPENROUTER_API_KEY"
+    assert "sk-or-secret" not in str(payload)
+
+
+def test_openai_client_receives_explicit_default_authorization_header(monkeypatch):
+    from app.services.llm_config import LLMConfig
+    from app.services.llm_review import openai_provider
+
+    captured = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            class Message:
+                content = '{"summary":"ok"}'
+            class Choice:
+                message = Message()
+            class Response:
+                choices = [Choice()]
+                usage = None
+            return Response()
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.chat = type("Chat", (), {"completions": FakeCompletions()})()
+
+    monkeypatch.setattr(openai_provider, "OpenAI", FakeOpenAI)
+    provider = openai_provider.OpenAIReviewProvider(config=LLMConfig(provider="openrouter", api_key="sk-or-secret", base_url="https://openrouter.ai/api/v1", model="x-ai/test", api_key_source="OPENROUTER_API_KEY"))
+
+    provider.generate_review({"video": {"title": "t"}})
+
+    assert captured["default_headers"]["Authorization"] == "Bearer sk-or-secret"
+    assert captured["default_headers"]["HTTP-Referer"] == "https://fxpilot.ru"


### PR DESCRIPTION
### Motivation
- Выявить и устранить причину 401 «Missing Authentication header» при вызовах OpenRouter, не меняя остальную бизнес-логику импорта медиа. 
- Обеспечить детальную, но безопасную диагностику конфигурации LLM и сравнение прямого HTTP-запроса с поведением OpenAI SDK. 

### Description
- Усилена логика конфигурации в `app/services/llm_config.py`: нормализация пробелов и кавычек, удаление префикса `Bearer `, отклонение невалидных значений (`None`, `null`, `undefined`, пустые), приоритет `OPENROUTER_API_KEY` перед `OPENAI_API_KEY`, нормализация полного `/chat/completions` URL обратно к базовому `https://openrouter.ai/api/v1`, и добавлены поля диагностики (`api_key_source`, `llm_api_key_length`, `llm_api_key_prefix_valid`, `openai_sdk_version`) без раскрытия ключа. 
- Для генерации AI Review явная передача заголовков в OpenAI-клиент: `default_headers` содержит `Authorization: Bearer <key>`, `HTTP-Referer` и `X-Title` в `app/services/llm_review/openai_provider.py`, чтобы не полагаться только на имплицитную аутентификацию SDK. 
- Добавлен диагностический модуль `app/services/openrouter_diagnostics.py` и новый endpoint `GET /api/ai/openrouter-test`, который выполняет прямой `requests.post` к `{base_url}/chat/completions` и параллельный вызов через OpenAI SDK, возвращая безопасные поля: `success`, `status_code`, `provider`, `base_url`, `model`, `api_key_present`, `api_key_source`, `response_preview`, `error`, `direct_http_success`, `sdk_success`, `direct_http_status`, `sdk_error`. 
- При стартапе приложения добавлен безопасный лог конфигурации через `log_llm_startup_config()` (без вывода ключей). 
- Обновлены и добавлены тесты: расширены `tests/test_llm_config.py` и добавлен `tests/test_openrouter_diagnostics.py` для проверки приоритета ключей, нормализации, безопасности debug-вывода, inclusion Authorization в прямом HTTP-запросе и передачи `default_headers` в OpenAI-клиент. 

### Testing
- Запущены модульные тесты: `pytest -q tests/test_llm_config.py tests/test_openrouter_diagnostics.py` и интеграционный набор `pytest -q tests/test_media_import_engine.py tests/test_llm_review.py tests/test_llm_config.py tests/test_openrouter_diagnostics.py`. 
- Все запущенные тесты прошли успешно (вместе: `52 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a508916f8388331928d4a4ad834b148)