### PR TITLE
Добавить GET-доступ к /api/media/reviews/reprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - The Grok/OpenRouter prompt explicitly requires valid JSON only, forbids invented instruments/prices, distinguishes broad market commentary from actionable trade ideas, and includes common aliases such as золото/gold → `XAUUSD`, euro dollar → `EURUSD`, Bitcoin → `BTCUSD`, Brent → `UKOIL`.
 - A deterministic fallback extractor validates and supplements LLM symbols from video title, description, tags, existing media symbol, transcript and LLM summaries so real instruments no longer collapse to the `MARKET` compatibility fallback.
 - `GET /api/media/review/{video_id}` and `GET /api/tv/review/{video_id}` now return structured top-level fields while keeping backward-compatible `symbol` and `llm_review` fields.
-- Added manual reprocessing endpoint: `POST /api/media/reviews/reprocess?force=false&limit=<number>` regenerates reviews with `MARKET`/missing symbols or empty trade ideas; use `force=true` to rebuild already structured reviews.
+- Added manual reprocessing endpoint: `POST /api/media/reviews/reprocess?force=false&limit=<number>` regenerates reviews with `MARKET`/missing symbols or empty trade ideas; the same JSON contract is available in a browser via `GET /api/media/reviews/reprocess?force=false&limit=<number>`, and `force=true` rebuilds already structured reviews.
 - `/api/media/debug` now reports review entity coverage: total reviews, reviews with primary symbol, trade ideas, MARKET fallback, direction, levels and last extraction error.
 
 ## Stage 12 — YouTube Data API Primary Provider

--- a/app/main.py
+++ b/app/main.py
@@ -1247,6 +1247,7 @@ def api_consensus_symbol_timeframe(symbol: str, timeframe: str, date_from: str |
     return create_consensus_engine().build(symbol, timeframe, date_from=date_from, date_to=date_to)
 
 
+@app.get("/api/media/reviews/reprocess")
 @app.post("/api/media/reviews/reprocess")
 def api_media_reviews_reprocess(force: bool = False, limit: int | None = None) -> dict[str, Any]:
     videos = _load_tv_video_catalog()

--- a/tests/test_llm_review.py
+++ b/tests/test_llm_review.py
@@ -307,3 +307,38 @@ def test_reprocess_endpoint_updates_market_reviews(monkeypatch, tmp_path):
     assert payload["requested"] == 1
     assert payload["updated"] == 1
     assert payload["items"][0]["primary_symbol"] == "EURUSD"
+
+
+def test_reprocess_endpoint_get_matches_post_contract(monkeypatch, tmp_path):
+    import app.main as main
+
+    videos = [
+        {"id": "v1", "youtube_id": "yt1", "title": "EURUSD", "symbol": "MARKET"},
+        {"id": "v2", "youtube_id": "yt2", "title": "GBPUSD", "symbol": "MARKET"},
+    ]
+    generated: list[str] = []
+
+    class Engine:
+        def generate(self, video_id, force=False):
+            generated.append(video_id)
+            review = LLMReview(symbols=[video_id.upper()], primary_symbol=video_id.upper(), trade_ideas=[{"symbol": video_id.upper()}])
+            main.LLM_REVIEW_STORAGE.set(video_id, review)
+            return review
+
+    monkeypatch.setattr(main, "_load_tv_video_catalog", lambda: videos)
+    monkeypatch.setattr(main, "ideas_market", lambda: {})
+    monkeypatch.setattr(main, "LLM_REVIEW_STORAGE", LLMReviewStorage(tmp_path))
+    for video in videos:
+        main.LLM_REVIEW_STORAGE.set(video["id"], LLMReview(symbols=["EURUSD"], primary_symbol="EURUSD", trade_ideas=[{"symbol":"EURUSD"}]))
+    monkeypatch.setattr(main, "create_llm_review_engine", lambda market_payload=None: Engine())
+
+    payload = TestClient(main.app).get("/api/media/reviews/reprocess?force=true&limit=1").json()
+
+    assert payload == {
+        "requested": 1,
+        "generated": 0,
+        "updated": 1,
+        "failed": 0,
+        "items": [{"video_id": "v1", "status": "updated", "primary_symbol": "V1", "symbols": ["V1"]}],
+    }
+    assert generated == ["v1"]


### PR DESCRIPTION
### Motivation
- Интерфейс поддержки в продакшне управляется через браузер, поэтому ручные/обслуживающие endpoint’ы должны быть доступны через GET без изменения существующего POST.
- Нужна единая реализация бизнес-логики для POST и браузерного GET, чтобы избежать дублирования и сохранилась обратная совместимость.

### Description
- Добавлен декоратор `@app.get("/api/media/reviews/reprocess")` над существующим обработчиком `api_media_reviews_reprocess`, чтобы один и тот же код обслуживал и GET, и POST запросы в одном месте (файл `app/main.py`).
- Добавлен тест `test_reprocess_endpoint_get_matches_post_contract` в `tests/test_llm_review.py`, который проверяет работу `GET /api/media/reviews/reprocess?force=true&limit=1` и соответствие JSON-контракта ответу POST.
- Обновлена документация в `README.md`, чтобы зафиксировать доступность того же JSON-контракта через браузер по `GET /api/media/reviews/reprocess`.

### Testing
- Запущены автоматические тесты с командой `pytest tests/test_llm_review.py -q` и все тесты прошли успешно (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b375b2c8833180b49d13caae6c68)