### PR TITLE
Stage 21.2: Улучшение извлечения торговых сигналов — BUY/SELL, уровни, confidence и diagnostics

### DIFF
--- a/app/services/llm_review/models.py
+++ b/app/services/llm_review/models.py
@@ -5,7 +5,39 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from app.services.llm_review.entity_extraction import EXPLICIT_ACTION_RE, VALID_DIRECTIONS, normalize_aliases, normalize_confidence, normalize_direction, normalize_timeframe, to_float_or_none, unique_symbols
+from app.services.llm_review.entity_extraction import EXPLICIT_ACTION_RE, VALID_DIRECTIONS, extract_symbols_from_text, normalize_aliases, normalize_confidence, normalize_direction, normalize_timeframe, to_float_or_none, unique_symbols
+import re
+
+_BUY_RE = re.compile(r"\b(buy|long)\b|покуп|лонг", re.I)
+_SELL_RE = re.compile(r"\b(sell|short)\b|прода|шорт", re.I)
+_ENTRY_RE = re.compile(r"(?:entry|enter|buy(?:ing)?\s+(?:at|from)|sell(?:ing)?\s+(?:at|from)|вход|зона входа)[:\s-]*(\d+(?:[\.,]\d+)?)", re.I)
+_SL_RE = re.compile(r"(?:stop loss|stop-loss|stop|sl|стоп)[:\s-]*(\d+(?:[\.,]\d+)?)", re.I)
+_TP_RE = re.compile(r"(?:take profit|take-profit|target|targets?|tp|цель|тейк)[:\s-]*(\d+(?:[\.,]\d+)?)", re.I)
+_ZONE_RE = re.compile(r"(\d+(?:[\.,]\d+)?)\s*(?:-|–|—|to|до)\s*(\d+(?:[\.,]\d+)?)")
+
+
+def _joined_text(*parts: Any) -> str:
+    out: list[str] = []
+    for part in parts:
+        if isinstance(part, list):
+            out.extend(str(x or "") for x in part)
+        else:
+            out.append(str(part or ""))
+    return "\n".join(out)
+
+
+def _label_for_confidence(confidence: int | None) -> str | None:
+    if confidence is None:
+        return None
+    if confidence >= 75:
+        return "HIGH"
+    if confidence >= 45:
+        return "MEDIUM"
+    return "LOW"
+
+
+def _extract_prices(pattern: re.Pattern[str], text: str) -> list[float]:
+    return [num for match in pattern.finditer(text) if (num := to_float_or_none(match.group(1))) is not None]
 
 
 class DetectedLevel(BaseModel):
@@ -37,6 +69,8 @@ class TradingIdea(BaseModel):
     take_profit: float | None = None
     targets: list[float] = Field(default_factory=list)
     confidence: int | None = Field(default=None, ge=0, le=100)
+    confidence_label: str | None = None
+    confidence_score: float | None = Field(default=None, ge=0.0, le=1.0)
     reasoning: str = ""
     reason: str = ""
     source_evidence: list[str] = Field(default_factory=list)
@@ -71,9 +105,20 @@ class TradingIdea(BaseModel):
 
     @field_validator("confidence", mode="before")
     @classmethod
-    def conf_norm(cls, value: Any) -> int:
+    def conf_norm(cls, value: Any) -> int | None:
+        return normalize_confidence(value)
+
+    @field_validator("confidence_label", mode="before")
+    @classmethod
+    def confidence_label_norm(cls, value: Any) -> str | None:
+        raw = str(value or "").strip().upper()
+        return raw if raw in {"LOW", "MEDIUM", "HIGH"} else None
+
+    @field_validator("confidence_score", mode="before")
+    @classmethod
+    def confidence_score_norm(cls, value: Any) -> float | None:
         conf = normalize_confidence(value)
-        return conf
+        return round(conf / 100, 4) if conf is not None else None
 
 
 class LLMReview(BaseModel):
@@ -87,6 +132,8 @@ class LLMReview(BaseModel):
     timeframe: str | None = None
     direction: str = "NEUTRAL"
     confidence: int | None = Field(default=None, ge=0, le=100)
+    confidence_label: str | None = None
+    confidence_score: float | None = Field(default=None, ge=0.0, le=1.0)
     agreement_score: int | None = Field(default=None, ge=0, le=100)
     entry: float | None = None
     entry_zone: list[float] = Field(default_factory=list)
@@ -101,6 +148,7 @@ class LLMReview(BaseModel):
     contradictions: list[str] = Field(default_factory=list)
     institutional_view: str = ""
     news_impact: str = ""
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
     non_actionable_reason: str = ""
     structured_parse_status: str = "success"
     entity_extraction_source: str = "llm_json"
@@ -165,6 +213,18 @@ class LLMReview(BaseModel):
             return []
         return [num for item in value if (num := to_float_or_none(item)) is not None]
 
+    @field_validator("confidence_label", mode="before")
+    @classmethod
+    def top_confidence_label_norm(cls, value: Any) -> str | None:
+        raw = str(value or "").strip().upper()
+        return raw if raw in {"LOW", "MEDIUM", "HIGH"} else None
+
+    @field_validator("confidence_score", mode="before")
+    @classmethod
+    def top_confidence_score_norm(cls, value: Any) -> float | None:
+        conf = normalize_confidence(value)
+        return round(conf / 100, 4) if conf is not None else None
+
     @model_validator(mode="before")
     @classmethod
     def aliases(cls, data: Any) -> Any:
@@ -173,6 +233,35 @@ class LLMReview(BaseModel):
     @model_validator(mode="after")
     def reconcile(self) -> "LLMReview":
         warnings = list(self.structured_warnings or [])
+        source_text = _joined_text(self.summary, self.market_overview, self.reasoning, self.risks, self.opportunities)
+        if not self.symbols:
+            self.symbols = extract_symbols_from_text(source_text)
+        if not self.primary_symbol and self.symbols:
+            self.primary_symbol = self.symbols[0]
+        if self.direction not in {"BUY", "SELL"}:
+            if _BUY_RE.search(source_text):
+                self.direction = "BUY"
+            elif _SELL_RE.search(source_text):
+                self.direction = "SELL"
+        if self.entry is None:
+            entries = _extract_prices(_ENTRY_RE, source_text)
+            if entries:
+                self.entry = entries[0]
+        if not self.entry_zone:
+            zones = [(to_float_or_none(a), to_float_or_none(b)) for a, b in _ZONE_RE.findall(source_text)]
+            usable_zones = [[a, b] for a, b in zones if a is not None and b is not None]
+            if usable_zones and re.search(r"entry|zone|зона|вход", source_text, re.I):
+                self.entry_zone = usable_zones[0]
+        if self.stop_loss is None:
+            stops = _extract_prices(_SL_RE, source_text)
+            if stops:
+                self.stop_loss = stops[0]
+        if self.take_profit is None:
+            tps = _extract_prices(_TP_RE, source_text)
+            if tps:
+                self.take_profit = tps[0]
+        if not self.targets:
+            self.targets = _extract_prices(_TP_RE, source_text)
         # Validate levels/prices without fabricating values.
         self.entry_zone = sorted(list(dict.fromkeys([x for x in self.entry_zone if x and x > 0]))) if len(self.entry_zone) == 2 else []
         self.targets = list(dict.fromkeys([x for x in self.targets if x and x > 0]))
@@ -186,9 +275,10 @@ class LLMReview(BaseModel):
         if self.primary_symbol not in self.symbols:
             self.primary_symbol = self.symbols[0] if self.symbols else None
         # Build one idea from top-level actionable fields when LLM omitted trade_ideas.
-        actionable_top = self.primary_symbol and self.direction in {"BUY", "SELL", "WAIT"} and (self.direction == "WAIT" or self.direction in {"BUY", "SELL"} or self.entry or self.entry_zone or self.stop_loss or self.take_profit or self.targets or EXPLICIT_ACTION_RE.search(" ".join([self.summary, self.market_overview, " ".join(self.reasoning)])))
+        actionable_top = self.primary_symbol and self.direction in {"BUY", "SELL", "WAIT"} and (self.direction == "WAIT" or self.direction in {"BUY", "SELL"} or self.entry or self.entry_zone or self.stop_loss or self.take_profit or self.targets or EXPLICIT_ACTION_RE.search(source_text))
         if not self.trade_ideas and actionable_top:
-            self.trade_ideas = [TradingIdea(symbol=self.primary_symbol, timeframe=self.timeframe, direction=self.direction, entry=self.entry, entry_zone=self.entry_zone, stop_loss=self.stop_loss, take_profit=self.take_profit, targets=self.targets, confidence=self.confidence, reasoning="; ".join(self.reasoning[:2]))]
+            idea_symbols = self.symbols or [self.primary_symbol]
+            self.trade_ideas = [TradingIdea(symbol=symbol, timeframe=self.timeframe, direction=self.direction, entry=self.entry, entry_zone=self.entry_zone, stop_loss=self.stop_loss, take_profit=self.take_profit, targets=self.targets, confidence=self.confidence, confidence_label=self.confidence_label, confidence_score=self.confidence_score, reasoning="; ".join(self.reasoning[:2])) for symbol in idea_symbols if symbol]
             self.entity_extraction_source = "hybrid" if self.entity_extraction_source == "llm_json" else self.entity_extraction_source
         # Drop invalid-symbol ideas and deduplicate.
         dedup=[]; seen=set()
@@ -209,8 +299,17 @@ class LLMReview(BaseModel):
             if self.direction == "NEUTRAL": self.direction = actionable[0].direction
             self.timeframe = self.timeframe or actionable[0].timeframe
             self.confidence = self.confidence if self.confidence is not None else actionable[0].confidence
+            self.confidence_label = self.confidence_label or actionable[0].confidence_label
+            self.confidence_score = self.confidence_score if self.confidence_score is not None else actionable[0].confidence_score
         elif self.primary_symbol not in self.symbols:
             self.primary_symbol = self.symbols[0] if self.symbols else None
+        if self.confidence_score is None and self.confidence is not None:
+            self.confidence_score = round(self.confidence / 100, 4)
+        self.confidence_label = self.confidence_label or _label_for_confidence(self.confidence)
+        for idea in self.trade_ideas:
+            if idea.confidence_score is None and idea.confidence is not None:
+                idea.confidence_score = round(idea.confidence / 100, 4)
+            idea.confidence_label = idea.confidence_label or _label_for_confidence(idea.confidence)
         if not self.trade_ideas and self.direction == "NEUTRAL" and not self.non_actionable_reason:
             self.non_actionable_reason = "Нет явной торговой рекомендации или плана сделки в источнике."
         self.symbol = self.primary_symbol
@@ -218,6 +317,16 @@ class LLMReview(BaseModel):
         weights={"primary_symbol":15,"direction":15,"timeframe":10,"confidence":10,"trade_idea":15,"entry_or_zone":10,"stop_loss":10,"target":10,"evidence_reason":5}
         self.structured_completeness_score = sum(w for k,w in weights.items() if fields[k])
         self.missing_structured_fields = [k for k,v in fields.items() if not v]
+        levels_detected = bool(self.entry or self.entry_zone or self.stop_loss or self.take_profit or self.targets or self.detected_levels or any(i.entry or i.entry_zone or i.stop_loss or i.take_profit or i.targets for i in self.trade_ideas))
+        targets_detected = bool(self.take_profit or self.targets or any(i.take_profit or i.targets for i in self.trade_ideas))
+        self.diagnostics.update({
+            "trade_signal_detected": bool(self.trade_ideas),
+            "structured_completeness": self.structured_completeness_score,
+            "levels_detected": levels_detected,
+            "reason_missing_direction": None if self.direction in {"BUY", "SELL", "WAIT"} else "no_explicit_buy_sell_or_wait_bias",
+            "reason_missing_levels": None if levels_detected else "no_explicit_entry_stop_or_target_levels",
+            "reason_missing_targets": None if targets_detected else "no_explicit_take_profit_or_target_levels",
+        })
         self.structured_warnings = list(dict.fromkeys(warnings))
         return self
 

--- a/app/services/llm_review/openai_provider.py
+++ b/app/services/llm_review/openai_provider.py
@@ -60,5 +60,8 @@ class OpenAIReviewProvider:
         else:
             payload["structured_parse_status"] = status
             payload.setdefault("entity_extraction_source", "llm_json")
+        diagnostics = payload.get("diagnostics") if isinstance(payload.get("diagnostics"), dict) else {}
+        diagnostics["raw_llm_structured_output"] = content
+        payload["diagnostics"] = diagnostics
         tokens = getattr(getattr(response, "usage", None), "total_tokens", 0) or 0
         return LLMReview.from_payload(payload, provider=f"{self.provider_name}:{self.model}", tokens_used=int(tokens), latency_ms=latency_ms)

--- a/app/services/llm_review/prompt_builder.py
+++ b/app/services/llm_review/prompt_builder.py
@@ -5,10 +5,12 @@ from typing import Any
 
 SCHEMA = {
   "summary":"string", "market_overview":"string", "primary_symbol":"EURUSD|null", "symbols":["EURUSD"],
-  "timeframe":"M15|M30|H1|H4|D1|W1|null", "direction":"BUY|SELL|WAIT|NEUTRAL", "confidence":"0-100|null",
+  "timeframe":"M15|M30|H1|H4|D1|W1|null", "direction":"BUY|SELL|WAIT|NEUTRAL",
+  "confidence":"0-100|null", "confidence_label":"LOW|MEDIUM|HIGH|null", "confidence_score":"0.0-1.0|null",
   "entry":"number|null", "entry_zone":["number","number"], "stop_loss":"number|null", "take_profit":"number|null", "targets":["number"],
   "detected_levels":[{"type":"support|resistance|entry|stop_loss|take_profit|target", "price":"number", "symbol":"EURUSD"}],
-  "trade_ideas":[{"symbol":"EURUSD", "timeframe":"H4|null", "direction":"BUY|SELL|WAIT", "confidence":"0-100|null", "entry":"number|null", "entry_zone":["number","number"], "stop_loss":"number|null", "take_profit":"number|null", "targets":["number"], "reason":"string", "source_evidence":["short quote"]}],
+  "trade_ideas":[{"symbol":"EURUSD", "timeframe":"H4|null", "direction":"BUY|SELL|WAIT", "confidence":"0-100|null", "confidence_label":"LOW|MEDIUM|HIGH|null", "confidence_score":"0.0-1.0|null", "entry":"number|null", "entry_zone":["number","number"], "stop_loss":"number|null", "take_profit":"number|null", "targets":["number"], "reason":"string", "source_evidence":["short quote"]}],
+  "diagnostics":{"trade_signal_detected":"boolean", "structured_completeness":"0-100", "levels_detected":"boolean", "reason_missing_direction":"string|null", "reason_missing_levels":"string|null", "reason_missing_targets":"string|null"},
   "non_actionable_reason":"string", "reasoning":["string"], "risks":["string"], "opportunities":["string"], "contradictions":["string"], "institutional_view":"string", "news_impact":"string", "recommended_action":"BUY|SELL|WAIT|IGNORE"
 }
 
@@ -16,25 +18,25 @@ class PromptBuilder:
     def build(self, context: dict[str, Any]) -> str:
         safe_context = json.dumps(context, ensure_ascii=False, default=str, indent=2)
         schema = json.dumps(SCHEMA, ensure_ascii=False, indent=2)
-        return f"""You are a Senior Institutional FX Analyst extracting structured trading entities for FXPilot. Answer ONLY valid JSON. Return ONLY one valid JSON object. No Markdown, no prose outside JSON.
+        return f"""You are a Senior Institutional FX Analyst and high-precision Trade Intelligence extractor for FXPilot. Your job is NOT to write a generic summary. Your priority is to extract every actionable trading setup stated in the source. Answer ONLY valid JSON. Return ONLY one valid JSON object. No Markdown.
 
-Contract and anti-fabrication rules:
-- Match this exact JSON schema; use null for absent scalar values and [] for absent arrays: {schema}
-- Extract only instruments explicitly discussed. Never output MARKET/UNKNOWN/N/A as a symbol.
-- Normalize aliases: gold/xau usd→XAUUSD; euro dollar/eur usd→EURUSD; bitcoin/btc usd→BTCUSD; brent→UKOIL; sp500/S&P 500→SPX; nasdaq→NAS100.
-- Timeframes only M15,M30,H1,H4,D1,W1; normalize 15m/m15, 30m/m30, 1h/h1/hourly, 4h/h4, daily/day/d1, weekly/w1. Do not infer timeframe from video duration.
-- Direction: WAIT means the author explicitly recommends waiting; NEUTRAL means no reliable directional position. Do not convert general bullish/bearish commentary into BUY/SELL unless there is an explicit recommendation, setup/plan, trade level, stop/target, or clearly stated directional position.
-- An actionable trade idea is a concrete BUY/SELL/WAIT plan or recommendation. Broad market commentary is non-actionable.
-- Never invent prices. Do not invent entry, entry_zone, stop_loss, take_profit, targets, detected_levels, prices, symbols, timeframe, or confidence. Preserve decimal prices as numbers. Never use 0 as a placeholder.
-- Confidence is confidence in the extracted idea, not the author. Use null if not stated.
-- One video may contain multiple trade_ideas. Directional SELL/BUY can be valid without prices if explicitly recommended.
-- detected_levels are evidence only; do not turn them into stops/targets automatically.
+Required JSON contract:
+{schema}
+
+Extraction priorities:
+1. Detect explicit trading bias before summarizing. If the author explicitly says BUY, buy, long, покупка, лонг, direction MUST be BUY. If the author explicitly says SELL, sell, short, продажа, шорт, direction MUST be SELL. Use NEUTRAL only when no trading bias exists. Use WAIT only when the explicit recommendation is to wait/stand aside and there is no explicit BUY/SELL setup.
+2. Create one trade_ideas item for EACH detected setup. If one review discusses EURUSD BUY and XAUUSD SELL, return two TradeIdea objects with their own symbol, direction, timeframe, confidence and levels.
+3. Extract prices exactly as mentioned. Populate entry, entry_zone, stop_loss, take_profit and targets whenever explicitly stated. Never invent prices. Never invent levels, never use 0 as a placeholder, and never convert support/resistance into SL/TP unless the author names it as SL/TP/target.
+4. Support entry zones such as "1.0850-1.0870", "buy zone", "entry area", "зона входа" as two numeric values in ascending order. Put single entry prices in entry.
+5. Confidence must describe extraction/setup confidence. Return both confidence_label (LOW/MEDIUM/HIGH) and confidence_score (0.0-1.0). If the author gives a percent, map it directly; otherwise estimate from evidence completeness: HIGH for explicit direction+symbol+entry+SL+TP, MEDIUM for explicit direction+symbol with partial levels, LOW for directional call without levels.
+6. Diagnostics are mandatory: trade_signal_detected, structured_completeness, levels_detected, reason_missing_direction, reason_missing_levels, reason_missing_targets. Put null reasons when not missing.
+7. Keep backward-compatible top-level fields. Top-level direction should represent the primary/highest-confidence setup; trade_ideas is the complete list.
+8. Summaries must be brief and secondary to structured extraction. Do not hide a BUY/SELL signal in summary while returning NEUTRAL.
 
 Compact examples:
-A BUY: {{"primary_symbol":"EURUSD","symbols":["EURUSD"],"timeframe":"H4","direction":"BUY","confidence":75,"entry":null,"entry_zone":[1.0850,1.0870],"stop_loss":1.0810,"take_profit":null,"targets":[1.0920,1.0980],"trade_ideas":[{{"symbol":"EURUSD","timeframe":"H4","direction":"BUY","confidence":75,"entry":null,"entry_zone":[1.0850,1.0870],"stop_loss":1.0810,"take_profit":null,"targets":[1.0920,1.0980],"reason":"buy zone stated","source_evidence":["buy zone 1.0850-1.0870"]}}]}}
-B SELL no exact entry: {{"primary_symbol":"XAUUSD","symbols":["XAUUSD"],"timeframe":null,"direction":"SELL","confidence":null,"entry":null,"entry_zone":[],"stop_loss":null,"take_profit":null,"targets":[],"trade_ideas":[{{"symbol":"XAUUSD","timeframe":null,"direction":"SELL","confidence":null,"entry":null,"entry_zone":[],"stop_loss":null,"take_profit":null,"targets":[],"reason":"explicit sell recommendation","source_evidence":["recommend selling gold"]}}]}}
-C Commentary: {{"primary_symbol":null,"symbols":[],"timeframe":null,"direction":"NEUTRAL","confidence":null,"entry":null,"entry_zone":[],"stop_loss":null,"take_profit":null,"targets":[],"trade_ideas":[],"non_actionable_reason":"Only broad market discussion; no trade plan."}}
-D Multiple: {{"primary_symbol":"BTCUSD","symbols":["EURUSD","BTCUSD"],"direction":"BUY","trade_ideas":[{{"symbol":"EURUSD","timeframe":"H1","direction":"SELL","confidence":60,"entry":null,"entry_zone":[],"stop_loss":null,"take_profit":null,"targets":[],"reason":"separate EURUSD idea","source_evidence":[]}},{{"symbol":"BTCUSD","timeframe":"D1","direction":"BUY","confidence":80,"entry":null,"entry_zone":[],"stop_loss":null,"take_profit":null,"targets":[],"reason":"higher confidence BTC idea","source_evidence":[]}}]}}
+BUY with levels: {{"primary_symbol":"EURUSD","symbols":["EURUSD"],"timeframe":"H4","direction":"BUY","confidence":85,"confidence_label":"HIGH","confidence_score":0.85,"entry":null,"entry_zone":[1.085,1.087],"stop_loss":1.081,"take_profit":null,"targets":[1.092,1.098],"trade_ideas":[{{"symbol":"EURUSD","timeframe":"H4","direction":"BUY","confidence":85,"confidence_label":"HIGH","confidence_score":0.85,"entry":null,"entry_zone":[1.085,1.087],"stop_loss":1.081,"take_profit":null,"targets":[1.092,1.098],"reason":"explicit buy zone, stop and targets stated","source_evidence":["buy zone 1.0850-1.0870"]}}],"diagnostics":{{"trade_signal_detected":true,"structured_completeness":95,"levels_detected":true,"reason_missing_direction":null,"reason_missing_levels":null,"reason_missing_targets":null}}}}
+SELL without levels: {{"primary_symbol":"XAUUSD","symbols":["XAUUSD"],"direction":"SELL","confidence_label":"LOW","confidence_score":0.35,"trade_ideas":[{{"symbol":"XAUUSD","direction":"SELL","confidence_label":"LOW","confidence_score":0.35,"entry":null,"entry_zone":[],"stop_loss":null,"take_profit":null,"targets":[],"reason":"explicit sell recommendation","source_evidence":["sell gold"]}}],"diagnostics":{{"trade_signal_detected":true,"structured_completeness":45,"levels_detected":false,"reason_missing_direction":null,"reason_missing_levels":"no explicit entry/SL/TP levels","reason_missing_targets":"no explicit targets"}}}}
+No signal: {{"primary_symbol":null,"symbols":[],"direction":"NEUTRAL","confidence":null,"confidence_label":null,"confidence_score":null,"entry":null,"entry_zone":[],"stop_loss":null,"take_profit":null,"targets":[],"trade_ideas":[],"non_actionable_reason":"Only broad market commentary; no trading bias or setup.","diagnostics":{{"trade_signal_detected":false,"structured_completeness":20,"levels_detected":false,"reason_missing_direction":"no explicit trading bias","reason_missing_levels":"no explicit entry/SL/TP levels","reason_missing_targets":"no explicit targets"}}}}
 
 Supplied context:
 {safe_context}

--- a/tests/test_stage21_structured_reviews.py
+++ b/tests/test_stage21_structured_reviews.py
@@ -105,3 +105,57 @@ def test_knowledge_graph_reads_normalized_fields(tmp_path):
 def test_no_secret_leakage_in_review_dump():
     dump=json.dumps(LLMReview.model_validate({"summary":"ok"}).model_dump())
     assert "OPENROUTER_API_KEY" not in dump and "sk-" not in dump
+
+
+def test_stage21_2_explicit_buy_text_recovers_direction_levels_and_diagnostics():
+    r = LLMReview.model_validate({
+        "summary": "EURUSD H1: we are looking to BUY from entry zone 1.0850-1.0870, stop loss 1.0810, targets 1.0920 and TP 1.0980.",
+        "direction": "neutral",
+    })
+    assert r.direction == "BUY"
+    assert len(r.trade_ideas) == 1
+    assert r.trade_ideas[0].direction == "BUY"
+    assert r.entry_zone == [1.085, 1.087]
+    assert r.stop_loss == 1.081
+    assert 1.098 in r.targets
+    assert r.diagnostics["trade_signal_detected"] is True
+    assert r.diagnostics["levels_detected"] is True
+    assert r.diagnostics["reason_missing_direction"] is None
+
+
+def test_stage21_2_explicit_sell_text_overrides_neutral():
+    r = LLMReview.model_validate({
+        "summary": "Gold update: explicit short XAUUSD if price rejects resistance; sell the rally. SL 2365, target 2320.",
+        "direction": "neutral",
+    })
+    assert r.primary_symbol == "XAUUSD"
+    assert r.direction == "SELL"
+    assert r.stop_loss == 2365
+    assert r.take_profit == 2320
+    assert r.trade_ideas[0].direction == "SELL"
+
+
+def test_stage21_2_multiple_top_level_symbols_create_one_idea_each():
+    r = LLMReview.model_validate({
+        "symbols": ["EURUSD", "BTCUSD"],
+        "direction": "long",
+        "confidence": 0.8,
+        "entry": 1.1,
+        "stop_loss": 1.09,
+        "targets": [1.12],
+    })
+    assert [idea.symbol for idea in r.trade_ideas] == ["EURUSD", "BTCUSD"]
+    assert all(idea.direction == "BUY" for idea in r.trade_ideas)
+    assert r.confidence_label == "HIGH"
+    assert r.confidence_score == 0.8
+    assert all(idea.confidence_score == 0.8 for idea in r.trade_ideas)
+
+
+def test_stage21_2_no_signal_diagnostics_are_explicit():
+    r = LLMReview.model_validate({"summary": "Macro discussion about central banks and liquidity, no trade plan."})
+    assert r.direction == "NEUTRAL"
+    assert r.trade_ideas == []
+    assert r.diagnostics["trade_signal_detected"] is False
+    assert r.diagnostics["levels_detected"] is False
+    assert r.diagnostics["reason_missing_levels"]
+    assert r.diagnostics["reason_missing_targets"]


### PR DESCRIPTION
### Motivation
- Повысить точность и полезность структуры, извлекаемой LLM, смещая приоритет с общего резюме на явные торговые сигналы и рабочие планы (Entry/Entry Zone/SL/TP/Targets) без изменений в хранилище, графе знаний или аутентификации. 
- Обеспечить корректную обработку явных указаний BUY/LONG → BUY и SELL/SHORT → SELL и поддержать множественные символы и отдельную идею на каждую найденную установку. 
- Добавить интерпретируемые показатели уверенности (label и numeric) и диагностические поля для прозрачности качества извлечения. 
- Сохранить обратную совместимость с текущими API и pipeline, а также упростить отладку через сохранение исходного LLM-вывода.

### Description
- Переписан промпт `PromptBuilder` для фокусировки на извлечении actionable trade setups, добавления полей `confidence_label`/`confidence_score` и обязательного блока `diagnostics` (файл: `app/services/llm_review/prompt_builder.py`).
- Расширены модели `LLMReview` и `TradingIdea`: добавлены `confidence_label`, `confidence_score` и `diagnostics`, при этом существующие поля сохранены (файл: `app/services/llm_review/models.py`).
- Добавлен post-processing: восстановление символов из текста, детектирование явных BUY/SELL выражений, извлечение entry, entry_zone, stop_loss, take_profit и targets из текста, а также создание отдельной `TradeIdea` для каждого топ-уровневого символа (файл: `app/services/llm_review/models.py`).
- Добавлено сохранение сырого LLM-структурированного вывода в `diagnostics.raw_llm_structured_output` для упрощённой отладки (файл: `app/services/llm_review/openai_provider.py`).
- Добавлены тесты Stage 21.2, покрывающие явный BUY, явный SELL, мульти-символьные сценарии и отсутствие сигнала (файл: `tests/test_stage21_structured_reviews.py`).

### Testing
- Запущена компиляция `python -m py_compile` для модулей LLM-review и проверка `git diff --check` — без ошибок. 
- Полный набор релевантных тестов выполнен: `pytest -q tests/test_llm_review.py tests/test_stage21_structured_reviews.py tests/test_knowledge_graph_stage20.py` и дополнительная проверка новых тестов, итог — все тесты в этих наборах прошли успешно (`52 passed`).
- Убедились в корректной сериализации/нормализации полей через существующие storage/knowledge-graph нагрузки в тестах интеграции. 
- Промпт и модели изменялись аккуратно, сохраняя совместимость top-level полей и существующей логики потребления `LLMReview` в pipeline и Knowledge Graph.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d00fbaf3c83318f8c03ed783abda9)