### PR TITLE
Fix OPS structured review diagnostics

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -50,7 +50,7 @@ from app.services.transcript import TranscriptEngine, TranscriptStorage
 from app.services.ai_analyzer import AIAnalyzerEngine
 from app.services.knowledge import KnowledgeEngine
 from app.services.llm_config import LLMConfigurationError, llm_debug_payload, log_llm_startup_config, resolve_llm_config
-from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewProvider, ReviewEngine
+from app.services.llm_review import LLMReview, LLMReviewStorage, OpenAIReviewProvider, ReviewEngine, build_review_diagnostics
 from app.services.openrouter_diagnostics import run_openrouter_diagnostic
 from app.services.investment_committee import InvestmentCommitteeEngine
 from app.services.consensus import ConsensusEngine
@@ -1029,11 +1029,10 @@ def _llm_review_entity_debug() -> dict[str, Any]:
                 last_error = f"{path.name}: {exc.__class__.__name__}"
     except Exception as exc:
         last_error = exc.__class__.__name__
+    diagnostics = build_review_diagnostics(reviews)
     return {
-        "reviews_total": len(reviews),
-        "reviews_with_primary_symbol": sum(1 for r in reviews if r.primary_symbol),
-        "reviews_with_trade_ideas": sum(1 for r in reviews if r.trade_ideas),
-        "reviews_with_market_fallback": sum(1 for r in reviews if (r.symbol or "").upper() == "MARKET" or not r.primary_symbol),
+        **diagnostics,
+        "reviews_with_market_fallback": diagnostics["reviews_market_fallback"],
         "reviews_with_direction": sum(1 for r in reviews if r.direction in {"BUY", "SELL", "WAIT"}),
         "reviews_with_levels": sum(1 for r in reviews if r.detected_levels or r.entry or r.stop_loss or r.take_profit or r.targets),
         "last_entity_extraction_error": last_error,
@@ -1366,10 +1365,26 @@ def api_ops_status() -> dict[str, Any]:
         debug = llm_debug_payload()
         llm = {"provider": debug.get("provider"), "model": debug.get("model"), "api_key_present": bool(debug.get("api_key_present")), "configuration_valid": False}
     scheduler = media_automation_service.status()
+    review_diagnostics = build_review_diagnostics(reviews)
     return {
         "service": "FXPilot",
         "media": {"catalog_items": len(catalog), "sources": len(tv_source_manager.list_public_sources()) if tv_source_manager else 0, "last_import": _safe_last_mtime(MEDIA_DEBUG_PATH)},
-        "reviews": {"total": len(reviews), "structured": sum(1 for r in reviews if r.primary_symbol and r.trade_ideas), "market_fallback": sum(1 for r in reviews if not r.primary_symbol or (r.symbol or "").upper() == "MARKET"), "last_review": _safe_last_mtime(LLM_REVIEW_STORAGE.base_dir)},
+        "reviews": {
+            "total": len(reviews),
+            "structured": review_diagnostics["reviews_structured"],
+            "structured_reviews": review_diagnostics["reviews_structured"],
+            "market_fallback": review_diagnostics["reviews_market_fallback"],
+            "last_review": _safe_last_mtime(LLM_REVIEW_STORAGE.base_dir),
+            **review_diagnostics,
+        },
+        "reviews_total": review_diagnostics["reviews_total"],
+        "reviews_structured": review_diagnostics["reviews_structured"],
+        "structured_reviews": review_diagnostics["reviews_structured"],
+        "reviews_with_primary_symbol": review_diagnostics["reviews_with_primary_symbol"],
+        "reviews_with_symbols": review_diagnostics["reviews_with_symbols"],
+        "reviews_with_trade_ideas": review_diagnostics["reviews_with_trade_ideas"],
+        "reviews_with_detected_levels": review_diagnostics["reviews_with_detected_levels"],
+        "reviews_market_fallback": review_diagnostics["reviews_market_fallback"],
         "llm": llm,
         "scheduler": {"enabled": bool(scheduler.get("enabled", scheduler.get("status") != "disabled")), "running": bool(scheduler.get("running", scheduler.get("status") == "running")), "last_run": scheduler.get("last_run"), "next_run": scheduler.get("next_run")},
         "pipeline": {"running": 0, "completed": sum(1 for v in catalog if v.get("pipeline_status") == "completed"), "partial": sum(1 for v in catalog if v.get("pipeline_status") == "partial"), "failed": sum(1 for v in catalog if v.get("pipeline_status") == "failed")},

--- a/app/services/llm_review/__init__.py
+++ b/app/services/llm_review/__init__.py
@@ -3,5 +3,6 @@ from app.services.llm_review.openai_provider import OpenAIReviewProvider
 from app.services.llm_review.provider import LLMReviewProvider
 from app.services.llm_review.review_engine import ReviewEngine
 from app.services.llm_review.storage import LLMReviewStorage
+from app.services.llm_review.diagnostics import build_review_diagnostics, is_market_fallback_review, is_structured_review
 
-__all__ = ["LLMReview", "LLMReviewProvider", "OpenAIReviewProvider", "ReviewEngine", "LLMReviewStorage"]
+__all__ = ["LLMReview", "LLMReviewProvider", "OpenAIReviewProvider", "ReviewEngine", "LLMReviewStorage", "build_review_diagnostics", "is_market_fallback_review", "is_structured_review"]

--- a/app/services/llm_review/diagnostics.py
+++ b/app/services/llm_review/diagnostics.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.llm_review.models import LLMReview
+
+_FALLBACK_VALUES = {"", "MARKET", "UNKNOWN", "N/A", "NA", "NONE", "NULL", "NEUTRAL"}
+_STRUCTURED_FIELDS = (
+    "primary_symbol",
+    "symbols",
+    "direction",
+    "timeframe",
+    "trade_ideas",
+    "detected_levels",
+    "entry",
+    "entry_zone",
+    "stop_loss",
+    "take_profit",
+    "targets",
+)
+
+
+def _dump(review: Any) -> dict[str, Any]:
+    if isinstance(review, LLMReview):
+        return review.model_dump()
+    if isinstance(review, dict):
+        return review
+    if hasattr(review, "model_dump"):
+        return review.model_dump()
+    return {}
+
+
+def _meaningful_scalar(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().upper() not in _FALLBACK_VALUES
+    if isinstance(value, (int, float)):
+        return value != 0
+    return bool(value)
+
+
+def _meaningful_list(value: Any) -> bool:
+    if not isinstance(value, list):
+        return False
+    return any(is_meaningful_structured_value(item) for item in value)
+
+
+def _meaningful_dict(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return any(is_meaningful_structured_value(item) for item in value.values())
+
+
+def is_meaningful_structured_value(value: Any) -> bool:
+    if isinstance(value, list):
+        return _meaningful_list(value)
+    if isinstance(value, dict):
+        return _meaningful_dict(value)
+    return _meaningful_scalar(value)
+
+
+def is_structured_review(review: Any) -> bool:
+    """Return True when a review contains real Stage 16 trading structure."""
+    data = _dump(review)
+    return any(is_meaningful_structured_value(data.get(field)) for field in _STRUCTURED_FIELDS)
+
+
+def is_market_fallback_review(review: Any) -> bool:
+    data = _dump(review)
+    primary = data.get("primary_symbol")
+    symbols = data.get("symbols") if isinstance(data.get("symbols"), list) else []
+    if _meaningful_scalar(primary):
+        return False
+    precise_symbols = [symbol for symbol in symbols if _meaningful_scalar(symbol)]
+    return not precise_symbols
+
+
+def build_review_diagnostics(reviews: list[Any]) -> dict[str, Any]:
+    return {
+        "reviews_total": len(reviews),
+        "reviews_structured": sum(1 for review in reviews if is_structured_review(review)),
+        "reviews_with_primary_symbol": sum(1 for review in reviews if is_meaningful_structured_value(_dump(review).get("primary_symbol"))),
+        "reviews_with_symbols": sum(1 for review in reviews if is_meaningful_structured_value(_dump(review).get("symbols"))),
+        "reviews_with_trade_ideas": sum(1 for review in reviews if is_meaningful_structured_value(_dump(review).get("trade_ideas"))),
+        "reviews_with_detected_levels": sum(1 for review in reviews if is_meaningful_structured_value(_dump(review).get("detected_levels"))),
+        "reviews_market_fallback": sum(1 for review in reviews if is_market_fallback_review(review)),
+    }

--- a/app/static/ops.js
+++ b/app/static/ops.js
@@ -18,9 +18,12 @@
     const r = await fetch('/api/ops/status', { headers: { Accept: 'application/json' }, cache: 'no-store' });
     statusPayload = await r.json(); renderStatus(statusPayload);
   }
+  function reviewStructuredCount(p) {
+    return p.reviews?.structured ?? p.reviews?.structured_reviews ?? p.structured_reviews ?? p.reviews_structured;
+  }
   function renderStatus(p) {
     const cards = [
-      ['Media catalog', p.media?.catalog_items], ['Sources', p.media?.sources], ['Reviews', p.reviews?.total], ['Structured reviews', p.reviews?.structured],
+      ['Media catalog', p.media?.catalog_items], ['Sources', p.media?.sources], ['Reviews', p.reviews?.total], ['Structured reviews', reviewStructuredCount(p)],
       ['LLM provider/model', `${p.llm?.provider || '—'} / ${p.llm?.model || '—'}`], ['Scheduler', p.scheduler?.running ? 'running' : 'stopped'],
       ['Pipeline', `run:${p.pipeline?.running || 0} ok:${p.pipeline?.completed || 0} fail:${p.pipeline?.failed || 0}`], ['Last import', p.media?.last_import || '—'], ['Last error', '—']
     ];
@@ -40,6 +43,7 @@
     finally { setBusy(button, false); }
     const finishedAt = new Date(); logResult({ name, started, finished: finishedAt.toLocaleString('ru-RU'), duration: finishedAt - startedAt, httpStatus, ok, payload });
     loadAudit().catch(() => {});
+    loadStatus().catch(() => {});
   }
   async function loadAudit() {
     const r = await fetch('/api/ops/audit?limit=50', { headers: headers(), cache: 'no-store' });

--- a/tests/test_ops_panel.py
+++ b/tests/test_ops_panel.py
@@ -107,3 +107,50 @@ def test_post_wrapper_reuses_existing_business_implementation(monkeypatch, tmp_p
     response = TestClient(main.app).post("/api/ops/media/import", headers={"X-FXPILOT-OPS-TOKEN": "secret"})
     assert response.status_code == 200
     assert called["import"] == 1
+
+
+def test_structured_review_helper_counts_primary_symbols_and_trade_ideas():
+    from app.services.llm_review import is_structured_review
+
+    assert is_structured_review({"primary_symbol": "EURUSD", "symbols": ["EURUSD"]}) is True
+    assert is_structured_review({"primary_symbol": "MARKET", "symbols": ["MARKET"]}) is False
+    assert is_structured_review({"trade_ideas": [{"symbol": "XAUUSD", "direction": "BUY"}]}) is True
+
+
+def test_review_diagnostics_counts_spx_and_market_fallback():
+    from app.services.llm_review import build_review_diagnostics
+
+    diagnostics = build_review_diagnostics([
+        {"primary_symbol": "SPX", "symbols": ["SPX"]},
+        {"primary_symbol": "MARKET", "symbols": ["MARKET"]},
+    ])
+    assert diagnostics["reviews_structured"] == 1
+    assert diagnostics["reviews_market_fallback"] == 1
+
+
+def test_status_counts_five_reviews_with_one_spx_structured(monkeypatch, tmp_path):
+    import app.main as main
+    from app.services.llm_review import LLMReviewStorage
+
+    storage = LLMReviewStorage(tmp_path / "reviews")
+    storage.set("spx", main.LLMReview.model_validate({"primary_symbol": "SPX", "symbols": ["SPX"]}))
+    for idx in range(4):
+        storage.set(f"market-{idx}", main.LLMReview.model_validate({"primary_symbol": "MARKET", "symbols": ["MARKET"]}))
+    monkeypatch.setattr(main, "LLM_REVIEW_STORAGE", storage)
+
+    response = TestClient(main.app).get("/api/ops/status")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["reviews"]["total"] == 5
+    assert payload["reviews"]["structured"] == 1
+    assert payload["reviews_structured"] == 1
+
+
+def test_ops_js_uses_backend_structured_count_compatibility_mapping():
+    text = open("app/static/ops.js", encoding="utf-8").read()
+    assert "reviewStructuredCount" in text
+    assert "p.reviews?.structured" in text
+    assert "p.reviews?.structured_reviews" in text
+    assert "p.structured_reviews" in text
+    assert "p.reviews_structured" in text
+    assert "['Structured reviews', 0]" not in text


### PR DESCRIPTION
### Motivation
- Исправить некорректный счётчик «Structured reviews» в панели /ops, который возвращал 0 для валидных Stage‑16 payload (например `primary_symbol: "SPX"`, `symbols: ["SPX"]`) несмотря на то, что структурированные поля уже сохранялись.
- Убрать расхождение между условием, которое использовалось при генерации/сохранении review, и тем, как OPS считает structured‑reviews в диагностике.

### Description
- Добавлен общий helper для определения структурированного review `is_structured_review` и сборки диагностики `build_review_diagnostics` в `app/services/llm_review/diagnostics.py`, который учитывает реальные Stage‑16 поля и отфильтровывает fallback‑значения (`MARKET`, `UNKNOWN`, `N/A`, `NONE`, `NEUTRAL` и пустые).
- `/api/ops/status` в `app/main.py` теперь использует `build_review_diagnostics(reviews)` и возвращает обратно‑совместимые поля `reviews.structured`, `reviews.structured_reviews`, а также расширённую безопасную разбивку: `reviews_total`, `reviews_structured`, `reviews_with_primary_symbol`, `reviews_with_symbols`, `reviews_with_trade_ideas`, `reviews_with_detected_levels`, `reviews_market_fallback`.
- Экспортировал helper‑функции через `app/services/llm_review/__init__.py` и заменил устаревшие/жёсткие подсчёты в отладочном payload на использование новой diagnostics‑функции.
- Обновлён фронтенд `app/static/ops.js` так, чтобы карточка «Structured reviews» читала значение через совместимую функцию (`reviewStructuredCount`) и чтобы статус автоматически обновлялся после выполнения OPS‑операций.
- Добавлены регрессионные тесты в `tests/test_ops_panel.py`, покрывающие: детекцию EURUSD/SPX как structured, отнесение `MARKET` к market fallback, детекцию по `trade_ideas`, сценарий «5 reviews, 1 SPX structured», и проверку фронтенд‑маппинга.

### Testing
- Запущен `pytest -q tests/test_ops_panel.py` и все тесты прошли успешно (`13 passed`).
- Проверена корректность синтаксиса/импорта с `python -m py_compile app/main.py app/services/llm_review/diagnostics.py app/services/llm_review/__init__.py` без ошибок.
- Локальные изменения протестированы интеграционно: `/api/ops/status` возвращает корректные агрегаты и `app/static/ops.js` отображает backend‑значение вместо жесткого нуля.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5113cb7d788331905e342aaa86ebf0)