### PR TITLE
Restore persistent FXPilot TV source registry

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -43,6 +43,7 @@ from app.services.timing import timing_log
 from app.services.ai_runtime_status import get_ai_status, record_ai_request_failure, record_ai_request_start, record_ai_request_success, run_ai_test_request, startup_ai_healthcheck
 from app.services.visitor_counter import get_visit_stats, increment_visit
 from app.services.tv_source_manager import TvSourceConfigError, TvSourceManager
+from app.services.tv_source_bootstrap import ensure_tv_sources_initialized, last_tv_sources_bootstrap_diagnostic
 from app.services.media_identity import canonical_catalog_id, canonical_youtube_id, resolve_media_video as _resolve_media_video_from_catalog
 from app.services.media_import_engine import MediaConfigError, MediaImportEngine
 from app.services.media_automation import MediaAutomationService
@@ -156,6 +157,7 @@ from backend.signal_engine import SignalEngine
 
 canonical_market_service = get_canonical_market_service()
 trade_idea_service = TradeIdeaService(signal_engine=SignalEngine())
+tv_sources_bootstrap = ensure_tv_sources_initialized()
 tv_source_manager = TvSourceManager(MEDIA_TV_SOURCES_PATH, MEDIA_TV_VIDEOS_PATH)
 OPS_LOCKS = {name: Lock() for name in ["media_import", "review_reprocess", "pipeline_run", "pipeline_run_all", "consensus_rebuild", "authors_rebuild", "performance_rebuild", "cache_clear", "storage_migrate"]}
 KG_SERVICE: KnowledgeGraphService | None = None
@@ -1080,6 +1082,11 @@ def invalidate_knowledge_graph(reason: str = "manual") -> None:
         KG_SERVICE.invalidate(reason)
 
 
+def _media_import_source_counts(engine: MediaImportEngine) -> tuple[int, int]:
+    sources = engine.load_sources()
+    return len(sources), len([source for source in sources if source.enabled])
+
+
 def _run_media_import() -> dict[str, Any]:
     engine = create_media_import_engine()
     result = engine.import_latest()
@@ -1092,6 +1099,8 @@ def _run_media_import() -> dict[str, Any]:
 def api_media_import() -> dict[str, Any]:
     try:
         return _run_media_import()
+    except HTTPException:
+        raise
     except MediaConfigError as exc:
         logger.exception("media_import_config_failed")
         raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
@@ -1104,6 +1113,8 @@ def api_media_import() -> dict[str, Any]:
 def api_media_import_now() -> dict[str, Any]:
     try:
         return _run_media_import()
+    except HTTPException:
+        raise
     except MediaConfigError as exc:
         logger.exception("media_import_config_failed")
         raise HTTPException(status_code=500, detail={"error": str(exc), "exception_type": exc.__class__.__name__}) from exc
@@ -1156,7 +1167,13 @@ def _review_needs_reprocess(review: LLMReview | None) -> bool:
 def api_media_debug() -> dict[str, Any]:
     try:
         payload = create_media_import_engine().debug_sources()
-        payload["tv_source_manager"] = tv_source_manager.debug_payload()
+        tv_debug = tv_source_manager.debug_payload()
+        bootstrap_debug = last_tv_sources_bootstrap_diagnostic()
+        tv_debug["bootstrap_status"] = bootstrap_debug.get("status")
+        tv_debug["template_exists"] = bootstrap_debug.get("template_exists")
+        tv_debug["load_error"] = tv_debug.get("load_error") or bootstrap_debug.get("load_error")
+        payload["tv_source_manager"] = tv_debug
+        payload["source_registry"] = tv_debug
         payload.update(transcript_engine.debug_payload())
         payload.update(MEDIA_KNOWLEDGE_DEBUG)
         payload.update(llm_debug_payload())
@@ -1516,6 +1533,7 @@ def api_ops_storage_migrate(dry_run: bool = True, execute: bool = False, _auth: 
     def run():
         result = migrate_legacy_data(execute=bool(execute) and not bool(dry_run), review_model=LLMReview)
         if execute and not dry_run:
+            result["tv_source_reload"] = tv_source_manager.reload_sources()
             invalidate_knowledge_graph("storage_migration")
         return result
     return _run_locked_ops("storage_migrate", {"dry_run": bool(dry_run), "execute": bool(execute)}, run)
@@ -1527,9 +1545,26 @@ def api_ops_audit(limit: int = 50, _auth: bool = Depends(require_ops_token)) -> 
     return {"success": True, "records": records[-limit:] if isinstance(records, list) else []}
 
 
+def _run_ops_media_import() -> dict[str, Any]:
+    engine = create_media_import_engine()
+    sources_loaded, enabled_sources = _media_import_source_counts(engine)
+    if sources_loaded == 0 or enabled_sources == 0:
+        raise HTTPException(status_code=409, detail={
+            "success": False,
+            "status": "no_enabled_sources",
+            "message": "Не настроено ни одного активного источника FXPilot TV.",
+            "sources_loaded": sources_loaded,
+            "enabled_sources": enabled_sources,
+        })
+    result = engine.import_latest()
+    result["review_generation"] = _generate_reviews_for_imported_items(result.get("new_item_ids") or [])
+    invalidate_knowledge_graph()
+    return result
+
+
 @app.post("/api/ops/media/import")
 def api_ops_media_import(_auth: bool = Depends(require_ops_token)) -> dict[str, Any]:
-    return _run_locked_ops("media_import", {}, _run_media_import)
+    return _run_locked_ops("media_import", {}, _run_ops_media_import)
 
 
 @app.post("/api/ops/reviews/reprocess")

--- a/app/services/storage_paths.py
+++ b/app/services/storage_paths.py
@@ -27,7 +27,16 @@ MEDIA_AUTOMATION_STATE_PATH = DATA_DIR / "media_automation_state.json"
 LLM_REVIEWS_DIR = DATA_DIR / "llm_reviews"
 TRANSCRIPTS_DIR = DATA_DIR / "transcripts"
 OPS_AUDIT_PATH = DATA_DIR / "ops_audit.json"
-KNOWN_JSON_FILES = ["media_catalog.json", "tv_videos.json", "media_sources.json", "media_import_debug.json", "media_automation_state.json", "ops_audit.json"]
+KNOWN_JSON_FILES = [
+    "media_catalog.json",
+    "tv_videos.json",
+    "tv_sources.json",
+    "media_sources.json",
+    "manual_youtube_videos.json",
+    "media_import_debug.json",
+    "media_automation_state.json",
+    "ops_audit.json",
+]
 
 
 def ensure_storage_dirs() -> None:

--- a/app/services/tv_source_bootstrap.py
+++ b/app/services/tv_source_bootstrap.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from app.services.storage_paths import MEDIA_TV_SOURCES_PATH, PROJECT_ROOT, atomic_write_json
+
+logger = logging.getLogger(__name__)
+
+TV_SOURCES_TEMPLATE_PATH = PROJECT_ROOT / "data" / "tv_sources.json"
+_LAST_BOOTSTRAP_DIAGNOSTIC: dict[str, Any] = {
+    "status": "not_run",
+    "total": 0,
+    "enabled": 0,
+    "template_exists": TV_SOURCES_TEMPLATE_PATH.exists(),
+    "load_error": None,
+}
+
+
+def _enabled_count(items: list[dict[str, Any]]) -> int:
+    return sum(1 for item in items if item.get("enabled") is True)
+
+
+def _validate_registry(payload: Any, *, source_name: str) -> tuple[list[dict[str, Any]] | None, str | None]:
+    if not isinstance(payload, list):
+        return None, f"{source_name} must contain a JSON list"
+    if not payload:
+        return [], None
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            return None, f"{source_name} record #{index} must be an object"
+        for field in ("id", "provider", "channel_url"):
+            if not str(item.get(field) or "").strip():
+                return None, f"{source_name} record #{index} field {field} is required"
+        enabled = item.get("enabled")
+        if isinstance(enabled, bool):
+            normalized_enabled = enabled
+        elif isinstance(enabled, str) and enabled.strip().lower() in {"true", "false"}:
+            normalized_enabled = enabled.strip().lower() == "true"
+        else:
+            return None, f"{source_name} record #{index} enabled must be boolean"
+        normalized.append({**item, "enabled": normalized_enabled})
+    return normalized, None
+
+
+def _result(status: str, items: list[dict[str, Any]] | None = None, *, error: str | None = None, target_path: Path = MEDIA_TV_SOURCES_PATH, template_path: Path = TV_SOURCES_TEMPLATE_PATH) -> dict[str, Any]:
+    payload = {
+        "status": status,
+        "total": len(items or []),
+        "enabled": _enabled_count(items or []),
+        "disabled": max(0, len(items or []) - _enabled_count(items or [])),
+        "sources_exists": target_path.exists(),
+        "template_exists": template_path.exists(),
+        "load_error": error,
+    }
+    _LAST_BOOTSTRAP_DIAGNOSTIC.clear()
+    _LAST_BOOTSTRAP_DIAGNOSTIC.update(payload)
+    return dict(payload)
+
+
+def last_tv_sources_bootstrap_diagnostic() -> dict[str, Any]:
+    return dict(_LAST_BOOTSTRAP_DIAGNOSTIC)
+
+
+def ensure_tv_sources_initialized(*, target_path: Path = MEDIA_TV_SOURCES_PATH, template_path: Path = TV_SOURCES_TEMPLATE_PATH) -> dict[str, Any]:
+    if target_path.exists():
+        try:
+            existing_payload = json.loads(target_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.error("tv_sources_bootstrap_existing_malformed path=%s error=%s", target_path, exc.__class__.__name__)
+            return _result("error", error="persistent_registry_malformed", target_path=target_path, template_path=template_path)
+        existing, error = _validate_registry(existing_payload, source_name="persistent tv_sources.json")
+        if error:
+            logger.error("tv_sources_bootstrap_existing_invalid path=%s error=%s", target_path, error)
+            return _result("error", error=error, target_path=target_path, template_path=template_path)
+        if existing:
+            return _result("existing", existing, target_path=target_path, template_path=template_path)
+        bootstrap_status = "bootstrapped_from_empty"
+    else:
+        bootstrap_status = "bootstrapped"
+
+    try:
+        template_payload = json.loads(template_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.error("tv_sources_bootstrap_template_unavailable path=%s error=%s", template_path, exc.__class__.__name__)
+        return _result("error", error="template_unavailable_or_malformed", target_path=target_path, template_path=template_path)
+    template, error = _validate_registry(template_payload, source_name="repository data/tv_sources.json")
+    if error or not template:
+        logger.error("tv_sources_bootstrap_template_invalid path=%s error=%s", template_path, error or "empty_template")
+        return _result("error", error=error or "template_empty", target_path=target_path, template_path=template_path)
+
+    atomic_write_json(target_path, template)
+    logger.info("tv_sources_bootstrapped status=%s path=%s total=%s enabled=%s", bootstrap_status, target_path, len(template), _enabled_count(template))
+    return _result(bootstrap_status, template, target_path=target_path, template_path=template_path)

--- a/app/services/tv_source_manager.py
+++ b/app/services/tv_source_manager.py
@@ -72,14 +72,25 @@ class TvSourceManager:
     def __init__(self, sources_path: Path, videos_path: Path | None = None) -> None:
         self.sources_path = sources_path
         self.videos_path = videos_path
+        self._sources: list[TvSource] = []
+        self._load_error: str | None = None
+        self.reload_sources()
 
     def load_sources(self) -> list[TvSource]:
+        return list(self._sources)
+
+    def reload_sources(self) -> dict[str, Any]:
         try:
             payload = json.loads(self.sources_path.read_text(encoding="utf-8"))
+            sources = self._validate_sources(payload)
         except Exception as exc:
-            logger.warning("tv_sources_config_unavailable path=%s error=%s", self.sources_path, exc)
-            return []
-        return self._validate_sources(payload)
+            logger.warning("tv_sources_reload_failed path=%s error=%s", self.sources_path, exc.__class__.__name__)
+            if not self._sources:
+                self._load_error = exc.__class__.__name__
+            return {"success": False, "sources_loaded": len(self._sources), "enabled_sources": len([s for s in self._sources if s.enabled]), "load_error": exc.__class__.__name__}
+        self._sources = sources
+        self._load_error = None
+        return {"success": True, "sources_loaded": len(sources), "enabled_sources": len([s for s in sources if s.enabled]), "load_error": None}
 
     def list_enabled_sources(self) -> list[TvSource]:
         return [source for source in self.load_sources() if source.enabled]
@@ -106,10 +117,13 @@ class TvSourceManager:
         payload = {
             "sources_path": str(self.sources_path.resolve()),
             "videos_path": str(self.videos_path.resolve()) if self.videos_path else None,
+            "sources_path_configured": bool(self.sources_path),
             "sources_exists": self.sources_path.exists(),
             "videos_exists": self.videos_path.exists() if self.videos_path else False,
             "sources_loaded": len(sources),
             "enabled_sources": len([s for s in sources if s.enabled]),
+            "disabled_sources": len([s for s in sources if not s.enabled]),
+            "load_error": self._load_error,
             "video_catalog_items": len(videos),
         }
         logger.info("tv_source_manager_debug sources_path=%s videos_path=%s sources_loaded=%s video_catalog_items=%s", payload["sources_path"], payload["videos_path"], payload["sources_loaded"], payload["video_catalog_items"])

--- a/tests/test_tv_source_bootstrap.py
+++ b/tests/test_tv_source_bootstrap.py
@@ -1,0 +1,146 @@
+import json
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from app.services.tv_source_bootstrap import ensure_tv_sources_initialized
+from app.services.tv_source_manager import TvSourceManager
+from app.services import storage_paths
+
+
+def _template() -> list[dict]:
+    return json.loads(Path("data/tv_sources.json").read_text(encoding="utf-8"))
+
+
+def test_fresh_persistent_disk_bootstraps_repository_template(tmp_path: Path):
+    target = tmp_path / "tv_sources.json"
+    result = ensure_tv_sources_initialized(target_path=target, template_path=Path("data/tv_sources.json"))
+    assert result["status"] == "bootstrapped"
+    assert result["total"] == 6
+    assert result["enabled"] == 6
+    assert json.loads(target.read_text(encoding="utf-8")) == _template()
+
+
+def test_valid_existing_registry_is_not_overwritten(tmp_path: Path):
+    target = tmp_path / "tv_sources.json"
+    custom = [{"id": "custom", "name": "Custom", "provider": "youtube", "channel_url": "https://youtube.com/@custom", "language": "ru", "categories": ["Forex"], "priority": 1, "enabled": False}]
+    target.write_text(json.dumps(custom), encoding="utf-8")
+    result = ensure_tv_sources_initialized(target_path=target, template_path=Path("data/tv_sources.json"))
+    assert result["status"] == "existing"
+    assert json.loads(target.read_text(encoding="utf-8")) == custom
+
+
+def test_empty_existing_registry_restores_defaults(tmp_path: Path):
+    target = tmp_path / "tv_sources.json"
+    target.write_text("[]", encoding="utf-8")
+    result = ensure_tv_sources_initialized(target_path=target, template_path=Path("data/tv_sources.json"))
+    assert result["status"] == "bootstrapped_from_empty"
+    assert result["total"] == 6
+    assert json.loads(target.read_text(encoding="utf-8")) == _template()
+
+
+def test_malformed_existing_registry_is_preserved(tmp_path: Path):
+    target = tmp_path / "tv_sources.json"
+    target.write_text("{broken", encoding="utf-8")
+    result = ensure_tv_sources_initialized(target_path=target, template_path=Path("data/tv_sources.json"))
+    assert result["status"] == "error"
+    assert result["load_error"] == "persistent_registry_malformed"
+    assert target.read_text(encoding="utf-8") == "{broken"
+
+
+def test_missing_or_malformed_template_does_not_create_empty_registry(tmp_path: Path):
+    target = tmp_path / "tv_sources.json"
+    result = ensure_tv_sources_initialized(target_path=target, template_path=tmp_path / "missing.json")
+    assert result["status"] == "error"
+    assert not target.exists()
+    malformed = tmp_path / "template.json"
+    malformed.write_text("[]", encoding="utf-8")
+    result = ensure_tv_sources_initialized(target_path=target, template_path=malformed)
+    assert result["status"] == "error"
+    assert result["load_error"] == "template_empty"
+    assert not target.exists()
+
+
+def test_migration_whitelist_contains_tv_and_manual_youtube_files(tmp_path: Path, monkeypatch):
+    source_dir = tmp_path / "repo" / "data"
+    data_dir = tmp_path / "persistent"
+    source_dir.mkdir(parents=True)
+    for name in ("tv_sources.json", "manual_youtube_videos.json"):
+        (source_dir / name).write_text('[{"id":"x"}]', encoding="utf-8")
+    monkeypatch.setattr(storage_paths, "PROJECT_ROOT", tmp_path / "repo")
+    monkeypatch.setattr(storage_paths, "DATA_DIR", data_dir)
+    monkeypatch.setattr(storage_paths, "LLM_REVIEWS_DIR", data_dir / "llm_reviews")
+    monkeypatch.setattr(storage_paths, "TRANSCRIPTS_DIR", data_dir / "transcripts")
+    assert "tv_sources.json" in storage_paths.KNOWN_JSON_FILES
+    assert "manual_youtube_videos.json" in storage_paths.KNOWN_JSON_FILES
+    dry = storage_paths.migrate_legacy_data(execute=False)
+    names = {item["name"] for item in dry["files"]}
+    assert {"tv_sources.json", "manual_youtube_videos.json"}.issubset(names)
+    executed = storage_paths.migrate_legacy_data(execute=True)
+    assert executed["copied"] >= 2
+    assert (data_dir / "tv_sources.json").exists()
+    assert (data_dir / "manual_youtube_videos.json").exists()
+    assert (source_dir / "tv_sources.json").exists()
+
+
+def test_manager_starts_after_bootstrap_and_reload_preserves_previous_on_malformed(tmp_path: Path):
+    target = tmp_path / "tv_sources.json"
+    ensure_tv_sources_initialized(target_path=target, template_path=Path("data/tv_sources.json"))
+    manager = TvSourceManager(target, tmp_path / "tv_videos.json")
+    assert len(manager.list_public_sources()) == 6
+    assert len(manager.list_enabled_sources()) == 6
+    target.write_text("[]", encoding="utf-8")
+    assert manager.reload_sources()["sources_loaded"] == 0
+    assert len(manager.list_public_sources()) == 0
+    target.write_text(json.dumps(_template()), encoding="utf-8")
+    assert manager.reload_sources()["enabled_sources"] == 6
+    target.write_text("{broken", encoding="utf-8")
+    result = manager.reload_sources()
+    assert result["success"] is False
+    assert result["enabled_sources"] == 6
+
+
+def test_bootstrap_diagnostics_do_not_call_paid_providers(monkeypatch, tmp_path: Path):
+    import app.services.providers.youtube_api_provider as youtube_api_provider
+    calls = []
+    monkeypatch.setattr(youtube_api_provider.YouTubeApiProvider, "fetch_latest", lambda *a, **k: calls.append("youtube"))
+    ensure_tv_sources_initialized(target_path=tmp_path / "tv_sources.json", template_path=Path("data/tv_sources.json"))
+    assert calls == []
+
+
+def test_ops_media_import_returns_409_when_no_enabled_sources(monkeypatch):
+    import app.main as main
+
+    class Engine:
+        def load_sources(self):
+            return []
+        def import_latest(self):
+            raise AssertionError("must not import")
+
+    monkeypatch.setattr(main, "create_media_import_engine", lambda: Engine())
+    try:
+        main._run_ops_media_import()
+    except HTTPException as exc:
+        assert exc.status_code == 409
+        assert exc.detail["status"] == "no_enabled_sources"
+    else:
+        raise AssertionError("expected HTTPException")
+
+
+def test_configured_sources_with_no_new_videos_stay_success(monkeypatch):
+    import app.main as main
+
+    class Source:
+        enabled = True
+
+    class Engine:
+        def load_sources(self):
+            return [Source()]
+        def import_latest(self):
+            return {"success": True, "sources": 1, "new_items": 0, "new_item_ids": []}
+
+    monkeypatch.setattr(main, "create_media_import_engine", lambda: Engine())
+    monkeypatch.setattr(main, "_generate_reviews_for_imported_items", lambda ids: {"requested": 0})
+    result = main._run_ops_media_import()
+    assert result["success"] is True
+    assert result["sources"] == 1


### PR DESCRIPTION
### Motivation
- На свежем persistent диске отсутствовал runtime-файл `DATA_DIR/tv_sources.json`, поэтому `TvSourceManager` загружал 0 источников и импорт медиа возвращал ложный успех; миграция не учитывала `tv_sources.json` и `manual_youtube_videos.json`.
- Цель — безопасно и атомарно инициализировать и защитить runtime-реестр TV-источников из репозитория при первом запуске, не перезаписывая валидные пользовательские настройки и позволяя перезагружать реестр после миграции без ребута сервиса.

### Description
- Добавлен bootstrap helper `app/services/tv_source_bootstrap.py` с функцией `ensure_tv_sources_initialized()` которая валидирует репозиторный шаблон `PROJECT_ROOT/data/tv_sources.json`, атомарно создаёт `MEDIA_TV_SOURCES_PATH` при отсутствии или при пустом списке и возвращает безопасную диагностику (`existing|bootstrapped|bootstrapped_from_empty|error`).
- Расширен список известных файлов миграции `KNOWN_JSON_FILES` в `app/services/storage_paths.py`, добавлены `tv_sources.json` и `manual_youtube_videos.json` для dry-run и выполнения миграции.
- `TvSourceManager` теперь кэширует список источников и предоставляет `reload_sources()`; при ошибке загрузки предыдущий валидный список сохраняется, а диагностика возвращает подробный статус и ошибку.
- В `app/main.py` изменён порядок инициализации: сначала `ensure_tv_sources_initialized()`, затем создаётся `TvSourceManager` на `MEDIA_TV_SOURCES_PATH`; после успешной реальной миграции (`/api/ops/storage/migrate`) вызывается `tv_source_manager.reload_sources()`.
- `/api/media/debug` расширен безопасной диагностикой реестра источников (bootstrap status, template_exists, sources_loaded, enabled/disabled counts, load_error) под `tv_source_manager` / `source_registry`.
- OPS media import (`/api/ops/media/import`) защищён от ложного `success=true`: если нет загруженных или активных источников возвращается `409 Conflict` с `status=no_enabled_sources`, при наличии источников и нулевых новых видео операция остаётся `200`.
- Добавлены регрессионные тесты `tests/test_tv_source_bootstrap.py` для всех кейсов: fresh persistent disk, existing valid/empty/malformed registry, missing/malformed template, миграция whitelist, manager reload, отсутствие платных вызовов, и поведение OPS import.

### Testing
- Скомпилированы изменённые модули: `python -m py_compile app/services/tv_source_bootstrap.py app/services/tv_source_manager.py app/services/storage_paths.py app/main.py` — успешно.
- Запущены новые регрессионные тесты: `pytest -q tests/test_tv_source_bootstrap.py` — все тесты пройдены.
- Прогон более широкого набора тестов (`tests/test_tv_source_manager.py`, `tests/test_media_import_engine.py`, `tests/test_llm_review.py`) во время разработки выявил один окруженчески-зависимый сетевой тест `tests/test_media_import_engine.py::test_media_review_endpoint_returns_fxpilot_context`, который является флакером/зависит от доступа к внешним провайдерам и не оказался связан с изменениями реестра; ключевые новые тесты и bootstrap-проверки зелёные.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bde0f62c48331b689a4f24bedf862)