### PR TITLE
Исправление извлечения структурированных торговых сущностей (Stage 16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+
+## Stage 16 — Structured AI Review entity extraction
+
+- AI Review now uses a strict structured JSON contract for trading entities: `symbols`, `primary_symbol`, `timeframe`, `direction`, confidence, entry/entry zone, stop loss, take profits/targets, detected levels and per-symbol `trade_ideas`. Missing market facts are stored as `null` or empty arrays instead of fake prices.
+- The Grok/OpenRouter prompt explicitly requires valid JSON only, forbids invented instruments/prices, distinguishes broad market commentary from actionable trade ideas, and includes common aliases such as золото/gold → `XAUUSD`, euro dollar → `EURUSD`, Bitcoin → `BTCUSD`, Brent → `UKOIL`.
+- A deterministic fallback extractor validates and supplements LLM symbols from video title, description, tags, existing media symbol, transcript and LLM summaries so real instruments no longer collapse to the `MARKET` compatibility fallback.
+- `GET /api/media/review/{video_id}` and `GET /api/tv/review/{video_id}` now return structured top-level fields while keeping backward-compatible `symbol` and `llm_review` fields.
+- Added manual reprocessing endpoint: `POST /api/media/reviews/reprocess?force=false&limit=<number>` regenerates reviews with `MARKET`/missing symbols or empty trade ideas; use `force=true` to rebuild already structured reviews.
+- `/api/media/debug` now reports review entity coverage: total reviews, reviews with primary symbol, trade ideas, MARKET fallback, direction, levels and last extraction error.
+
 ## Stage 12 — YouTube Data API Primary Provider
 
 - FXPilot TV теперь использует официальный YouTube Data API v3 как первичный YouTube-провайдер при наличии `YOUTUBE_API_KEY`; `yt-dlp` остаётся автоматическим fallback только для источников, где API-импорт завершился ошибкой или ключ отсутствует.

--- a/app/main.py
+++ b/app/main.py
@@ -764,6 +764,19 @@ def _build_tv_review_payload(video: dict[str, Any], market_payload: dict[str, An
         "knowledge_context": knowledge_context,
         "knowledge": knowledge_context,
         "llm_review": llm_review.model_dump(),
+        "symbols": llm_review.symbols,
+        "primary_symbol": llm_review.primary_symbol,
+        "symbol": llm_review.primary_symbol,
+        "timeframe": llm_review.timeframe,
+        "direction": llm_review.direction,
+        "confidence": llm_review.confidence,
+        "entry": llm_review.entry,
+        "entry_zone": llm_review.entry_zone,
+        "stop_loss": llm_review.stop_loss,
+        "take_profit": llm_review.take_profit,
+        "targets": llm_review.targets,
+        "detected_levels": [level.model_dump() for level in llm_review.detected_levels],
+        "trade_ideas": [idea.model_dump() for idea in llm_review.trade_ideas],
         "agreement_score": knowledge_context.get("agreement_score"),
         "warnings": knowledge_context.get("warnings", []),
         "conflicts": knowledge_context.get("conflicts", []),
@@ -995,6 +1008,34 @@ def api_media_stats() -> dict[str, Any]:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+
+def _llm_review_entity_debug() -> dict[str, Any]:
+    reviews: list[LLMReview] = []
+    last_error = None
+    try:
+        for path in LLM_REVIEW_STORAGE.base_dir.glob("*.json"):
+            try:
+                review = LLMReview.model_validate(json.loads(path.read_text(encoding="utf-8")))
+                reviews.append(review)
+            except Exception as exc:
+                last_error = f"{path.name}: {exc.__class__.__name__}"
+    except Exception as exc:
+        last_error = exc.__class__.__name__
+    return {
+        "reviews_total": len(reviews),
+        "reviews_with_primary_symbol": sum(1 for r in reviews if r.primary_symbol),
+        "reviews_with_trade_ideas": sum(1 for r in reviews if r.trade_ideas),
+        "reviews_with_market_fallback": sum(1 for r in reviews if (r.symbol or "").upper() == "MARKET" or not r.primary_symbol),
+        "reviews_with_direction": sum(1 for r in reviews if r.direction in {"BUY", "SELL", "WAIT"}),
+        "reviews_with_levels": sum(1 for r in reviews if r.detected_levels or r.entry or r.stop_loss or r.take_profit or r.targets),
+        "last_entity_extraction_error": last_error,
+    }
+
+def _review_needs_reprocess(review: LLMReview | None) -> bool:
+    if review is None:
+        return True
+    return (not review.primary_symbol) or ((review.symbol or "").upper() == "MARKET") or (not review.trade_ideas)
+
 @app.get("/api/media/debug")
 def api_media_debug() -> dict[str, Any]:
     try:
@@ -1002,6 +1043,7 @@ def api_media_debug() -> dict[str, Any]:
         payload.update(transcript_engine.debug_payload())
         payload.update(MEDIA_KNOWLEDGE_DEBUG)
         payload.update(llm_debug_payload())
+        payload.update(_llm_review_entity_debug())
         return payload
     except MediaConfigError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -1204,6 +1246,31 @@ def api_consensus_symbol(symbol: str, timeframe: str | None = None, date_from: s
 def api_consensus_symbol_timeframe(symbol: str, timeframe: str, date_from: str | None = None, date_to: str | None = None) -> dict[str, Any]:
     return create_consensus_engine().build(symbol, timeframe, date_from=date_from, date_to=date_to)
 
+
+@app.post("/api/media/reviews/reprocess")
+def api_media_reviews_reprocess(force: bool = False, limit: int | None = None) -> dict[str, Any]:
+    videos = _load_tv_video_catalog()
+    engine = create_llm_review_engine(market_payload=ideas_market())
+    result: dict[str, Any] = {"requested": 0, "generated": 0, "updated": 0, "failed": 0, "items": []}
+    max_items = max(0, int(limit)) if limit is not None else None
+    for video in videos:
+        catalog_id = canonical_catalog_id(video)
+        cached = LLM_REVIEW_STORAGE.get(catalog_id)
+        if not force and not _review_needs_reprocess(cached):
+            continue
+        if max_items is not None and result["requested"] >= max_items:
+            break
+        result["requested"] += 1
+        try:
+            existed = cached is not None
+            review = engine.generate(catalog_id, force=True)
+            result["updated" if existed else "generated"] += 1
+            result["items"].append({"video_id": catalog_id, "status": "updated" if existed else "generated", "primary_symbol": review.primary_symbol, "symbols": review.symbols})
+        except Exception as exc:
+            logger.exception("media_reviews_reprocess_failed video_id=%s", catalog_id)
+            result["failed"] += 1
+            result["items"].append({"video_id": catalog_id, "status": "failed", "error": exc.__class__.__name__})
+    return result
 
 @app.get("/api/media/review/{video_id}")
 def api_media_review(video_id: str) -> dict[str, Any]:

--- a/app/services/llm_review/entity_extraction.py
+++ b/app/services/llm_review/entity_extraction.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+VALID_DIRECTIONS = {"BUY", "SELL", "WAIT", "NEUTRAL"}
+VALID_TIMEFRAMES = {"M1", "M5", "M15", "M30", "H1", "H4", "D1", "W1"}
+
+_ALIAS_PATTERNS: list[tuple[str, str]] = [
+    ("EURUSD", r"\bEUR\s*/?\s*USD\b|\bEURUSD\b|евро\s*(?:доллар|бакс)|евро/доллар|euro\s*dollar"),
+    ("GBPUSD", r"\bGBP\s*/?\s*USD\b|\bGBPUSD\b|фунт\s*(?:доллар|бакс)|pound\s*dollar|cable"),
+    ("USDJPY", r"\bUSD\s*/?\s*JPY\b|\bUSDJPY\b|доллар\s*иен|доллар/иен|dollar\s*yen"),
+    ("USDCHF", r"\bUSD\s*/?\s*CHF\b|\bUSDCHF\b|доллар\s*франк|dollar\s*franc"),
+    ("USDCAD", r"\bUSD\s*/?\s*CAD\b|\bUSDCAD\b|доллар\s*канад|dollar\s*cad"),
+    ("AUDUSD", r"\bAUD\s*/?\s*USD\b|\bAUDUSD\b|австрал(?:иец|ийский доллар)|aussie"),
+    ("NZDUSD", r"\bNZD\s*/?\s*USD\b|\bNZDUSD\b|новозеланд|kiwi"),
+    ("EURGBP", r"\bEUR\s*/?\s*GBP\b|\bEURGBP\b|евро\s*фунт"),
+    ("EURJPY", r"\bEUR\s*/?\s*JPY\b|\bEURJPY\b|евро\s*иен"),
+    ("GBPJPY", r"\bGBP\s*/?\s*JPY\b|\bGBPJPY\b|фунт\s*иен"),
+    ("XAUUSD", r"\bXAU\s*/?\s*USD\b|\bXAUUSD\b|\bgold\b|золото"),
+    ("XAGUSD", r"\bXAG\s*/?\s*USD\b|\bXAGUSD\b|\bsilver\b|серебро"),
+    ("BTCUSD", r"\bBTC\s*/?\s*USD\b|\bBTCUSD\b|\bbitcoin\b|биткоин|биткойн"),
+    ("ETHUSD", r"\bETH\s*/?\s*USD\b|\bETHUSD\b|\bethereum\b|эфириум|эфир"),
+    ("SPX", r"\bSPX\b|\bS&P\s*500\b|\bSP500\b|s\s*&\s*p|эс\s*энд\s*пи"),
+    ("NAS100", r"\bNAS100\b|\bNASDAQ\s*100\b|\bNDX\b|насдак"),
+    ("DAX", r"\bDAX\b|\bGER40\b|немецкий\s*индекс"),
+    ("UKOIL", r"\bUKOIL\b|\bBRENT\b|brent|брент"),
+    ("WTI", r"\bWTI\b|\bUSOIL\b|wti|американская\s*нефть"),
+]
+
+
+def unique_symbols(values: list[Any]) -> list[str]:
+    out: list[str] = []
+    for value in values:
+        raw = str(value or "").upper().replace("/", "").replace(" ", "").strip()
+        if raw in {"", "MARKET", "UNKNOWN", "NONE", "NULL"}:
+            continue
+        if raw == "SP500": raw = "SPX"
+        if raw == "BRENT": raw = "UKOIL"
+        if raw == "NDX": raw = "NAS100"
+        if raw not in out:
+            out.append(raw)
+    return out
+
+
+def extract_symbols_from_text(*parts: Any) -> list[str]:
+    text = "\n".join(str(p or "") for p in parts)
+    found: list[str] = []
+    for symbol, pattern in _ALIAS_PATTERNS:
+        if re.search(pattern, text, flags=re.IGNORECASE | re.UNICODE):
+            found.append(symbol)
+    return unique_symbols(found)
+
+
+def normalize_direction(value: Any) -> str:
+    raw = str(value or "").strip().upper()
+    mapping = {"LONG":"BUY", "BUY":"BUY", "ПОКУП":"BUY", "ЛОНГ":"BUY", "SHORT":"SELL", "SELL":"SELL", "ПРОДА":"SELL", "ШОРТ":"SELL", "WAIT":"WAIT", "HOLD":"WAIT", "ЖДАТ":"WAIT", "NEUTRAL":"NEUTRAL", "IGNORE":"NEUTRAL"}
+    for key, val in mapping.items():
+        if key in raw:
+            return val
+    return "NEUTRAL"
+
+
+def normalize_timeframe(value: Any) -> str | None:
+    raw = str(value or "").strip().upper().replace(" ", "")
+    aliases = {"1M":"M1", "5M":"M5", "15M":"M15", "30M":"M30", "1H":"H1", "4H":"H4", "1D":"D1", "DAILY":"D1", "1W":"W1", "WEEKLY":"W1"}
+    raw = aliases.get(raw, raw)
+    return raw if raw in VALID_TIMEFRAMES else None
+
+
+def to_float_or_none(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(str(value).replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_confidence(value: Any) -> int:
+    try:
+        num = float(value)
+        if 0 < num <= 1:
+            num *= 100
+        return max(0, min(100, int(round(num))))
+    except (TypeError, ValueError):
+        return 0

--- a/app/services/llm_review/models.py
+++ b/app/services/llm_review/models.py
@@ -3,49 +3,165 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from pydantic import BaseModel, Field, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.services.llm_review.entity_extraction import normalize_confidence, normalize_direction, normalize_timeframe, to_float_or_none, unique_symbols
+
+
+class DetectedLevel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    type: str | None = None
+    price: float | None = None
+    symbol: str | None = None
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def price_float(cls, value: Any) -> float | None:
+        return to_float_or_none(value)
+
+    @field_validator("symbol", mode="before")
+    @classmethod
+    def symbol_norm(cls, value: Any) -> str | None:
+        vals = unique_symbols([value])
+        return vals[0] if vals else None
+
+
+class TradingIdea(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    symbol: str | None = None
+    timeframe: str | None = None
+    direction: str = "NEUTRAL"
+    entry: float | None = None
+    entry_zone: list[float] = Field(default_factory=list)
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    targets: list[float] = Field(default_factory=list)
+    confidence: int = Field(default=0, ge=0, le=100)
+    reasoning: str = ""
+
+    @field_validator("symbol", mode="before")
+    @classmethod
+    def symbol_norm(cls, value: Any) -> str | None:
+        vals = unique_symbols([value])
+        return vals[0] if vals else None
+
+    @field_validator("timeframe", mode="before")
+    @classmethod
+    def tf_norm(cls, value: Any) -> str | None:
+        return normalize_timeframe(value)
+
+    @field_validator("direction", mode="before")
+    @classmethod
+    def dir_norm(cls, value: Any) -> str:
+        return normalize_direction(value)
+
+    @field_validator("entry", "stop_loss", "take_profit", mode="before")
+    @classmethod
+    def float_norm(cls, value: Any) -> float | None:
+        return to_float_or_none(value)
+
+    @field_validator("entry_zone", "targets", mode="before")
+    @classmethod
+    def floats_norm(cls, value: Any) -> list[float]:
+        if not isinstance(value, list):
+            return []
+        return [num for item in value if (num := to_float_or_none(item)) is not None]
+
+    @field_validator("confidence", mode="before")
+    @classmethod
+    def conf_norm(cls, value: Any) -> int:
+        return normalize_confidence(value)
 
 
 class LLMReview(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    summary: str = "Unknown."
-    direction: str = "Unknown"
+    summary: str = ""
+    market_overview: str = ""
+    symbols: list[str] = Field(default_factory=list)
+    primary_symbol: str | None = None
+    symbol: str | None = None
+    timeframe: str | None = None
+    direction: str = "NEUTRAL"
     confidence: int = Field(default=0, ge=0, le=100)
     agreement_score: int = Field(default=0, ge=0, le=100)
-    entry: Any = "Unknown"
-    stop_loss: Any = "Unknown"
-    take_profit: Any = "Unknown"
-    targets: list[Any] = Field(default_factory=list)
+    entry: float | None = None
+    entry_zone: list[float] = Field(default_factory=list)
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    targets: list[float] = Field(default_factory=list)
+    detected_levels: list[DetectedLevel] = Field(default_factory=list)
+    trade_ideas: list[TradingIdea] = Field(default_factory=list)
     reasoning: list[str] = Field(default_factory=list)
     risks: list[str] = Field(default_factory=list)
     opportunities: list[str] = Field(default_factory=list)
     contradictions: list[str] = Field(default_factory=list)
-    institutional_view: str = "Unknown."
-    news_impact: str = "Unknown."
-    market_bias: str = "Unknown"
-    recommended_action: str = "Unknown."
+    institutional_view: str = ""
+    news_impact: str = ""
+    market_bias: str = "NEUTRAL"
+    recommended_action: str = "IGNORE"
     created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     provider: str = "unknown"
     tokens_used: int = 0
     latency_ms: int = 0
 
+    @field_validator("symbols", mode="before")
+    @classmethod
+    def symbols_norm(cls, value: Any) -> list[str]:
+        return unique_symbols(value if isinstance(value, list) else [value])
+
+    @field_validator("primary_symbol", "symbol", mode="before")
+    @classmethod
+    def single_symbol_norm(cls, value: Any) -> str | None:
+        vals = unique_symbols([value])
+        return vals[0] if vals else None
+
+    @field_validator("direction", "market_bias", mode="before")
+    @classmethod
+    def direction_norm(cls, value: Any) -> str:
+        return normalize_direction(value)
+
+    @field_validator("recommended_action", mode="before")
+    @classmethod
+    def action_norm(cls, value: Any) -> str:
+        raw = normalize_direction(value)
+        return raw if raw in {"BUY", "SELL", "WAIT"} else "IGNORE"
+
+    @field_validator("timeframe", mode="before")
+    @classmethod
+    def timeframe_norm(cls, value: Any) -> str | None:
+        return normalize_timeframe(value)
+
     @field_validator("confidence", "agreement_score", mode="before")
     @classmethod
     def clamp_percent(cls, value: Any) -> int:
-        try:
-            number = int(round(float(value)))
-        except (TypeError, ValueError):
-            return 0
-        return max(0, min(100, number))
+        return normalize_confidence(value)
+
+    @field_validator("entry", "stop_loss", "take_profit", mode="before")
+    @classmethod
+    def float_norm(cls, value: Any) -> float | None:
+        return to_float_or_none(value)
+
+    @field_validator("entry_zone", "targets", mode="before")
+    @classmethod
+    def floats_norm(cls, value: Any) -> list[float]:
+        if not isinstance(value, list):
+            return []
+        return [num for item in value if (num := to_float_or_none(item)) is not None]
+
+    @model_validator(mode="after")
+    def reconcile(self) -> "LLMReview":
+        idea_symbols = [idea.symbol for idea in self.trade_ideas if idea.symbol]
+        self.symbols = unique_symbols([*self.symbols, self.primary_symbol, self.symbol, *idea_symbols])
+        if self.primary_symbol not in self.symbols:
+            self.primary_symbol = self.symbols[0] if self.symbols else None
+        self.symbol = self.primary_symbol
+        return self
 
     @classmethod
     def from_payload(cls, payload: dict[str, Any], *, provider: str | None = None, tokens_used: int | None = None, latency_ms: int | None = None) -> "LLMReview":
-        data = dict(payload or {})
-        if provider is not None:
-            data["provider"] = provider
-        if tokens_used is not None:
-            data["tokens_used"] = tokens_used
-        if latency_ms is not None:
-            data["latency_ms"] = latency_ms
+        data = dict(payload or {}) if isinstance(payload, dict) else {}
+        if provider is not None: data["provider"] = provider
+        if tokens_used is not None: data["tokens_used"] = tokens_used
+        if latency_ms is not None: data["latency_ms"] = latency_ms
         return cls.model_validate(data)

--- a/app/services/llm_review/openai_provider.py
+++ b/app/services/llm_review/openai_provider.py
@@ -54,6 +54,9 @@ class OpenAIReviewProvider:
         )
         latency_ms = int((time.perf_counter() - started) * 1000)
         content = response.choices[0].message.content or "{}"
-        payload = json.loads(content)
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError:
+            payload = {"summary": "LLM вернул невалидный JSON; применена безопасная нормализация.", "risks": ["invalid_llm_json"]}
         tokens = getattr(getattr(response, "usage", None), "total_tokens", 0) or 0
         return LLMReview.from_payload(payload, provider=f"{self.provider_name}:{self.model}", tokens_used=int(tokens), latency_ms=latency_ms)

--- a/app/services/llm_review/prompt_builder.py
+++ b/app/services/llm_review/prompt_builder.py
@@ -3,32 +3,37 @@ from __future__ import annotations
 import json
 from typing import Any
 
-
-REQUIRED_JSON_FIELDS = [
-    "summary", "direction", "confidence", "agreement_score", "entry", "stop_loss", "take_profit",
-    "targets", "reasoning", "risks", "opportunities", "contradictions", "institutional_view",
-    "news_impact", "market_bias", "recommended_action",
-]
-
+SCHEMA = {
+  "summary":"string", "market_overview":"string", "symbols":["EURUSD","XAUUSD"], "primary_symbol":"EURUSD|null",
+  "timeframe":"M1|M5|M15|M30|H1|H4|D1|W1|null", "direction":"BUY|SELL|WAIT|NEUTRAL", "confidence":0,
+  "entry":0.0, "entry_zone":[0.0,0.0], "stop_loss":0.0, "take_profit":0.0, "targets":[0.0],
+  "detected_levels":[{"type":"support|resistance|entry|stop_loss|take_profit|target", "price":0.0, "symbol":"EURUSD"}],
+  "trade_ideas":[{"symbol":"EURUSD", "timeframe":"H4", "direction":"BUY|SELL|WAIT|NEUTRAL", "entry":0.0, "entry_zone":[0.0,0.0], "stop_loss":0.0, "take_profit":0.0, "targets":[0.0], "confidence":0, "reasoning":"string"}],
+  "risks":["string"], "opportunities":["string"], "contradictions":["string"], "institutional_view":"string", "news_impact":"string", "recommended_action":"BUY|SELL|WAIT|IGNORE"
+}
 
 class PromptBuilder:
     def build(self, context: dict[str, Any]) -> str:
         safe_context = json.dumps(context, ensure_ascii=False, default=str, indent=2)
-        fields = json.dumps(REQUIRED_JSON_FIELDS, ensure_ascii=False)
-        return f"""You are a Senior Institutional FX Analyst.
+        schema = json.dumps(SCHEMA, ensure_ascii=False, indent=2)
+        return f"""You are a Senior Institutional FX Analyst extracting structured trading entities from FXPilot TV review context.
 
 Rules:
-- Answer ONLY valid JSON. No markdown. No prose outside JSON.
-- Use only the supplied context.
-- Never invent prices.
-- Never invent symbols.
-- If information is missing, write "Unknown".
-- Clearly distinguish proxy metrics from real market metrics.
-- Provide a professional trading review, not financial advice.
+- Answer ONLY valid JSON. No Markdown. No explanations outside JSON.
+- Analyze only facts found in supplied video metadata, transcript and FXPilot context.
+- Never invent symbols. Never invent prices. Never invent an instrument, timeframe or price. Missing values must be null or empty arrays.
+- Distinguish broad market discussion from an actionable trade idea.
+- Extract every explicitly mentioned symbol and create separate trade_ideas for several actionable instruments.
+- If no exact instrument exists, use primary_symbol = null, not MARKET.
+- If no actionable forecast exists, use direction = NEUTRAL and recommended_action = IGNORE.
+- Normalize confidence to 0-100 integer.
+- Normalize direction to BUY, SELL, WAIT or NEUTRAL.
+- Normalize timeframe to M1, M5, M15, M30, H1, H4, D1, W1 or null.
+- Map aliases: gold→XAUUSD; euro dollar→EURUSD; pound dollar→GBPUSD; dollar yen→USDJPY; S&P 500/SP500→SPX; Bitcoin→BTCUSD; Ethereum→ETHUSD; Brent→UKOIL.
+- Clearly label proxy metrics vs real market metrics in text fields when relevant.
 
-Return one JSON object with exactly these business fields: {fields}.
-Use arrays for targets, reasoning, risks, opportunities, contradictions.
-confidence and agreement_score must be integers from 0 to 100.
+Return exactly one JSON object compatible with this schema (use null for missing numeric/string fields):
+{schema}
 
 Supplied context:
 {safe_context}

--- a/app/services/llm_review/review_engine.py
+++ b/app/services/llm_review/review_engine.py
@@ -7,6 +7,7 @@ from app.services.media_identity import canonical_catalog_id, canonical_youtube_
 from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge import KnowledgeEngine
 from app.services.llm_review.models import LLMReview
+from app.services.llm_review.entity_extraction import extract_symbols_from_text, unique_symbols
 from app.services.llm_review.provider import LLMReviewProvider
 from app.services.llm_review.storage import LLMReviewStorage
 from app.services.transcript import TranscriptEngine
@@ -57,6 +58,19 @@ class ReviewEngine:
             "detected_conflicts": knowledge.conflicts,
         }
 
+    def _enrich_entities(self, review: LLMReview, context: dict[str, Any]) -> LLMReview:
+        video = context.get("video") or {}
+        transcript = context.get("transcript") or {}
+        llm_symbols = review.symbols
+        metadata_symbols = extract_symbols_from_text(video.get("title"), video.get("description"), video.get("tags"), video.get("symbol"))
+        context_symbols = extract_symbols_from_text(transcript.get("text"), review.summary, review.market_overview)
+        symbols = unique_symbols([*llm_symbols, *metadata_symbols, *context_symbols])
+        payload = review.model_dump()
+        payload["symbols"] = symbols
+        payload["primary_symbol"] = review.primary_symbol if review.primary_symbol in symbols else (metadata_symbols[0] if metadata_symbols else (symbols[0] if symbols else None))
+        payload["symbol"] = payload["primary_symbol"]
+        return LLMReview.model_validate(payload)
+
     def generate(self, video_id: str, *, force: bool = False) -> LLMReview:
         video = resolve_media_video(video_id, self.media_catalog_loader())
         storage_id = canonical_catalog_id(video) if video else str(video_id)
@@ -64,8 +78,12 @@ class ReviewEngine:
             cached = self.storage.get(storage_id) or self.storage.get(video_id)
             if cached:
                 return cached
-        review = self.provider.generate_review(self.build_context(storage_id))
-        # Re-validate provider JSON through the explicit contract before caching.
-        review = LLMReview.model_validate(review.model_dump())
+        context = self.build_context(storage_id)
+        try:
+            review = self.provider.generate_review(context)
+        except Exception as exc:
+            review = LLMReview(summary="LLM review unavailable; применена детерминированная нормализация.", risks=[f"llm_error:{exc.__class__.__name__}"], provider=getattr(self.provider, "provider_name", "unknown"))
+        # Re-validate provider JSON through the explicit contract and deterministic entity fallback before caching.
+        review = self._enrich_entities(LLMReview.model_validate(review.model_dump()), context)
         self.storage.set(storage_id, review)
         return review

--- a/app/static/tv-review.js
+++ b/app/static/tv-review.js
@@ -7,8 +7,8 @@
     const parts = window.location.pathname.split('/').filter(Boolean);
     return parts[0] === 'tv' && parts[1] === 'review' ? decodeURIComponent(parts[2] || '') : '';
   };
-  const value = (input, fallback = '—') => (input === undefined || input === null || input === '' ? fallback : input);
-  const percent = (input) => input === undefined || input === null || input === '' ? '—' : `${Math.round(Number(input))}%`;
+  const value = (input, fallback = 'Не определено') => (input === undefined || input === null || input === '' ? fallback : input);
+  const percent = (input) => input === undefined || input === null || input === '' ? 'Не определено' : `${Math.round(Number(input))}%`;
   const statusRu = (status) => status === 'available' ? 'Доступен' : 'Недоступен';
   const directionRu = (direction) => direction === 'BUY' ? 'Покупка' : direction === 'SELL' ? 'Продажа' : value(direction, 'Нет направления');
   const verdictRu = (verdict) => ({
@@ -56,7 +56,7 @@
       ['News status', idea.news_status || 'neutral'],
       ['Institutional Narrative', idea.institutional_narrative],
     ];
-    return ReviewSection({ id: 'fxpilotIdea', className: 'tv-review-section--summary', title: 'Current FXPilot idea', content: `<div class="tv-snapshot-grid tv-review-wide-grid">${rows.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div><p class="tv-context-note">Контекст построен фактически из /api/ideas/market. Transcript и LLM не используются.</p>` });
+    return ReviewSection({ id: 'fxpilotIdea', className: 'tv-review-section--summary', title: 'Current FXPilot idea', content: `<div class="tv-snapshot-grid tv-review-wide-grid">${rows.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div><p class="tv-context-note">Контекст построен фактически из /api/ideas/market. LLM Review создаётся настроенным LLM-провайдером и проходит детерминированную проверку символов.</p>` });
   }
 
   function transcriptMessage(status) {
@@ -120,7 +120,7 @@
       ['Risk Warnings', Array.isArray(knowledge.warnings) && knowledge.warnings.length ? knowledge.warnings.join(' · ') : 'Предупреждений нет'],
       ['Conflicts', Array.isArray(knowledge.conflicts) && knowledge.conflicts.length ? knowledge.conflicts.join(' · ') : 'Конфликтов нет'],
     ];
-    return ReviewSection({ id: 'knowledgeContext', className: 'tv-review-section--summary tv-verdict-section', title: 'FXPilot Knowledge Context', content: `<div class="tv-snapshot-grid tv-review-wide-grid">${cards.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div><p class="tv-context-note">Единый Knowledge Layer: metadata + transcript + rule AI analysis + FXPilot market idea. LLM/external AI calls не используются.</p>` });
+    return ReviewSection({ id: 'knowledgeContext', className: 'tv-review-section--summary tv-verdict-section', title: 'FXPilot Knowledge Context', content: `<div class="tv-snapshot-grid tv-review-wide-grid">${cards.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div><p class="tv-context-note">Единый Knowledge Layer: metadata + transcript + rule AI analysis + FXPilot market idea. AI Review использует настроенный LLM-провайдер и детерминированную валидацию извлечённых сущностей.</p>` });
   }
 
 
@@ -147,6 +147,30 @@
   }
 
 
+  function renderStructuredEntities(review) {
+    const ideas = Array.isArray(review.trade_ideas) ? review.trade_ideas : [];
+    const rows = [
+      ['Обнаруженные инструменты', Array.isArray(review.symbols) && review.symbols.length ? review.symbols.join(', ') : null],
+      ['Основной символ', review.primary_symbol || review.symbol],
+      ['Таймфрейм', review.timeframe],
+      ['Направление', directionRu(review.direction)],
+      ['Confidence', percent(review.confidence)],
+      ['Вход', review.entry_zone && review.entry_zone.length ? review.entry_zone.join(' — ') : review.entry],
+      ['Stop loss', review.stop_loss],
+      ['Targets', Array.isArray(review.targets) && review.targets.length ? review.targets.join(', ') : review.take_profit],
+    ];
+    const ideaCards = ideas.length ? ideas.map((idea, index) => `
+      <article class="tv-premium-placeholder">
+        <strong>Trade idea ${index + 1}: ${escapeHtml(value(idea.symbol))}</strong>
+        <p>${escapeHtml(directionRu(idea.direction))} · TF: ${escapeHtml(value(idea.timeframe))} · Entry: ${escapeHtml(value(idea.entry_zone && idea.entry_zone.length ? idea.entry_zone.join(' — ') : idea.entry))} · SL: ${escapeHtml(value(idea.stop_loss))} · TP: ${escapeHtml(value(idea.take_profit || (idea.targets || []).join(', ')))} · Confidence: ${escapeHtml(percent(idea.confidence))}</p>
+        <p>${escapeHtml(value(idea.reasoning))}</p>
+      </article>`).join('') : '<div class="tv-player-empty">Trade ideas: Не определено</div>';
+    return ReviewSection({ id: 'structuredEntities', className: 'tv-review-section--summary tv-verdict-section', title: 'Структурированные торговые сущности', content: `
+      <div class="tv-snapshot-grid tv-review-wide-grid">${rows.map(([label, item]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value(item))}</strong></div>`).join('')}</div>
+      <div class="tv-analysis-lists">${ideaCards}</div>
+      <p class="tv-context-note">AI Review создан настроенным LLM-провайдером; символы дополнительно проверены детерминированными алиасами.</p>` });
+  }
+
   function renderComparison(review) {
     const idea = review.current_fxpilot_idea || {};
     return ReviewSection({ id: 'comparison', className: 'tv-review-section--summary', title: 'Comparison', content: `
@@ -166,7 +190,7 @@
 
   function ReviewPage(review, transcript) {
     const video = review.video || {};
-    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review v1: фактический контекст без OpenAI, с архитектурой transcript pipeline и локальным кешем.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderAIAnalysis(review)}${renderExpertVerdict(review)}${renderKnowledgeContext(review)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
+    return `<section class="panel tv-review-watch" data-video-id="${escapeHtml(video.id)}"><a class="tv-back-link" href="/tv">← Вернуться к каталогу FXPilot TV</a><p class="tv-review-slogan">FXPilot TV AI Review: разбор создаётся настроенным LLM-провайдером с детерминированной валидацией инструментов и уровней.</p></section><div class="tv-review-grid" id="reviewSections">${renderVideoInfo(video)}${renderTranscript(transcript)}${renderAIAnalysis(review)}${renderStructuredEntities(review)}${renderExpertVerdict(review)}${renderKnowledgeContext(review)}${renderSource(review)}${renderIdea(review)}${renderComparison(review)}${renderScore(review)}${renderVerdict(review)}</div>`;
   }
 
   async function loadReview() {

--- a/tests/test_llm_review.py
+++ b/tests/test_llm_review.py
@@ -232,3 +232,78 @@ def test_import_now_generates_review_for_imported_youtube_id(monkeypatch):
     assert calls == ["Hf7eX113oIc"]
     assert result["review_generation"]["generated"] == 1
     assert result["review_generation"]["failed"] == 0
+
+from app.services.llm_review.entity_extraction import extract_symbols_from_text, normalize_direction, normalize_timeframe, to_float_or_none
+
+
+def test_structured_extraction_aliases_and_normalization():
+    assert extract_symbols_from_text("Прогноз по евро доллару") == ["EURUSD"]
+    assert extract_symbols_from_text("золото готовится к импульсу") == ["XAUUSD"]
+    assert extract_symbols_from_text("Bitcoin и EURUSD обзор") == ["EURUSD", "BTCUSD"]
+    assert extract_symbols_from_text("общий рыночный обзор") == []
+    assert normalize_direction("long buy") == "BUY"
+    assert normalize_direction("шорт") == "SELL"
+    assert normalize_direction("подождать") == "WAIT"
+    assert normalize_timeframe("4h") == "H4"
+    assert normalize_timeframe("Daily") == "D1"
+    assert to_float_or_none("1,2345") == 1.2345
+
+
+def test_llm_review_primary_symbol_null_not_market():
+    review = LLMReview.model_validate({"summary": "общий рынок", "symbols": ["MARKET"], "primary_symbol": "MARKET"})
+    assert review.primary_symbol is None
+    assert review.symbol is None
+
+
+def test_deterministic_fallback_supplements_missing_llm_symbols(tmp_path):
+    class EmptyProvider:
+        provider_name = "empty"
+        def generate_review(self, context):
+            return LLMReview(summary="Обзор без символа", provider="empty")
+    engine = ReviewEngine(
+        media_catalog_loader=lambda: [{"id": "v1", "youtube_id": "yt1", "title": "Прогноз золото и Bitcoin", "symbol": "MARKET"}],
+        transcript_engine=FakeTranscriptEngine(), ai_analyzer_engine=FakeAnalyzer(), market_payload_loader=lambda: {},
+        provider=EmptyProvider(), storage=LLMReviewStorage(tmp_path),
+    )
+    review = engine.generate("v1")
+    assert review.primary_symbol == "XAUUSD"
+    assert "BTCUSD" in review.symbols
+
+
+def test_storage_preserves_structured_fields(tmp_path):
+    storage = LLMReviewStorage(tmp_path)
+    review = LLMReview.model_validate({"symbols": ["EURUSD"], "primary_symbol": "EURUSD", "timeframe": "H4", "direction": "BUY", "entry": "1.10", "entry_zone": ["1.09", "1.10"], "stop_loss": "1.08", "take_profit": "1.12", "targets": ["1.12"], "trade_ideas": [{"symbol": "EURUSD", "direction": "BUY", "entry": "1.10", "confidence": 0.8}]})
+    storage.set("v1", review)
+    loaded = storage.get("v1")
+    assert loaded.primary_symbol == "EURUSD"
+    assert loaded.trade_ideas[0].confidence == 80
+    assert loaded.entry == 1.1
+
+
+def test_review_api_returns_structured_fields(monkeypatch, tmp_path):
+    import app.main as main
+    video = {"id": "v1", "youtube_id": "yt1", "title": "EURUSD buy", "symbol": "MARKET"}
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [video])
+    monkeypatch.setattr(main, "ideas_market", lambda: {})
+    monkeypatch.setattr(main, "_review_transcript_payload", lambda video: {"status": "FOUND", "text": "Buy EURUSD from 1.10"})
+    monkeypatch.setattr(main.ai_analyzer_engine, "analyze", lambda transcript, metadata: AIReview(video_id="v1", symbol="EURUSD", direction="BUY"))
+    monkeypatch.setattr(main, "_build_knowledge_for_video", lambda video_id, market_payload=None: type("Knowledge", (), {"model_dump": lambda self: {"agreement_score": 70}})())
+    monkeypatch.setattr(main, "create_llm_review_engine", lambda market_payload=None: type("Engine", (), {"generate": lambda self, video_id, force=False: LLMReview(symbols=["EURUSD"], primary_symbol="EURUSD", direction="BUY", confidence=90, trade_ideas=[{"symbol":"EURUSD","direction":"BUY"}], provider="mock")})())
+    payload = TestClient(main.app).get("/api/media/review/v1").json()
+    assert payload["primary_symbol"] == "EURUSD"
+    assert payload["symbol"] == "EURUSD"
+    assert payload["trade_ideas"][0]["symbol"] == "EURUSD"
+
+
+def test_reprocess_endpoint_updates_market_reviews(monkeypatch, tmp_path):
+    import app.main as main
+    video = {"id": "v1", "youtube_id": "yt1", "title": "EURUSD", "symbol": "MARKET"}
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: [video])
+    monkeypatch.setattr(main, "ideas_market", lambda: {})
+    monkeypatch.setattr(main, "LLM_REVIEW_STORAGE", LLMReviewStorage(tmp_path))
+    main.LLM_REVIEW_STORAGE.set("v1", LLMReview.model_validate({"symbol": "MARKET"}))
+    monkeypatch.setattr(main, "create_llm_review_engine", lambda market_payload=None: type("Engine", (), {"generate": lambda self, video_id, force=False: main.LLM_REVIEW_STORAGE.set(video_id, LLMReview(symbols=["EURUSD"], primary_symbol="EURUSD", trade_ideas=[{"symbol":"EURUSD"}])) or main.LLM_REVIEW_STORAGE.get(video_id)})())
+    payload = TestClient(main.app).post("/api/media/reviews/reprocess").json()
+    assert payload["requested"] == 1
+    assert payload["updated"] == 1
+    assert payload["items"][0]["primary_symbol"] == "EURUSD"


### PR DESCRIPTION
### Motivation
- Проблема: AI Reviews часто сохранялись с `symbol = "MARKET"` и без надёжных структурированных полей, из‑за чего Consensus, статистики авторов и оценка производительности бесполезны; задача — обеспечить корректный и сохраняемый контракт торговых сущностей без перестройки pipeline и без изменения YouTube/OpenRouter.

### Description
- Добавлен строгий структурированный контракт и Pydantic‑модели `LLMReview`, `TradingIdea`, `DetectedLevel` для явного хранения `symbols`, `primary_symbol`, `timeframe`, `direction`, `confidence`, `entry`/`entry_zone`, `stop_loss`, `take_profit`, `targets`, `detected_levels` и `trade_ideas` (`app/services/llm_review/models.py`).
- Реализован детерминированный извлекатель и нормализаторы в `app/services/llm_review/entity_extraction.py` с поддержкой английских/русских алиасов (gold→`XAUUSD`, euro dollar→`EURUSD`, Bitcoin→`BTCUSD`, Brent→`UKOIL` и др.), нормализацией direction/timeframe/confidence и безопасным преобразованием чисел.
- Обновлён `PromptBuilder` чтобы в prompt включать точную JSON‑схему и жёсткие правила: `JSON only`, «не придумывать символы/цены», отличать broad market от actionable ideas (`app/services/llm_review/prompt_builder.py`).
- Усилен провайдер и движок обзора: `OpenAIReviewProvider` теперь безопасно обрабатывает невалидный JSON; `ReviewEngine` применяет детерминированный fallback (title/description/tags/media symbol/transcript/LLM summary), нормализацию и не падает при ошибках LLM; API расширен для выдачи структурированных полей, добавлен endpoint `POST /api/media/reviews/reprocess` и диагностика в `/api/media/debug`, а фронтенд `/tv/review/{video_id}` отображает новые структурированные сущности (`app/main.py`, `app/services/llm_review/*`, `app/static/tv-review.js`).

### Testing
- Запущено `pytest -q tests/test_llm_review.py` и все тесты в наборе прошли успешно. 
- Сборка/проверка модулей выполнена командой `python -m compileall app/services/llm_review app/main.py` и прошла успешно. 
- Полный прогон тестов `pytest -q -x` завершился с фейлом в уже существующем и не связанном с этим PR тесте `tests/api/test_ideas_api.py::test_build_api_ideas_prefers_model_narrative_when_source_marked_fallback`, который требует отдельного расследования и не блокирует изменения, касающиеся извлечения сущностей.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50a9272ab0833186705e3a5bd98f26)