### PR TITLE
Stage 20.2 — Персистентное хранилище для Render: канонический DATA_DIR, диагностика и миграция

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,3 +769,27 @@ When Render-like production is detected without a persistent configured data roo
 ### Knowledge Graph cache behavior
 
 Knowledge Graph keeps the normal healthy TTL, but empty graphs with zero catalog items and zero review files use a short TTL so startup races or late-mounted storage do not preserve an empty graph for the full cache duration. OPS media import, review generation/reprocessing, migration, aggregation rebuilds and safe cache clear invalidate the graph cache.
+
+## Постоянное хранилище FXPilot на Render
+
+Render хранит обычные файлы web service в эфемерной файловой системе контейнера. Файлы, записанные в каталог развернутого репозитория (`data/media_catalog.json`, `data/tv_videos.json`, `data/llm_reviews/*.json`, `data/transcripts/*`, `data/ops_audit.json`), могут исчезнуть после перезапуска или деплоя, если не подключен persistent disk. Переменные окружения сами по себе **не создают** диск: диск должен быть создан и смонтирован до того, как производственные данные станут долговечными. Persistent disk на Render обычно требует платный instance; текущий `render.yaml` не добавляет disk declaration, чтобы не ломать бесплатный план автоматически.
+
+Точные шаги в браузере:
+
+1. Open Render Dashboard.
+2. Select AI-FOREX-SIGNAL-PLATFORM.
+3. Open the Disk section.
+4. Create a persistent disk.
+5. Disk name: `fxpilot-data`.
+6. Mount path: `/var/data/fxpilot`.
+7. Open Environment.
+8. Add: `FXPILOT_DATA_DIR=/var/data/fxpilot`.
+9. Add: `FXPILOT_STORAGE_MODE=persistent`.
+10. Save changes.
+11. Redeploy the service.
+12. Open: `https://fxpilot.ru/ops`.
+13. Enter the OPS token.
+14. Click: `Обновить диагностику хранилища`.
+15. Confirm: `Storage mode = persistent` and `Status = healthy`.
+
+Если данные уже были потеряны вместе со старым уничтоженным контейнером Render, приложение не сможет восстановить их без копии, резервной выгрузки или другого внешнего бэкапа. После настройки диска можно использовать защищенную операцию миграции в `/ops`: сначала dry run, затем execute. Она копирует только известные runtime-файлы, не вызывает LLM, не удаляет источники и не перезаписывает более новые destination-файлы.

--- a/app/main.py
+++ b/app/main.py
@@ -59,12 +59,13 @@ from app.services.performance import PerformanceEngine
 from app.services.knowledge_graph.builder import KnowledgeGraphBuilder
 from app.services.knowledge_graph.service import KnowledgeGraphService
 from app.services.storage_paths import (
-    DATA_DIR, DATA_ROOT_SOURCE, STORAGE_MODE, INSTANCE_ID, PROCESS_STARTED_AT,
+    DATA_DIR, DATA_ROOT_SOURCE, STORAGE_MODE,
     MEDIA_SOURCES_PATH, MEDIA_CATALOG_PATH, MEDIA_TV_SOURCES_PATH, MEDIA_TV_VIDEOS_PATH,
     MEDIA_MANUAL_YOUTUBE_PATH, MEDIA_DEBUG_PATH, MEDIA_AUTOMATION_STATE_PATH,
     LLM_REVIEWS_DIR, TRANSCRIPTS_DIR, OPS_AUDIT_PATH, atomic_write_json,
-    migrate_legacy_data, storage_diagnostics, storage_health,
+    migrate_legacy_data,
 )
+from app.services.storage_health import FXPILOT_INSTANCE_ID, PROCESS_STARTED_AT, backup_manifest, storage_diagnostics, storage_health
 from backend.chat_service import ChatRequest, ForexChatService
 
 logger = logging.getLogger(__name__)
@@ -1083,7 +1084,7 @@ def _run_media_import() -> dict[str, Any]:
     engine = create_media_import_engine()
     result = engine.import_latest()
     result["review_generation"] = _generate_reviews_for_imported_items(result.get("new_item_ids") or [])
-    invalidate_knowledge_graph()
+    invalidate_knowledge_graph("media_import")
     return result
 
 
@@ -1248,7 +1249,7 @@ def api_media_llm_review(video_id: str, force: bool = False) -> dict[str, Any]:
     market_payload = ideas_market()
     review = create_llm_review_engine(market_payload=market_payload).generate(catalog_id, force=force)
     knowledge = _build_knowledge_for_video(catalog_id, market_payload=market_payload).model_dump()
-    invalidate_knowledge_graph()
+    invalidate_knowledge_graph("ai_review_generation")
     return {
         "video": video,
         "analysis": knowledge.get("ai_analysis", {}),
@@ -1388,7 +1389,7 @@ def api_media_reviews_reprocess(force: bool = False, limit: int | None = None) -
             result["failed"] += 1
             result["items"].append({"video_id": catalog_id, "status": "failed", "error": exc.__class__.__name__})
     if result["generated"] or result["updated"]:
-        invalidate_knowledge_graph()
+        invalidate_knowledge_graph("media_import")
     return result
 
 
@@ -1478,7 +1479,7 @@ def api_ops_status() -> dict[str, Any]:
     health = storage_health()
     return {
         "service": "FXPilot",
-        "storage": {"mode": health["mode"], "healthy": health["healthy"], "warning": health["warning"], "data_root_source": DATA_ROOT_SOURCE, "instance_id": INSTANCE_ID, "process_started_at": PROCESS_STARTED_AT},
+        "storage": {"mode": health["mode"], "healthy": health["healthy"], "status": health["status"], "code": health["code"], "message": health["message"], "review_files": listed.files_scanned, "media_items": len(catalog), "data_root_source": DATA_ROOT_SOURCE, "instance_id": FXPILOT_INSTANCE_ID, "process_started_at": PROCESS_STARTED_AT},
         "media": {"catalog_items": len(catalog), "sources": len(tv_source_manager.list_public_sources()) if tv_source_manager else 0, "last_import": _safe_last_mtime(MEDIA_DEBUG_PATH)},
         "reviews": {
             "total": len(reviews), "storage_files": listed.files_scanned,
@@ -1507,6 +1508,11 @@ def api_ops_status() -> dict[str, Any]:
 @app.get("/api/ops/storage")
 def api_ops_storage(_auth: bool = Depends(require_ops_token)) -> dict[str, Any]:
     return {"success": True, **storage_diagnostics(LLM_REVIEW_STORAGE)}
+
+
+@app.get("/api/ops/storage/backup-manifest")
+def api_ops_storage_backup_manifest(_auth: bool = Depends(require_ops_token)) -> dict[str, Any]:
+    return backup_manifest(LLM_REVIEW_STORAGE)
 
 
 @app.post("/api/ops/storage/migrate")
@@ -1558,17 +1564,17 @@ def api_ops_pipeline_run_all(limit: int = 1, _auth: bool = Depends(require_ops_t
 
 @app.post("/api/ops/consensus/rebuild")
 def api_ops_consensus_rebuild(symbol: str = "MARKET", timeframe: str | None = None, _auth: bool = Depends(require_ops_token)) -> dict[str, Any]:
-    return _run_locked_ops("consensus_rebuild", {"symbol": symbol, "timeframe": timeframe}, lambda: (invalidate_knowledge_graph() or create_consensus_engine().build(symbol, timeframe)))
+    return _run_locked_ops("consensus_rebuild", {"symbol": symbol, "timeframe": timeframe}, lambda: (invalidate_knowledge_graph("consensus_rebuild") or create_consensus_engine().build(symbol, timeframe)))
 
 
 @app.post("/api/ops/authors/rebuild")
 def api_ops_authors_rebuild(_auth: bool = Depends(require_ops_token)) -> dict[str, Any]:
-    return _run_locked_ops("authors_rebuild", {}, lambda: (invalidate_knowledge_graph() or {"success": True, "authors": create_author_intelligence_engine().build_all()}))
+    return _run_locked_ops("authors_rebuild", {}, lambda: (invalidate_knowledge_graph("authors_rebuild") or {"success": True, "authors": create_author_intelligence_engine().build_all()}))
 
 
 @app.post("/api/ops/performance/rebuild")
 def api_ops_performance_rebuild(_auth: bool = Depends(require_ops_token)) -> dict[str, Any]:
-    return _run_locked_ops("performance_rebuild", {}, lambda: (invalidate_knowledge_graph() or create_performance_engine().evaluate_all()))
+    return _run_locked_ops("performance_rebuild", {}, lambda: (invalidate_knowledge_graph("performance_rebuild") or create_performance_engine().evaluate_all()))
 
 
 @app.post("/api/ops/cache/clear")
@@ -1578,7 +1584,7 @@ def api_ops_cache_clear(_auth: bool = Depends(require_ops_token)) -> dict[str, A
             if isinstance(cache, dict):
                 cache.clear()
         MARKET_IDEAS_CACHE.update({"updated_at_epoch": 0.0, "payload": None})
-        invalidate_knowledge_graph()
+        invalidate_knowledge_graph("safe_cache_clear")
         return {"success": True, "status": "cleared", "message": "Safe application caches cleared."}
     return _run_locked_ops("cache_clear", {}, clear)
 

--- a/app/services/atomic_storage.py
+++ b/app/services/atomic_storage.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_text(path: Path | str, text: str) -> None:
+    destination = Path(path).expanduser().resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd: int | None = None
+    tmp_name: str | None = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{destination.name}.", suffix=".tmp", dir=str(destination.parent))
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            handle.write(text)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                pass
+        os.replace(tmp_name, destination)
+        tmp_name = None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp_name:
+            try:
+                Path(tmp_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def atomic_write_json(path: Path | str, payload: Any, *, indent: int = 2) -> None:
+    atomic_write_text(path, json.dumps(payload, ensure_ascii=False, indent=indent) + "\n")

--- a/app/services/storage_health.py
+++ b/app/services/storage_health.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from app.services import storage_paths as sp
+
+PROCESS_STARTED_AT = datetime.now(timezone.utc).isoformat()
+FXPILOT_INSTANCE_ID = os.getenv("FXPILOT_INSTANCE_ID", "").strip() or uuid.uuid4().hex[:10]
+
+
+def _iso(path: Path) -> str | None:
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat() if path.exists() else None
+    except Exception:
+        return None
+
+
+def _json_items(path: Path) -> int:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, list):
+            return len(payload)
+        if isinstance(payload, dict) and isinstance(payload.get("items"), list):
+            return len(payload["items"])
+    except Exception:
+        pass
+    return 0
+
+
+def _file(path: Path) -> dict[str, Any]:
+    return {"exists": path.exists(), "items": _json_items(path) if path.exists() else 0, "size_bytes": path.stat().st_size if path.exists() else 0, "modified_at": _iso(path)}
+
+
+def _writable(path: Path) -> bool:
+    try:
+        if not path.exists():
+            return False if sp.STORAGE_MODE == "persistent" else True
+        probe = path / ".fxpilot_write_test"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+        return True
+    except Exception:
+        return False
+
+
+def _render_env() -> bool:
+    return bool(os.getenv("RENDER") or os.getenv("RENDER_SERVICE_ID") or os.getenv("RENDER_EXTERNAL_HOSTNAME"))
+
+
+def _inside_repo(path: Path) -> bool:
+    try:
+        path.resolve().relative_to(sp.PROJECT_ROOT.resolve())
+        return True
+    except Exception:
+        return False
+
+
+def storage_health() -> dict[str, Any]:
+    exists = sp.DATA_DIR.exists()
+    writable = _writable(sp.DATA_DIR)
+    status, code, message = "healthy", None, None
+    configured = bool(getattr(sp, "_ENV_DATA_DIR", ""))
+    if sp.STORAGE_MODE == "persistent" and (not exists or not writable):
+        status = "error"; code = "persistent_storage_unavailable"; message = "Постоянное хранилище недоступно: каталог не существует или недоступен для записи."
+    elif _render_env() and sp.STORAGE_MODE != "persistent" and (not configured or _inside_repo(sp.DATA_DIR)):
+        status = "degraded"; code = "ephemeral_storage_risk"; message = "Постоянное хранилище не настроено. Импортированные материалы и AI Reviews могут исчезнуть после перезапуска или деплоя Render."
+    return {"mode": sp.STORAGE_MODE, "status": status, "healthy": status == "healthy", "code": code, "message": message, "warning": ({"code": code, "message": message} if code else None), "data_root_source": sp.DATA_ROOT_SOURCE, "configured": configured, "exists": exists, "writable": writable}
+
+
+def review_diagnostics(review_storage=None) -> dict[str, Any]:
+    if review_storage is not None and hasattr(review_storage, "diagnostics"):
+        return review_storage.diagnostics()
+    directory = sp.LLM_REVIEWS_DIR
+    json_files = list(directory.glob("*.json")) if directory.exists() else []
+    valid = malformed = size = 0; latest = None
+    for path in json_files:
+        size += path.stat().st_size
+        latest = max(latest, _iso(path)) if latest else _iso(path)
+        try:
+            json.loads(path.read_text(encoding="utf-8")); valid += 1
+        except Exception:
+            malformed += 1
+    return {"directory_exists": directory.exists(), "json_files": len(json_files), "valid_reviews": valid, "malformed_reviews": malformed, "size_bytes": size, "latest_modified_at": latest}
+
+
+def storage_diagnostics(review_storage=None) -> dict[str, Any]:
+    health = storage_health()
+    reviews = review_diagnostics(review_storage)
+    transcript_files = [p for p in sp.TRANSCRIPTS_DIR.glob("*") if p.is_file()] if sp.TRANSCRIPTS_DIR.exists() else []
+    return {"storage": health, "media_catalog": _file(sp.MEDIA_CATALOG_PATH), "tv_catalog": _file(sp.MEDIA_TV_VIDEOS_PATH), "llm_reviews": reviews, "transcripts": {"directory_exists": sp.TRANSCRIPTS_DIR.exists(), "files": len(transcript_files), "latest_modified_at": max((_iso(p) for p in transcript_files), default=None)}, "runtime": {"instance_id": FXPILOT_INSTANCE_ID, "process_started_at": PROCESS_STARTED_AT, "storage_mode": sp.STORAGE_MODE}}
+
+
+def backup_manifest(review_storage=None) -> dict[str, Any]:
+    diag = storage_diagnostics(review_storage)
+    known = []
+    for name in sp.KNOWN_JSON_FILES:
+        path = sp.DATA_DIR / name
+        known.append({"name": name, "exists": path.exists(), "size_bytes": path.stat().st_size if path.exists() else 0, "modified_at": _iso(path)})
+    return {"success": True, "known_files": known, "review_count": diag["llm_reviews"]["json_files"], "transcript_count": diag["transcripts"]["files"], "storage": diag["storage"], "runtime": diag["runtime"]}

--- a/app/services/storage_paths.py
+++ b/app/services/storage_paths.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
-import json
 import os
 import shutil
-import tempfile
-import uuid
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+
+from app.services.atomic_storage import atomic_write_json, atomic_write_text
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DATA_DIR = PROJECT_ROOT / "data"
 _ENV_DATA_DIR = os.getenv("FXPILOT_DATA_DIR", "").strip()
-DATA_DIR = Path(_ENV_DATA_DIR or PROJECT_ROOT / "data").expanduser().resolve()
+DATA_DIR = Path(_ENV_DATA_DIR or DEFAULT_DATA_DIR).expanduser().resolve()
 DATA_ROOT_SOURCE = "FXPILOT_DATA_DIR" if _ENV_DATA_DIR else "local_default"
-STORAGE_MODE = os.getenv("FXPILOT_STORAGE_MODE", "persistent" if _ENV_DATA_DIR else "local").strip().lower() or "local"
-PROCESS_STARTED_AT = datetime.now(timezone.utc).isoformat()
-INSTANCE_ID = os.getenv("FXPILOT_INSTANCE_ID", "").strip() or uuid.uuid4().hex[:10]
+_RAW_STORAGE_MODE = os.getenv("FXPILOT_STORAGE_MODE", "local").strip().lower() or "local"
+SUPPORTED_STORAGE_MODES = {"local", "persistent", "ephemeral"}
+STORAGE_MODE_WARNING = None if _RAW_STORAGE_MODE in SUPPORTED_STORAGE_MODES else f"Unsupported FXPILOT_STORAGE_MODE={_RAW_STORAGE_MODE!r}; normalized to local."
+STORAGE_MODE = _RAW_STORAGE_MODE if _RAW_STORAGE_MODE in SUPPORTED_STORAGE_MODES else "local"
 
 MEDIA_SOURCES_PATH = DATA_DIR / "media_sources.json"
 MEDIA_CATALOG_PATH = DATA_DIR / "media_catalog.json"
@@ -24,128 +23,109 @@ MEDIA_TV_VIDEOS_PATH = DATA_DIR / "tv_videos.json"
 MEDIA_MANUAL_YOUTUBE_PATH = DATA_DIR / "manual_youtube_videos.json"
 MEDIA_DEBUG_PATH = DATA_DIR / "media_import_debug.json"
 MEDIA_AUTOMATION_STATE_PATH = DATA_DIR / "media_automation_state.json"
+OPS_AUDIT_PATH = DATA_DIR / "ops_audit.json"
 LLM_REVIEWS_DIR = DATA_DIR / "llm_reviews"
 TRANSCRIPTS_DIR = DATA_DIR / "transcripts"
-OPS_AUDIT_PATH = DATA_DIR / "ops_audit.json"
-KNOWN_JSON_FILES = ["media_catalog.json", "tv_videos.json", "media_sources.json", "media_import_debug.json", "media_automation_state.json", "ops_audit.json"]
+
+KNOWN_JSON_FILES = [
+    "media_catalog.json", "tv_videos.json", "media_sources.json", "manual_youtube_videos.json",
+    "media_import_debug.json", "media_automation_state.json", "ops_audit.json",
+]
 
 
-def ensure_storage_dirs() -> None:
+def ensure_storage_directories() -> None:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     LLM_REVIEWS_DIR.mkdir(parents=True, exist_ok=True)
     TRANSCRIPTS_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def atomic_write_json(path: Path, payload: Any) -> None:
-    path = Path(path).expanduser().resolve()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh, ensure_ascii=False, indent=2)
-            fh.write("\n")
-            fh.flush()
-            os.fsync(fh.fileno())
-        Path(tmp_name).replace(path)
-    finally:
-        tmp = Path(tmp_name)
-        if tmp.exists():
-            tmp.unlink(missing_ok=True)
-
-
-def _iso_mtime(path: Path) -> str | None:
-    try:
-        return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat() if path.exists() else None
-    except Exception:
-        return None
-
-
-def _json_items(path: Path) -> int:
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(payload, list):
-            return len(payload)
-        if isinstance(payload, dict) and isinstance(payload.get("items"), list):
-            return len(payload["items"])
-    except Exception:
-        pass
-    return 0
-
-
-def _file_diag(path: Path) -> dict[str, Any]:
-    return {"exists": path.exists(), "file_count": 1 if path.exists() else 0, "items": _json_items(path) if path.exists() else 0, "size_bytes": path.stat().st_size if path.exists() else 0, "modified_at": _iso_mtime(path)}
-
-
-def storage_health() -> dict[str, Any]:
-    exists = DATA_DIR.exists()
-    writable = False
-    try:
-        DATA_DIR.mkdir(parents=True, exist_ok=True)
-        test = DATA_DIR / ".fxpilot_write_test"
-        test.write_text("ok", encoding="utf-8"); test.unlink(missing_ok=True)
-        writable = True
-    except Exception:
-        writable = False
-    is_render = bool(os.getenv("RENDER") or os.getenv("RENDER_SERVICE_ID") or os.getenv("RENDER_EXTERNAL_HOSTNAME"))
-    warning = None; status = "ok"
-    if STORAGE_MODE == "persistent" and (not _ENV_DATA_DIR or not exists or not writable):
-        status = "degraded"; warning = {"code": "persistent_storage_unavailable", "message": "Persistent storage mode is requested but FXPILOT_DATA_DIR is missing, absent or not writable."}
-    elif is_render and (not _ENV_DATA_DIR or STORAGE_MODE != "persistent"):
-        status = "degraded"; warning = {"code": "ephemeral_storage_risk", "message": "Persistent data directory is not configured. Imported media and generated reviews may disappear after redeploy."}
-    return {"status": status, "mode": STORAGE_MODE, "healthy": status == "ok", "warning": warning}
-
-
-def storage_diagnostics(review_storage: Any | None = None) -> dict[str, Any]:
-    ensure_storage_dirs()
-    review_diag = review_storage.diagnostics() if review_storage else {"directory_exists": LLM_REVIEWS_DIR.exists(), "json_files": len(list(LLM_REVIEWS_DIR.glob("*.json"))), "valid_reviews": 0, "malformed_reviews": 0, "size_bytes": sum(p.stat().st_size for p in LLM_REVIEWS_DIR.glob("*.json") if p.is_file()), "latest_modified_at": max((_iso_mtime(p) for p in LLM_REVIEWS_DIR.glob("*.json") if p.is_file()), default=None)}
-    health = storage_health()
-    cwd_consistent = (Path.cwd() / "data").resolve() == DATA_DIR or DATA_ROOT_SOURCE == "FXPILOT_DATA_DIR"
-    return {
-        "data_root": {"configured": bool(_ENV_DATA_DIR), "exists": DATA_DIR.exists(), "writable": health["healthy"] or DATA_DIR.exists(), "persistent_mode": STORAGE_MODE == "persistent", "data_root_source": DATA_ROOT_SOURCE, "storage_mode": STORAGE_MODE, "health": health},
-        "media_catalog": _file_diag(MEDIA_CATALOG_PATH),
-        "tv_catalog": _file_diag(MEDIA_TV_VIDEOS_PATH),
-        "llm_reviews": review_diag,
-        "transcripts": {"directory_exists": TRANSCRIPTS_DIR.exists(), "files": len([p for p in TRANSCRIPTS_DIR.glob("*") if p.is_file()]) if TRANSCRIPTS_DIR.exists() else 0},
-        "process": {"instance_id": INSTANCE_ID, "started_at": PROCESS_STARTED_AT, "working_directory_consistent": cwd_consistent, "storage_mode": STORAGE_MODE, "data_root_source": DATA_ROOT_SOURCE},
-    }
+def ensure_storage_dirs() -> None:  # backwards-compatible alias
+    ensure_storage_directories()
 
 
 def legacy_data_dirs() -> list[Path]:
-    candidates = [PROJECT_ROOT / "data", Path("data").resolve(), Path(__file__).resolve().parents[2] / "data", DATA_DIR]
-    out=[]
-    for p in candidates:
-        rp=p.expanduser().resolve()
-        if rp not in out:
-            out.append(rp)
+    candidates = [PROJECT_ROOT / "data", Path("data").resolve(), DATA_DIR]
+    out: list[Path] = []
+    for item in candidates:
+        path = item.expanduser().resolve()
+        if path not in out:
+            out.append(path)
     return out
 
 
-def migrate_legacy_data(*, execute: bool = False, review_model: Any | None = None) -> dict[str, Any]:
-    ensure_storage_dirs()
-    result = {"success": True, "dry_run": not execute, "copied": 0, "skipped": 0, "conflicted": 0, "malformed": 0, "sources": ["repo_data", "cwd_data", "previous_base_dir_parent_data", "configured_data_dir"], "files": []}
-    def consider(src: Path, dst: Path, kind: str):
-        if not src.exists() or src.resolve() == dst.resolve(): return
-        if kind == "review" and review_model:
-            try: review_model.model_validate(json.loads(src.read_text(encoding="utf-8")))
+def _destination_for(src: Path) -> Path:
+    if src.parent.name == "llm_reviews":
+        return LLM_REVIEWS_DIR / src.name
+    if src.parent.name == "transcripts":
+        return TRANSCRIPTS_DIR / src.name
+    return DATA_DIR / src.name
+
+
+def migrate_legacy_data(*, execute: bool = False, review_model=None) -> dict[str, object]:
+    ensure_storage_directories()
+    counters = {"scanned": 0, "copy_planned": 0, "copied": 0, "skipped_existing": 0, "skipped_newer_destination": 0, "malformed": 0, "errors": 0}
+    files: list[dict[str, object]] = []
+
+    def consider(src: Path, kind: str) -> None:
+        if not src.exists() or not src.is_file():
+            return
+        counters["scanned"] += 1
+        dst = _destination_for(src)
+        if src.resolve() == dst.resolve():
+            counters["skipped_existing"] += 1
+            files.append({"name": src.name, "kind": kind, "action": "skipped_existing"})
+            return
+        if kind == "review" and review_model is not None:
+            try:
+                import json
+                review_model.model_validate(json.loads(src.read_text(encoding="utf-8")))
             except Exception:
-                result["malformed"] += 1; result["files"].append({"source": kind, "name": src.name, "action": "malformed"}); return
-        action = "copy"
+                counters["malformed"] += 1
+                files.append({"name": src.name, "kind": kind, "action": "malformed"})
+                return
         if dst.exists():
-            action = "skip_newer_destination" if dst.stat().st_mtime >= src.stat().st_mtime else "conflict_destination_older"
-            result["skipped" if action.startswith("skip") else "conflicted"] += 1
+            if dst.stat().st_mtime >= src.stat().st_mtime:
+                counters["skipped_newer_destination"] += 1
+                files.append({"name": src.name, "kind": kind, "action": "skipped_newer_destination"})
+                return
+            counters["skipped_existing"] += 1
+            files.append({"name": src.name, "kind": kind, "action": "skipped_existing_destination_older"})
+            return
+        counters["copy_planned"] += 1
+        if execute:
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+                counters["copied"] += 1
+                files.append({"name": src.name, "kind": kind, "action": "copied"})
+            except Exception as exc:
+                counters["errors"] += 1
+                files.append({"name": src.name, "kind": kind, "action": "error", "error": exc.__class__.__name__})
         else:
-            result["copied"] += 1
-            if execute:
-                dst.parent.mkdir(parents=True, exist_ok=True); shutil.copy2(src, dst)
-        result["files"].append({"source": kind, "name": src.name, "action": action})
+            files.append({"name": src.name, "kind": kind, "action": "copy_planned"})
+
     for base in legacy_data_dirs():
         for name in KNOWN_JSON_FILES:
-            consider(base / name, DATA_DIR / name, "json")
-        for src in sorted((base / "llm_reviews").glob("*.json")) if (base / "llm_reviews").exists() else []:
-            consider(src, LLM_REVIEWS_DIR / src.name, "review")
-        if (base / "transcripts").exists():
-            for src in sorted(p for p in (base / "transcripts").glob("*") if p.is_file()):
-                consider(src, TRANSCRIPTS_DIR / src.name, "transcript")
-    return result
+            consider(base / name, "json")
+        reviews = base / "llm_reviews"
+        if reviews.exists():
+            for src in sorted(reviews.glob("*.json")):
+                consider(src, "review")
+        transcripts = base / "transcripts"
+        if transcripts.exists():
+            for src in sorted(p for p in transcripts.glob("*") if p.is_file()):
+                consider(src, "transcript")
+    return {"success": counters["errors"] == 0, "dry_run": not execute, "cost": "FREE / NO LLM COST", **counters, "files": files}
 
-ensure_storage_dirs()
+
+ensure_storage_directories()
+
+
+def storage_health():
+    from app.services.storage_health import storage_health as _storage_health
+    return _storage_health()
+
+
+def storage_diagnostics(review_storage=None):
+    from app.services.storage_health import storage_diagnostics as _storage_diagnostics
+    return _storage_diagnostics(review_storage)

--- a/app/static/ops.js
+++ b/app/static/ops.js
@@ -32,17 +32,29 @@
   }
   function renderStorageFromStatus(p) {
     const s = p.storage || {}; const r = p.reviews || {}; const kg = p.knowledge_graph || {};
-    const warning = s.warning?.message || '—';
+    const warning = s.message || s.warning?.message || '—';
     const cards = [
-      ['Storage mode', s.mode || '—'], ['Persistent directory configured', s.data_root_source === 'FXPILOT_DATA_DIR' ? 'Да' : 'Нет'],
-      ['Media catalog items', p.media?.catalog_items ?? 0], ['Review files', r.storage_files ?? 0], ['Valid reviews', r.total ?? 0],
-      ['Knowledge Graph symbols', kg.symbols ?? 0], ['Last storage modification', r.last_review || p.media?.last_import || '—'], ['Warning', warning],
+      ['Storage mode', s.mode || '—'], ['Status', s.status || (s.healthy ? 'healthy' : '—')], ['Persistent storage configured', s.data_root_source === 'FXPILOT_DATA_DIR' ? 'Да' : 'Нет'],
+      ['Media catalog items', s.media_items ?? p.media?.catalog_items ?? 0], ['Review files', s.review_files ?? r.storage_files ?? 0], ['Valid reviews', r.total ?? 0],
+      ['Malformed reviews', kg.malformed_reviews ?? 0], ['Transcript files', p.transcripts?.files ?? '—'], ['Runtime instance', s.instance_id || '—'], ['Process start time', s.process_started_at || '—'], ['Warning', warning],
     ];
-    const el = $('storageCards'); if (el) el.innerHTML = cards.map(([label, value]) => `<article class="stats-page-card"><span>${label}</span><strong>${value ?? '—'}</strong></article>`).join('');
+    const el = $('storageCards');
+    if (el) el.innerHTML = cards.map(([label, value]) => `<article class="stats-page-card ${s.code === 'ephemeral_storage_risk' ? 'warning' : ''}"><span>${label}</span><strong>${value ?? '—'}</strong></article>`).join('');
+  }
+  function renderStorageDiagnostics(p) {
+    const s = p.storage || {}; const reviews = p.llm_reviews || {}; const transcripts = p.transcripts || {};
+    const cards = [
+      ['Storage mode', s.mode || '—'], ['Status', s.status || '—'], ['Persistent storage configured', s.configured ? 'Да' : 'Нет'],
+      ['Media catalog items', p.media_catalog?.items ?? 0], ['TV catalog items', p.tv_catalog?.items ?? 0], ['Review files', reviews.json_files ?? 0],
+      ['Valid reviews', reviews.valid_reviews ?? 0], ['Malformed reviews', reviews.malformed_reviews ?? 0], ['Transcript files', transcripts.files ?? 0],
+      ['Runtime instance', p.runtime?.instance_id || '—'], ['Process start time', p.runtime?.process_started_at || '—'], ['Warning', s.message || '—'],
+    ];
+    const el = $('storageCards');
+    if (el) el.innerHTML = cards.map(([label, value]) => `<article class="stats-page-card ${s.code === 'ephemeral_storage_risk' ? 'warning' : ''}"><span>${label}</span><strong>${value ?? '—'}</strong></article>`).join('');
   }
   async function loadStorage(button) {
     if (button) setBusy(button, true);
-    try { const r = await fetch('/api/ops/storage', { headers: headers(), cache: 'no-store' }); storagePayload = await r.json(); logResult({ name: 'Диагностика хранилища', started: new Date().toLocaleString('ru-RU'), finished: new Date().toLocaleString('ru-RU'), duration: 0, httpStatus: r.status, ok: r.ok, payload: storagePayload }); }
+    try { const r = await fetch('/api/ops/storage', { headers: headers(), cache: 'no-store' }); storagePayload = await r.json(); renderStorageDiagnostics(storagePayload); logResult({ name: 'Диагностика хранилища', started: new Date().toLocaleString('ru-RU'), finished: new Date().toLocaleString('ru-RU'), duration: 0, httpStatus: r.status, ok: r.ok, payload: storagePayload }); }
     finally { if (button) setBusy(button, false); }
   }
   function confirmCostly(name, count) {

--- a/render.yaml
+++ b/render.yaml
@@ -11,6 +11,8 @@ services:
         value: https://fxpilot-orderflow-engine.onrender.com
       - key: ORDERFLOW_TIMEOUT_SECONDS
         value: 2
+      - key: FXPILOT_STORAGE_MODE
+        value: persistent
     buildCommand: pip install -r requirements.txt
     startCommand: python -m uvicorn app.main:app --host 0.0.0.0 --port $PORT
     plan: free

--- a/tests/test_storage_paths_health_stage20_2.py
+++ b/tests/test_storage_paths_health_stage20_2.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.services.llm_review import LLMReview, LLMReviewStorage
+from app.services.storage_paths import atomic_write_json
+
+
+def _reload_storage(monkeypatch, data_dir=None, mode=None):
+    if data_dir is None:
+        monkeypatch.delenv("FXPILOT_DATA_DIR", raising=False)
+    else:
+        monkeypatch.setenv("FXPILOT_DATA_DIR", str(data_dir))
+    if mode is None:
+        monkeypatch.delenv("FXPILOT_STORAGE_MODE", raising=False)
+    else:
+        monkeypatch.setenv("FXPILOT_STORAGE_MODE", mode)
+    import app.services.storage_paths as sp
+    import app.services.storage_health as sh
+    importlib.reload(sp); importlib.reload(sh)
+    return sp, sh
+
+
+def test_configured_canonical_paths_inside_env_dir(tmp_path, monkeypatch):
+    sp, _ = _reload_storage(monkeypatch, tmp_path / "persistent", "persistent")
+    for path in [sp.MEDIA_SOURCES_PATH, sp.MEDIA_CATALOG_PATH, sp.MEDIA_TV_VIDEOS_PATH, sp.MEDIA_MANUAL_YOUTUBE_PATH, sp.MEDIA_DEBUG_PATH, sp.MEDIA_AUTOMATION_STATE_PATH, sp.OPS_AUDIT_PATH, sp.LLM_REVIEWS_DIR, sp.TRANSCRIPTS_DIR]:
+        assert path.is_relative_to(sp.DATA_DIR)
+    assert sp.DATA_DIR == (tmp_path / "persistent").resolve()
+
+
+def test_default_local_path_uses_repository_data(monkeypatch):
+    sp, _ = _reload_storage(monkeypatch, None, None)
+    assert sp.DATA_DIR == (sp.PROJECT_ROOT / "data").resolve()
+    assert sp.STORAGE_MODE == "local"
+
+
+def test_storage_health_persistent_writable_and_unavailable(tmp_path, monkeypatch):
+    sp, sh = _reload_storage(monkeypatch, tmp_path / "ok", "persistent")
+    sp.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    assert sh.storage_health()["status"] == "healthy"
+    sp.DATA_DIR = tmp_path / "missing"
+    assert sh.storage_health()["code"] == "persistent_storage_unavailable"
+
+
+def test_ops_storage_endpoint_token_and_no_secret(monkeypatch, tmp_path):
+    import app.main as main
+    storage = LLMReviewStorage(tmp_path / "reviews")
+    storage.set("v1", LLMReview(primary_symbol="BTCUSD", symbols=["BTCUSD"], direction="BUY"))
+    monkeypatch.setattr(main, "LLM_REVIEW_STORAGE", storage)
+    monkeypatch.setenv("FXPILOT_OPS_TOKEN", "super-secret-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value")
+    client = TestClient(main.app)
+    assert client.get("/api/ops/storage").status_code == 401
+    payload = client.get("/api/ops/storage", headers={"X-FXPILOT-OPS-TOKEN": "super-secret-token"}).json()
+    text = json.dumps(payload)
+    assert payload["success"] is True
+    assert "super-secret-token" not in text
+    assert "sk-secret-value" not in text
+    assert str(tmp_path) not in text
+
+
+def test_backup_manifest_metadata_only(monkeypatch, tmp_path):
+    import app.main as main
+    monkeypatch.setenv("FXPILOT_OPS_TOKEN", "ops")
+    client = TestClient(main.app)
+    payload = client.get("/api/ops/storage/backup-manifest", headers={"X-FXPILOT-OPS-TOKEN": "ops"}).json()
+    assert payload["success"] is True
+    assert "known_files" in payload
+    assert "contents" not in json.dumps(payload).lower()
+
+
+def test_atomic_review_write_leaves_no_temp_files(tmp_path):
+    storage = LLMReviewStorage(tmp_path / "reviews")
+    storage.set("youtube:v1", LLMReview(primary_symbol="BTCUSD", symbols=["BTCUSD"], direction="BUY"))
+    files = list(storage.base_dir.iterdir())
+    assert all(not p.name.endswith(".tmp") for p in files)
+    assert json.loads((storage.base_dir / "youtubev1.json").read_text(encoding="utf-8"))["primary_symbol"] == "BTCUSD"

--- a/tests/test_storage_stage20_2.py
+++ b/tests/test_storage_stage20_2.py
@@ -64,7 +64,7 @@ def test_migration_dry_run_execute_newer_and_atomic(tmp_path):
     sp.DATA_DIR = dst; sp.LLM_REVIEWS_DIR = dst / "llm_reviews"; sp.TRANSCRIPTS_DIR = dst / "transcripts"
     try:
         dry = sp.migrate_legacy_data(execute=False, review_model=LLMReview)
-        assert dry["copied"] >= 1 and not (dst / "llm_reviews" / "v1.json").exists()
+        assert dry["copy_planned"] >= 1 and dry["copied"] == 0 and not (dst / "llm_reviews" / "v1.json").exists()
         done = sp.migrate_legacy_data(execute=True, review_model=LLMReview)
         assert (dst / "llm_reviews" / "v1.json").exists()
         assert json.loads((dst / "media_catalog.json").read_text())[0]["id"] == "newer"


### PR DESCRIPTION
### Motivation

- Исправить корневую проблему: runtime-данные приложения записывались в репозиторный `data/` каталог, который на Render является эфемерным и теряется при перезапусках/деплоях. 
- Ввести один канонический настраиваемый корень данных, поддерживающий и локальную разработку, и смонтированный persistent disk на Render (`/var/data/fxpilot`).
- Обеспечить безопасную миграцию существующих файлов, надежные атомарные записи и безопасные диагностические эндпоинты без утечек секретов.

### Description

- Добавлен модуль канонических путей `app/services/storage_paths.py`, который разрешает `FXPILOT_DATA_DIR`, нормализует `FXPILOT_STORAGE_MODE`, экспортирует все ключевые пути (`DATA_DIR`, `MEDIA_CATALOG_PATH`, `LLM_REVIEWS_DIR`, `TRANSCRIPTS_DIR`, `OPS_AUDIT_PATH` и т.д.) и предоставляет совместимый alias `ensure_storage_dirs()`.
- Добавлен атомарный механизм записи в `app/services/atomic_storage.py` и применён он для сохранения AI Reviews, TV/ media catalog, automation state и debug-файлов через `atomic_write_json()`.
- Добавлен сервис диагностики `app/services/storage_health.py` с безопасной моделью отчёта (режим, состояние, код/сообщение при риске эфемерного хранилища, счётчики файлов/элементов, runtime `instance_id` и `process_started_at`) и backup manifest.
- Обновлён `app/main.py` для использования канонических путей: все сервисы (TvSourceManager, MediaImportEngine, MediaAutomationService, TranscriptStorage, LLMReviewStorage, OPS audit) читают/пишут один корень; добавлены защищённые эндпоинты `GET /api/ops/storage`, `GET /api/ops/storage/backup-manifest` и `POST /api/ops/storage/migrate` с безопасной миграцией известных файлов (dry-run / execute), а также расширена секция `storage` в `GET /api/ops/status`.
- Сохранена независимость конструктора `LLMReviewStorage` для тестов, конвертирован базовый путь в абсолютный, и все методы используют единый resolved base_dir; добавлена валидация при миграции review-файлов (malformed пропускаются).
- OPS frontend (`app/static/ops.js` / `app/static/ops.html`) дополнен read-only карточкой хранилища, кнопкой «Обновить диагностику хранилища» и явным предупреждением при риске эфемерного хранилища; UI не показывает абсолютных путей или секретов.
- Механика миграции реализована аккуратно: копируются только известные файлы/директории, не удаляются источники, не перезаписываются более новые destination-файлы, malformed reviews пропускаются, операция помечается `FREE / NO LLM COST` и при успешном `execute` инвалидируется Knowledge Graph.
- Документация: добавлен раздел с точными шагами для Render в `README.md`; `render.yaml` обновлён только с безопасной переменной `FXPILOT_STORAGE_MODE=persistent` (не добавлен disk declaration, поэтому ручная настройка диска на Render остаётся требуемой).

### Testing

- Код проинспектирован под `python -m py_compile` и успешно скомпилирован для `app/main.py`, `app/services/storage_paths.py`, `app/services/storage_health.py` и `app/services/atomic_storage.py`.
- Запущены регрессионные тесты хранения: `tests/test_storage_stage20_2.py` и `tests/test_storage_paths_health_stage20_2.py` успешно прошли (включая сценарии миграции dry-run/execute, CWD-independence, atomic write, malformed review handling, Knowledge Graph invalidation/empty-ttl и OPS security checks).
- Запуск более широкой тестовой выборки показал единичную внешне-зависимую ошибку: `test_media_review_endpoint_returns_fxpilot_context` упал по сетевой причине (прокси/YouTube, `403 Forbidden`), не связанной с изменениями хранения; остальные тесты в этой прогонке прошли успешно.
- Все автоматические тесты, затрагивающие новые механизмы хранения, миграции и диагностики, прошли успешно; приёмка требует вручную смонтировать persistent disk на Render по инструкции в `README.md` и установить `FXPILOT_DATA_DIR=/var/data/fxpilot` и `FXPILOT_STORAGE_MODE=persistent` перед деплоем.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b502f84c48331b95898e7eeff22ca)