### PR TITLE
Исправление сохранения каталога медиа: диагностика и защита от нулевой записи

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,3 +769,9 @@ When Render-like production is detected without a persistent configured data roo
 ### Knowledge Graph cache behavior
 
 Knowledge Graph keeps the normal healthy TTL, but empty graphs with zero catalog items and zero review files use a short TTL so startup races or late-mounted storage do not preserve an empty graph for the full cache duration. OPS media import, review generation/reprocessing, migration, aggregation rebuilds and safe cache clear invalidate the graph cache.
+
+## Stage 20.4 Media Import persistence diagnostics
+
+- Media Import now records canonical catalog path, storage root, catalog existence, before/after item counts, loaded source items, written items, write success/error state and per-filter removal counters in `/api/media/debug`.
+- The import pipeline refuses a successful zero-item catalog write when providers returned importable videos, so fetched YouTube media is persisted to the canonical `media_catalog.json` or the write error is surfaced in diagnostics.
+- Added a regression test that imports one mock YouTube video, verifies catalog file persistence and subsequent catalog loading, then confirms the Knowledge Graph indexes the imported item with a stored review.

--- a/app/main.py
+++ b/app/main.py
@@ -162,6 +162,7 @@ KG_SERVICE: KnowledgeGraphService | None = None
 
 def create_media_import_engine() -> MediaImportEngine:
     manual_path = MEDIA_MANUAL_YOUTUBE_PATH if os.getenv("FXPILOT_DEV_MANUAL_MEDIA", "").strip().lower() in {"1", "true", "yes", "on", "dev"} else None
+    logger.info("create_media_import_engine storage_root=%s sources_path=%s catalog_path=%s debug_path=%s manual_path=%s", DATA_DIR, MEDIA_SOURCES_PATH, MEDIA_CATALOG_PATH, MEDIA_DEBUG_PATH, manual_path)
     return MediaImportEngine(MEDIA_SOURCES_PATH, MEDIA_CATALOG_PATH, manual_path, debug_path=MEDIA_DEBUG_PATH)
 
 media_import_engine = create_media_import_engine()
@@ -1155,6 +1156,7 @@ def _review_needs_reprocess(review: LLMReview | None) -> bool:
 def api_media_debug() -> dict[str, Any]:
     try:
         payload = create_media_import_engine().debug_sources()
+        payload["tv_source_manager"] = tv_source_manager.debug_payload()
         payload.update(transcript_engine.debug_payload())
         payload.update(MEDIA_KNOWLEDGE_DEBUG)
         payload.update(llm_debug_payload())

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -404,13 +404,18 @@ class MediaImportEngine:
         return str(os.getenv("FXPILOT_DEV_MANUAL_MEDIA") or "").strip().lower() in {"1", "true", "yes", "on", "dev"}
     def import_latest(self, source_types: set[str] | None = None) -> dict[str, Any]:
         now = datetime.now(timezone.utc).isoformat()
-        run_log: dict[str, Any] = {"started_at": now, "finished_at": None, "sources": [], "steps": ["ENTER import_latest()"]}
+        run_log: dict[str, Any] = {"started_at": now, "finished_at": None, "sources": [], "steps": ["ENTER import_latest()"], **self._catalog_debug_snapshot("start")}
         self._persist_debug_run(run_log)
         logger.info("ENTER import_latest()")
 
         sources = [s for s in self.load_sources() if s.enabled and (not source_types or s.source_type in source_types)]
         existing_raw_catalog = self._read_json_list(self.catalog_path)
         existing = self.load_catalog()
+        run_log["catalog_items_before"] = len(existing)
+        run_log["catalog_raw_items_before"] = len(existing_raw_catalog)
+        run_log["storage_root"] = str(self.catalog_path.parent.resolve())
+        run_log["catalog_path"] = str(self.catalog_path.resolve())
+        run_log["catalog_exists"] = self.catalog_path.exists()
         fetched: list[dict[str, Any]] = []
         errors: list[dict[str, str]] = []
         processed = 0
@@ -449,6 +454,13 @@ class MediaImportEngine:
                 "skipped_reasons": {},
                 "skipped_items": [],
                 "saved_catalog_items": 0,
+                "items_loaded_from_sources": 0,
+                "items_written": 0,
+                "catalog_items_before": len(existing),
+                "catalog_items_after": None,
+                "write_success": False,
+                "last_write_error": None,
+                "filters": self._empty_filter_counts(),
             }
             try:
                 run_log["steps"].append(f"Processing source {source.name}")
@@ -496,8 +508,10 @@ class MediaImportEngine:
                     "execution_time": active_diag.get("execution_time") or (datetime.now(timezone.utc) - source_started).total_seconds(),
                     "fetched_raw_count": active_diag.get("fetched_raw_count", result.videos_found),
                     "valid_items": active_diag.get("valid_items", len(result.items)),
+                    "items_loaded_from_sources": len(result.items),
                     "skipped_invalid": active_diag.get("skipped_invalid", 0),
                     "skipped_reasons": active_diag.get("skipped_reasons", {}),
+                    "filters": self._source_filter_counts(source, result, active_diag),
                     "skipped_items": active_diag.get("skipped_items", [])[:20],
                     "youtube_api_enabled": bool(os.getenv("YOUTUBE_API_KEY")),
                     "api_key_detected": bool(os.getenv("YOUTUBE_API_KEY")),
@@ -530,6 +544,7 @@ class MediaImportEngine:
             finally:
                 run_log["sources"].append(source_log)
 
+        filter_counts = self._filter_counts(fetched, existing)
         valid_fetched = [item for item in fetched if self._is_catalog_item_importable(item)]
         successful_source_ids = {s.id for s in updated_sources if not s.last_error and s.provider != "youtube_manual"}
         kept_existing = [item for item in existing if str(item.get("source_id") or "") not in successful_source_ids]
@@ -541,15 +556,37 @@ class MediaImportEngine:
         after_keys = {self._dedupe_key(i) for i in merged if self._dedupe_key(i)}
         before = {str(i.get("youtube_id")) for i in existing if is_valid_youtube_id(i.get("youtube_id"))}
         after = {str(i.get("youtube_id")) for i in merged if is_valid_youtube_id(i.get("youtube_id"))}
+        if valid_fetched and not merged:
+            raise MediaImportError("media import fetched importable items but catalog merge produced zero items; refusing successful zero-item write")
         run_log["steps"].append("Saving catalog...")
         logger.info("Saving catalog...")
-        self._atomic_write_json(self.catalog_path, merged)
+        write_success = False
+        last_write_error = None
+        try:
+            self._atomic_write_json(self.catalog_path, merged)
+            write_success = True
+        except Exception as exc:
+            last_write_error = str(exc)
+            run_log["last_write_error"] = last_write_error
+            run_log["write_success"] = False
+            self._persist_debug_run(run_log)
+            raise
         for row in run_log["sources"]:
             if row.get("error"):
                 continue
             row["saved_catalog_items"] = len([item for item in merged if item.get("source_id") == row.get("source_id")])
+            row["items_written"] = row["saved_catalog_items"]
+            row["catalog_items_after"] = len(merged)
+            row["write_success"] = write_success
+            row["last_write_error"] = last_write_error
             row["updated_count"] = len([item for item in valid_fetched if item.get("source_id") == row.get("source_id") and str(item.get("youtube_id")) in before])
         self._save_sources(updated_sources)
+        run_log["filters"] = filter_counts
+        run_log["items_loaded_from_sources"] = len(fetched)
+        run_log["items_written"] = len(merged)
+        run_log["catalog_items_after"] = len(merged)
+        run_log["write_success"] = write_success
+        run_log["last_write_error"] = last_write_error
         run_log["duplicates_removed"] = duplicates_removed
         run_log["fetched_raw_count"] = sum(int(row.get("fetched_raw_count") or row.get("entries_found") or 0) for row in run_log["sources"])
         run_log["valid_items"] = len(valid_fetched)
@@ -601,6 +638,56 @@ class MediaImportEngine:
     def _persist_debug_run(self, run_log: dict[str, Any]) -> None:
         self.debug_path.parent.mkdir(parents=True, exist_ok=True)
         self._atomic_write_json(self.debug_path, run_log)
+
+    def _catalog_debug_snapshot(self, label: str) -> dict[str, Any]:
+        items = self._read_json_list(self.catalog_path)
+        return {
+            "catalog_path": str(self.catalog_path.resolve()),
+            "storage_root": str(self.catalog_path.parent.resolve()),
+            "catalog_exists": self.catalog_path.exists(),
+            "catalog_items": len(items),
+            "catalog_debug_label": label,
+        }
+
+    @staticmethod
+    def _empty_filter_counts() -> dict[str, int]:
+        return {
+            "invalid_metadata": 0,
+            "duplicates": 0,
+            "missing_youtube_id": 0,
+            "unsupported_source": 0,
+            "validation": 0,
+            "normalization": 0,
+        }
+
+    def _source_filter_counts(self, source: MediaSource, result: ImportSourceResult, provider_diag: dict[str, Any] | None = None) -> dict[str, int]:
+        counts = self._empty_filter_counts()
+        provider_diag = provider_diag or {}
+        counts["unsupported_source"] = 0 if self.resolve_provider(source.provider).__class__ is not EmptyProvider else int(result.videos_found or 0)
+        counts["invalid_metadata"] = int(provider_diag.get("invalid_metadata") or 0)
+        counts["missing_youtube_id"] = int(provider_diag.get("missing_youtube_id") or 0)
+        counts["validation"] = int(provider_diag.get("skipped_invalid") or 0)
+        counts["normalization"] = int(provider_diag.get("normalization") or 0)
+        return counts
+
+    def _filter_counts(self, fetched: list[dict[str, Any]], existing: list[dict[str, Any]]) -> dict[str, int]:
+        counts = self._empty_filter_counts()
+        seen = {self._dedupe_key(item) for item in existing if self._dedupe_key(item)}
+        for item in fetched:
+            provider = str(item.get("provider") or "")
+            if provider in {"youtube", "youtube_api", "youtube_ytdlp", "auto", "youtube-rss"} and not str(item.get("youtube_id") or "").strip():
+                counts["missing_youtube_id"] += 1
+            if not self._is_catalog_item_importable(item):
+                counts["validation"] += 1
+                continue
+            key = self._dedupe_key(item)
+            if not key:
+                counts["normalization"] += 1
+            elif key in seen:
+                counts["duplicates"] += 1
+            else:
+                seen.add(key)
+        return counts
 
     def debug_sources(self) -> dict[str, Any]:
         last_run = {"started_at": None, "finished_at": None, "sources": []}
@@ -698,7 +785,18 @@ class MediaImportEngine:
                     "fallback_reason": last_source_run.get("fallback_reason"),
                 },
             })
-        return {"last_import_run": last_run, "sources": rows}
+        catalog = self.load_catalog()
+        diag = self._catalog_debug_snapshot("debug")
+        diag.update({
+            "catalog_items_before": last_run.get("catalog_items_before", len(catalog)),
+            "catalog_items_after": last_run.get("catalog_items_after", len(catalog)),
+            "items_loaded_from_sources": last_run.get("items_loaded_from_sources", 0),
+            "items_written": last_run.get("items_written", len(catalog)),
+            "write_success": bool(last_run.get("write_success", False)),
+            "last_write_error": last_run.get("last_write_error"),
+            "filters": last_run.get("filters") or self._empty_filter_counts(),
+        })
+        return {"last_import_run": last_run, "sources": rows, **diag}
     def stats(self) -> dict[str, Any]:
         catalog = self.load_catalog()
         last_run = {}
@@ -1005,8 +1103,7 @@ class MediaImportEngine:
         if not allow_manual and (item.get("status") == "manual_demo" or provider in {"youtube_manual", "youtube-manual"}):
             return False
         if provider in {"youtube", "youtube_api", "youtube_ytdlp", "auto", "youtube-rss"} or item.get("youtube_id"):
-            youtube_id = str(item.get("youtube_id") or "").strip()
-            return bool(youtube_id and not youtube_id.upper().startswith("DEMO"))
+            return is_valid_youtube_id(item.get("youtube_id"))
         return bool(str(item.get("url") or item.get("id") or "").strip())
 
     @staticmethod

--- a/app/services/tv_source_manager.py
+++ b/app/services/tv_source_manager.py
@@ -100,6 +100,21 @@ class TvSourceManager:
             for source in sorted(self.list_enabled_sources(), key=lambda item: (item.priority, item.name.lower()))
         ]
 
+    def debug_payload(self) -> dict[str, Any]:
+        sources = self.load_sources()
+        videos = self._load_video_catalog()
+        payload = {
+            "sources_path": str(self.sources_path.resolve()),
+            "videos_path": str(self.videos_path.resolve()) if self.videos_path else None,
+            "sources_exists": self.sources_path.exists(),
+            "videos_exists": self.videos_path.exists() if self.videos_path else False,
+            "sources_loaded": len(sources),
+            "enabled_sources": len([s for s in sources if s.enabled]),
+            "video_catalog_items": len(videos),
+        }
+        logger.info("tv_source_manager_debug sources_path=%s videos_path=%s sources_loaded=%s video_catalog_items=%s", payload["sources_path"], payload["videos_path"], payload["sources_loaded"], payload["video_catalog_items"])
+        return payload
+
     def dashboard_stats(self) -> dict[str, Any]:
         sources = self.load_sources()
         videos = self._load_video_catalog()

--- a/tests/test_media_import_engine.py
+++ b/tests/test_media_import_engine.py
@@ -569,3 +569,49 @@ def test_stats_include_provider_quota_latency_and_fallback_count(tmp_path: Path)
     assert stats["quota_usage"] == 102
     assert stats["api_latency"] == 0.5
     assert stats["fallback_count"] == 1
+
+
+def test_stage_20_4_mock_youtube_import_persists_and_indexes_knowledge_graph(tmp_path: Path):
+    from app.services.knowledge_graph.builder import KnowledgeGraphBuilder
+    from app.services.knowledge_graph.service import KnowledgeGraphService
+    from app.services.llm_review import LLMReview, LLMReviewStorage
+
+    sources_path = tmp_path / "media_sources.json"
+    catalog_path = tmp_path / "media_catalog.json"
+    debug_path = tmp_path / "media_import_debug.json"
+    sources_path.write_text(json.dumps([
+        {"id":"demo","name":"Demo","provider":"youtube_ytdlp","source_type":"youtube","channel_url":"https://www.youtube.com/@demo","language":"ru","priority":1,"categories":["Forex"],"enabled":True}
+    ]), encoding="utf-8")
+
+    class Provider:
+        provider_name = "youtube_ytdlp"
+        last_diagnostic = {"execution_time": 0.01, "fetched_raw_count": 1, "valid_items": 1, "skipped_invalid": 0}
+        def fetch_latest(self, source):
+            item = MediaItem("youtube:KgStage204A", "youtube_ytdlp", source.id, "BTCUSD обзор", "Demo", "KgStage204A", "https://www.youtube.com/watch?v=KgStage204A", None, "2026-07-18T00:00:00+00:00", None, "Forex", "BTCUSD", "ru", "")
+            return ImportSourceResult(source, [item], "ok", 200, 1)
+
+    engine = MediaImportEngine(sources_path, catalog_path, ytdlp_provider=Provider(), debug_path=debug_path)
+    result = engine.import_latest()
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+
+    assert result["success"] is True
+    assert catalog_path.exists()
+    assert len(catalog) == 1
+    assert engine.load_catalog()[0]["youtube_id"] == "KgStage204A"
+    debug = engine.debug_sources()
+    assert debug["catalog_path"] == str(catalog_path.resolve())
+    assert debug["catalog_exists"] is True
+    assert debug["catalog_items_before"] == 0
+    assert debug["catalog_items_after"] == 1
+    assert debug["items_loaded_from_sources"] == 1
+    assert debug["items_written"] == 1
+    assert debug["write_success"] is True
+    assert debug["last_write_error"] is None
+    assert set(debug["filters"]).issuperset({"invalid_metadata", "duplicates", "missing_youtube_id", "unsupported_source", "validation", "normalization"})
+
+    storage = LLMReviewStorage(tmp_path / "llm_reviews")
+    storage.set("youtube:KgStage204A", LLMReview(primary_symbol="BTCUSD", symbols=["BTCUSD"], direction="BUY", confidence=80, trade_ideas=[{"symbol":"BTCUSD","direction":"BUY"}]))
+    service = KnowledgeGraphService(KnowledgeGraphBuilder(media_catalog_loader=engine.load_catalog, review_storage=storage))
+    symbols = service.list_symbols()
+    assert symbols["total"] == 1
+    assert symbols["diagnostics"].catalog_items_scanned == 1


### PR DESCRIPTION
### Motivation
- В проде импорт видео загружался от провайдеров, но `media_catalog.json` оказывался пустым (saved_catalog_items = 0), поэтому Knowledge Graph не индексировал новые видео.
- Нужно проследить весь pipeline импорта и добавить подробную диагностику, чтобы никогда не проходил успешный импорт с нулевой записью каталога, если провайдер вернул импортируемые элементы.

### Description
- Инструментированы точки создания/записи каталога: добавлена диагностика в `create_media_import_engine()`, `MediaImportEngine` (поля `catalog_path`, `storage_root`, `catalog_exists`, `catalog_items_before`, `catalog_items_after`, `items_loaded_from_sources`, `items_written`, `write_success`, `last_write_error`) и сериализацию каталога/запись. 
- Добавлены счётчики фильтрации по стадиям (`invalid_metadata`, `duplicates`, `missing_youtube_id`, `unsupported_source`, `validation`, `normalization`) и включены в ответ `GET /api/media/debug` вместе с данными `debug_sources()`; расширен `TvSourceManager` для отдачи отладочного payload.
- Введена защита: если есть импортируемые элементы (`valid_fetched`) и объединённый `merged` каталог пустой, импорт прерывается с ошибкой и запись с нулём запрещается, чтобы избежать потери данных.
- Уточнена валидация YouTube id: проверка импортируемости YouTube-видео теперь использует `is_valid_youtube_id()` с ожидаемыми 11 символами.
- Добавлен регрессионный тест `test_stage_20_4_mock_youtube_import_persists_and_indexes_knowledge_graph` который имитирует импорт одного YouTube-видео, проверяет наличие и содержимое `media_catalog.json` и то, что Knowledge Graph индексирует импортированный элемент.
- Обновлён `README` разделом Stage 20.4 о новой диагностике импорта.

### Testing
- Запущен unit тест `pytest -q tests/test_media_import_engine.py::test_stage_20_4_mock_youtube_import_persists_and_indexes_knowledge_graph` и он прошёл успешно.
- Прогон набора `pytest -q tests/test_media_import_engine.py::test_stage_20_4_mock_youtube_import_persists_and_indexes_knowledge_graph tests/test_media_import_engine.py::test_media_debug_endpoint_contract tests/test_tv_source_manager.py` прошёл успешно (все три теста зелёные).
- Полный прогон `pytest -q tests/test_media_import_engine.py` выявил один ранее существовавший флоп — `test_media_review_endpoint_returns_fxpilot_context` упал из‑за блокировки исходящего доступа к YouTube (проблема с прокси, `ProxyError` 403) и не связан с изменениями сохранения каталога; остальные тесты в модуле проходят.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5784eb848331ba122c48cde08851)