### PR TITLE
Добавить Source Manager (UI + API) — управление медиа‑источниками

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,3 +775,19 @@ Knowledge Graph keeps the normal healthy TTL, but empty graphs with zero catalog
 - Media Import now records canonical catalog path, storage root, catalog existence, before/after item counts, loaded source items, written items, write success/error state and per-filter removal counters in `/api/media/debug`.
 - The import pipeline refuses a successful zero-item catalog write when providers returned importable videos, so fetched YouTube media is persisted to the canonical `media_catalog.json` or the write error is surfaced in diagnostics.
 - Added a regression test that imports one mock YouTube video, verifies catalog file persistence and subsequent catalog loading, then confirms the Knowledge Graph indexes the imported item with a stored review.
+
+## Stage 22 — FXPilot Source Manager
+
+Production users can manage runtime media sources from `/ops/sources` without editing JSON files, redeploying, or restarting Render. The Source Manager reads and writes only the canonical `DATA_DIR/media_sources.json` registry, so scheduler and media import jobs pick up added, edited, deleted, enabled, and disabled sources on the next run.
+
+API contract:
+
+- `GET /api/sources` and `GET /api/sources/{id}` list source configuration and runtime import metadata.
+- `POST /api/sources`, `PUT /api/sources/{id}`, and `DELETE /api/sources/{id}` create, edit, toggle, or remove runtime sources with URL validation.
+- `POST /api/sources/{id}/test` resolves provider metadata and reports reachability, titles, IDs, and error reasons.
+- `POST /api/sources/{id}/import` imports only one selected source and returns imported, updated, skipped, and error counts.
+- `POST /api/sources/import` supports JSON/OPML migration plus bulk actions (`enable`, `disable`, `delete`, `import_selected`, `test`).
+- `GET /api/sources/export?format=json|opml` exports sources for migration between development, Render, and new servers.
+- `GET /api/sources/debug` returns source counts, provider statistics, recent imports, recent errors, and validation errors.
+
+Supported providers are modular and include YouTube channel/playlist URLs, Telegram public channel URLs, Telegram RSS bridges, and generic RSS feeds. All source mutations are appended to the OPS audit log with actor, operation, timestamp, and before/after payloads.

--- a/app/main.py
+++ b/app/main.py
@@ -551,6 +551,11 @@ def media_admin_page():
     return FileResponse(STATIC_DIR / "media-admin.html")
 
 
+@app.get("/ops/sources", include_in_schema=False)
+def ops_sources_page():
+    return FileResponse(STATIC_DIR / "media-admin.html")
+
+
 @app.get("/ops", include_in_schema=False)
 def ops_page():
     return FileResponse(STATIC_DIR / "ops.html")
@@ -942,6 +947,123 @@ def _media_catalog_item(video: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+
+@app.get("/api/sources")
+def api_sources() -> list[dict[str, Any]]:
+    return api_media_sources()
+
+@app.get("/api/sources/debug")
+def api_sources_debug() -> dict[str, Any]:
+    engine = create_media_import_engine()
+    sources = engine.list_sources()
+    debug = engine.debug_sources()
+    stats: dict[str, dict[str, int]] = {}
+    for source in sources:
+        provider = str(source.get("provider") or "unknown")
+        row = stats.setdefault(provider, {"total": 0, "enabled": 0, "disabled": 0})
+        row["total"] += 1
+        row["enabled" if source.get("enabled") else "disabled"] += 1
+    return {
+        "total_sources": len(sources),
+        "enabled_sources": len([s for s in sources if s.get("enabled")]),
+        "disabled_sources": len([s for s in sources if not s.get("enabled")]),
+        "provider_statistics": stats,
+        "last_imports": [{"source_id": s.get("id"), "last_successful_import": s.get("last_successful_import") or s.get("last_success"), "last_import": s.get("last_import")} for s in sources],
+        "last_errors": [{"source_id": s.get("id"), "name": s.get("name"), "error": s.get("last_error")} for s in sources if s.get("last_error")],
+        "validation_errors": [{"source_id": s.get("id"), "name": s.get("name"), "error": s.get("last_resolve_error")} for s in sources if s.get("last_resolve_error")],
+        "media_debug": debug,
+    }
+
+@app.get("/api/sources/export")
+def api_sources_export(format: str = "json"):
+    sources = create_media_import_engine().list_sources()
+    if format.lower() == "opml":
+        return Response(content=MediaImportEngine.sources_to_opml(sources), media_type="text/x-opml")
+    return {"format": "json", "sources": sources, "exported_at": datetime.now(timezone.utc).isoformat()}
+
+
+@app.post("/api/sources/import")
+async def api_sources_import(request: Request) -> dict[str, Any]:
+    content_type = request.headers.get("content-type", "")
+    engine = create_media_import_engine()
+    payload: Any
+    if "xml" in content_type or "opml" in content_type:
+        payload = {"sources": MediaImportEngine.opml_to_sources((await request.body()).decode("utf-8"))}
+    else:
+        payload = await request.json()
+    action = str(payload.get("action") or "import").lower() if isinstance(payload, dict) else "import"
+    ids = [str(v) for v in (payload.get("ids") or [])] if isinstance(payload, dict) else []
+    if action in {"enable", "disable", "delete", "import_selected", "test"}:
+        results = []
+        for sid in ids:
+            if action == "enable": results.append(engine.update_source(sid, {"enabled": True}))
+            elif action == "disable": results.append(engine.update_source(sid, {"enabled": False}))
+            elif action == "delete": results.append(engine.delete_source(sid))
+            elif action == "import_selected": results.append(engine.import_source(sid))
+            elif action == "test": results.append(engine.test_source(sid))
+        _audit_source_change(request, f"bulk_{action}", None, ids, results)
+        return {"success": True, "action": action, "results": results}
+    rows = payload.get("sources") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise HTTPException(status_code=400, detail="sources list is required")
+    results=[]
+    for row in rows:
+        results.append(engine.add_source(row))
+    _audit_source_change(request, "import_sources", None, None, {"count": len(results)})
+    return {"success": True, "imported_sources": len(results), "sources": results}
+
+
+@app.get("/api/sources/{source_id}")
+def api_source_get(source_id: str) -> dict[str, Any]:
+    return _source_by_id_payload(source_id)
+
+@app.post("/api/sources")
+async def api_source_add(request: Request) -> dict[str, Any]:
+    payload = await request.json()
+    try:
+        result = create_media_import_engine().add_source(payload)
+        _audit_source_change(request, "create", result.get("id"), None, result)
+        return result
+    except MediaConfigError as exc:
+        _audit_source_change(request, "create", None, payload, None, False, str(exc))
+        raise HTTPException(status_code=409 if "duplicate" in str(exc).lower() else 400, detail=str(exc)) from exc
+
+@app.put("/api/sources/{source_id}")
+async def api_source_update(source_id: str, request: Request) -> dict[str, Any]:
+    payload = await request.json()
+    before = None
+    try:
+        before = _source_by_id_payload(source_id)
+        result = create_media_import_engine().update_source(source_id, payload)
+        _audit_source_change(request, "update", source_id, before, result)
+        return result
+    except MediaConfigError as exc:
+        _audit_source_change(request, "update", source_id, before, payload, False, str(exc))
+        raise HTTPException(status_code=404 if "unknown" in str(exc).lower() else 400, detail=str(exc)) from exc
+
+@app.delete("/api/sources/{source_id}")
+def api_source_delete(source_id: str, request: Request) -> dict[str, Any]:
+    before = _source_by_id_payload(source_id)
+    try:
+        result = create_media_import_engine().delete_source(source_id)
+        _audit_source_change(request, "delete", source_id, before, result)
+        return result
+    except MediaConfigError as exc:
+        _audit_source_change(request, "delete", source_id, before, None, False, str(exc))
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+@app.post("/api/sources/{source_id}/test")
+def api_source_test(source_id: str) -> dict[str, Any]:
+    result = api_media_test_source(source_id)
+    return {"reachable": bool(result.get("ok") or result.get("items_found") or result.get("feed_title") or result.get("channel_title")), "channel_title": result.get("channel_title"), "channel_id": result.get("channel_id") or result.get("resolved_channel_id"), "feed_title": result.get("feed_title"), "error_reason": result.get("error"), **result}
+
+@app.post("/api/sources/{source_id}/import")
+def api_source_import(source_id: str, request: Request) -> dict[str, Any]:
+    result = api_media_import_source(source_id)
+    _audit_source_change(request, "import", source_id, None, {k: result.get(k) for k in ("imported", "updated", "skipped_invalid", "errors", "success")})
+    result.setdefault("skipped", result.get("skipped_invalid", 0))
+    return result
+
 @app.get("/api/media/catalog")
 def api_media_catalog() -> dict[str, Any]:
     items = [_media_catalog_item(video) for video in _load_tv_video_catalog() if video and (video.get("status") in {None, "", "imported"})]
@@ -951,6 +1073,19 @@ def api_media_catalog() -> dict[str, Any]:
         "review_ready": sum(1 for item in items if item.get("review_status") == "ready"),
         "structured": sum(1 for item in items if item.get("primary_symbol") or item.get("direction") or item.get("confidence")),
     }
+
+
+def _audit_source_change(request: Request | None, operation: str, source_id: str | None, before: Any, after: Any, success: bool = True, error: str = "") -> None:
+    actor = "browser"
+    if request is not None:
+        actor = request.headers.get("X-FXPILOT-OPS-USER") or request.headers.get("X-Forwarded-User") or (request.client.host if request.client else "browser")
+    _append_ops_audit(f"sources.{operation}", {"who": actor, "source_id": source_id, "what_changed": {"before": before, "after": after}}, success, 0, summary=operation, error={"type": "SourceManager", "message": error} if error else None)
+
+def _source_by_id_payload(source_id: str) -> dict[str, Any]:
+    source = next((s for s in create_media_import_engine().list_sources() if str(s.get("id")) == source_id), None)
+    if not source:
+        raise HTTPException(status_code=404, detail=f"unknown media source id: {source_id}")
+    return source
 
 @app.get("/api/media/sources")
 def api_media_sources() -> list[dict[str, Any]]:

--- a/app/services/media_import_engine.py
+++ b/app/services/media_import_engine.py
@@ -21,7 +21,7 @@ from app.services.youtube_source_resolver import YouTubeSourceResolver
 logger = logging.getLogger(__name__)
 
 SUPPORTED_SOURCE_TYPES = {"youtube", "telegram", "rss", "website", "podcast", "manual"}
-SUPPORTED_MEDIA_PROVIDERS = {"youtube_api", "youtube_ytdlp", "auto", "telegram_public", "telegram_bot", "rss_feed", "manual", "youtube", "youtube_manual", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
+SUPPORTED_MEDIA_PROVIDERS = {"youtube_api", "youtube_ytdlp", "auto", "telegram_public", "telegram_bot", "telegram_rss", "rss_feed", "manual", "youtube", "youtube_manual", "youtube_playlist", "telegram", "rss", "podcast", "vimeo", "fxpilot", "news", "articles"}
 SYMBOLS = ("EURUSD", "GBPUSD", "USDJPY", "USDCHF", "USDCAD", "AUDUSD", "NZDUSD", "XAUUSD", "XAGUSD", "BTCUSD", "ETHUSD", "DXY", "US500", "NASDAQ", "GER40", "UK100")
 YOUTUBE_RSS_BY_CHANNEL = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
 YOUTUBE_RSS_BY_USER = "https://www.youtube.com/feeds/videos.xml?user={user}"
@@ -904,7 +904,7 @@ class MediaImportEngine:
         tags = payload.get("tags") or []
         if isinstance(tags, str): tags = [v.strip() for v in tags.split(",") if v.strip()]
         url = str(payload.get("url") or payload.get("channel_url") or "").strip()
-        if not url: raise MediaConfigError("url is required")
+        self._validate_source_url(provider, source_type, url)
         now = datetime.now(timezone.utc).isoformat()
         provider_config = payload.get("provider_config") if isinstance(payload.get("provider_config"), dict) else {}
         item = {"id": source_id, "name": name, "provider": provider, "source_type": source_type, "url": url, "channel_url": url, "language": str(payload.get("language") or "ru").strip(), "priority": int(payload.get("priority") or 1), "categories": categories, "symbols": symbols, "tags": tags, "enabled": bool(payload.get("enabled", True)), "provider_config": provider_config, "created_at": now, "updated_at": now}
@@ -970,7 +970,7 @@ class MediaImportEngine:
             return self.youtube_provider
         if provider == "youtube_ytdlp":
             return self.ytdlp_provider
-        if provider == "rss_feed" or provider == "rss":
+        if provider == "rss_feed" or provider == "rss" or provider == "telegram_rss":
             from app.services.providers.rss_feed_provider import RssFeedProvider
             return RssFeedProvider()
         if provider == "telegram_public" or provider == "telegram":
@@ -1029,10 +1029,54 @@ class MediaImportEngine:
     @staticmethod
     def _infer_source_type(provider: str) -> str:
         if provider.startswith("youtube") or provider in {"youtube", "auto"}: return "youtube"
+        if provider == "telegram_rss": return "rss"
         if provider.startswith("telegram"): return "telegram"
         if provider in {"rss", "rss_feed"}: return "rss"
         if provider in {"manual", "youtube_manual"}: return "manual"
         return "website"
+
+    @staticmethod
+    def _validate_source_url(provider: str, source_type: str, url: str) -> None:
+        text = str(url or "").strip()
+        if not text:
+            raise MediaConfigError("url is required")
+        parsed = urlparse(text)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise MediaConfigError("url must be an absolute http(s) URL")
+        host = parsed.netloc.lower()
+        provider = str(provider or "").lower()
+        source_type = str(source_type or "").lower()
+        if source_type == "youtube" or provider.startswith("youtube") or provider in {"auto", "youtube"}:
+            if not any(h in host for h in ("youtube.com", "youtu.be")):
+                raise MediaConfigError("YouTube source URL must point to youtube.com or youtu.be")
+        if source_type == "telegram" or provider in {"telegram", "telegram_public", "telegram_bot"}:
+            if "t.me" not in host and "telegram.me" not in host:
+                raise MediaConfigError("Telegram source URL must point to t.me or telegram.me")
+        if source_type == "rss" or provider in {"rss", "rss_feed", "telegram_rss"}:
+            if not parsed.path and not parsed.query:
+                raise MediaConfigError("RSS source URL must include a feed path or query")
+
+    @staticmethod
+    def sources_to_opml(sources: list[dict[str, Any]]) -> str:
+        def esc(v: Any) -> str:
+            return str(v or "").replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+        outlines = []
+        for source in sources:
+            url = source.get("rss_url") or source.get("url") or source.get("channel_url") or ""
+            outlines.append(f'    <outline text="{esc(source.get("name"))}" title="{esc(source.get("name"))}" type="rss" xmlUrl="{esc(url)}" htmlUrl="{esc(source.get("channel_url") or url)}" category="{esc(",".join(source.get("categories") or []))}" />')
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opml version=\"2.0\"><head><title>FXPilot Sources</title></head><body>\n" + "\n".join(outlines) + "\n</body></opml>\n"
+
+    @staticmethod
+    def opml_to_sources(text: str) -> list[dict[str, Any]]:
+        import xml.etree.ElementTree as ET
+        root = ET.fromstring(text)
+        rows = []
+        for outline in root.findall(".//outline"):
+            url = outline.attrib.get("xmlUrl") or outline.attrib.get("htmlUrl") or outline.attrib.get("url") or ""
+            name = outline.attrib.get("title") or outline.attrib.get("text") or url
+            cats = [v.strip() for v in (outline.attrib.get("category") or "Market Analysis").split(",") if v.strip()]
+            rows.append({"name": name, "provider": "rss_feed", "source_type": "rss", "url": url, "channel_url": outline.attrib.get("htmlUrl") or url, "language": "ru", "priority": 1, "categories": cats, "enabled": True})
+        return rows
 
     def update_source(self, source_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         raw = self._read_json_list(self.sources_path); now = datetime.now(timezone.utc).isoformat(); found = False
@@ -1042,6 +1086,9 @@ class MediaImportEngine:
                 for key in ("name","provider","source_type","url","channel_url","language","categories","symbols","tags","priority","enabled","provider_config"):
                     if key in payload: item[key] = payload[key]
                 if "url" in payload and "channel_url" not in payload: item["channel_url"] = payload["url"]
+                provider = self._default_provider_for_source_type(str(item.get("source_type") or ""), str(item.get("provider") or ""))
+                source_type = str(item.get("source_type") or self._infer_source_type(provider)).lower()
+                self._validate_source_url(provider, source_type, str(item.get("url") or item.get("channel_url") or ""))
                 item["updated_at"] = now
         if not found: raise MediaConfigError(f"unknown media source id: {source_id}")
         self._validate_sources(raw); self._atomic_write_json(self.sources_path, raw)

--- a/app/static/media-admin.html
+++ b/app/static/media-admin.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>FXPilot TV · Media Admin</title>
+    <title>FXPilot TV · Sources</title>
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body data-page="tv-sources">
@@ -12,8 +12,8 @@
         <div class="tv-hero__grid">
           <div class="tv-hero__copy">
             <p class="eyebrow">FXPilot TV · Автономная админ-панель</p>
-            <h1>Автономный Media Engine</h1>
-            <p class="lead">Администратор добавляет YouTube, Telegram или RSS один раз — дальше импорт, AI-анализ, публикация и архивирование выполняются автоматически.</p>
+            <h1>Source Manager</h1>
+            <p class="lead">Управление YouTube, Telegram и RSS источниками из браузера без редактирования JSON, рестарта или redeploy.</p>
           </div>
           <div class="tv-hero__signal" aria-label="Статус импорта">
             <span class="tv-live-dot"></span><strong id="mediaImportStatus">Engine ready</strong>
@@ -24,16 +24,16 @@
 
       <main class="content-stack tv-content">
         <section class="tv-source-stats" aria-label="Статистика Media Engine">
-          <article><span>Configured sources</span><strong id="mediaStatSources">—</strong></article>
-          <article><span>Imported videos</span><strong id="mediaStatVideos">—</strong></article>
-          <article><span>Last update</span><strong id="mediaStatLastUpdate">—</strong></article>
-          <article><span>Newest media</span><strong id="mediaStatNewest">—</strong></article>
+          <article><span>Источники</span><strong id="mediaStatSources">—</strong></article>
+          <article><span>Импортировано</span><strong id="mediaStatVideos">—</strong></article>
+          <article><span>Последний импорт</span><strong id="mediaStatLastUpdate">—</strong></article>
+          <article><span>Последний материал</span><strong id="mediaStatNewest">—</strong></article>
         </section>
 
 
         <section class="panel tv-source-panel" aria-labelledby="mediaAddTitle">
           <div class="section-heading split-heading">
-            <div><p class="section-kicker">Add source</p><h2 id="mediaAddTitle">Добавить источник</h2><p class="section-text">YouTube: URL канала, Telegram: t.me URL, RSS: feed URL. Импорт не удаляет старый каталог при ошибках провайдера.</p></div>
+            <div><p class="section-kicker">Source Manager</p><h2 id="mediaAddTitle">Добавить источник</h2><p class="section-text">YouTube: URL канала, Telegram: t.me URL, RSS: feed URL. Импорт не удаляет старый каталог при ошибках провайдера.</p></div>
             <div class="tv-source-actions"><button type="button" id="mediaResolveAll">Обновить YouTube-метаданные</button></div>
           </div>
           <form id="mediaSourceForm" class="media-source-form">
@@ -57,13 +57,13 @@
               <h2 id="mediaSourcesTitle">Настроенные источники</h2>
               <p class="section-text">Ежедневный импорт автоматический. Ручные кнопки импорта скрыты и оставлены только API-совместимостью.</p>
             </div>
-            <div class="tv-source-actions"><span class="tv-status-pill is-enabled">Автопилот включён</span></div>
+            <div class="tv-source-actions"><input id="sourceSearch" placeholder="Поиск: имя, provider, категория, URL" /><button id="bulkEnable" type="button">Enable Selected</button><button id="bulkDisable" type="button">Disable Selected</button><button id="bulkDelete" type="button">Delete Selected</button><button id="bulkImport" type="button">Import Selected</button><button id="bulkTest" type="button">Test Selected</button><button id="exportSources" type="button">Export Sources</button><button id="importSources" type="button">Import Sources</button></div>
               <pre id="mediaImportResult" class="media-import-result" aria-live="polite">—</pre>
           </div>
           <div class="tv-source-table-wrap">
             <table class="tv-source-table">
-              <thead><tr><th>Источник</th><th>Тип</th><th>Provider</th><th>Enabled</th><th>Last success</th><th>Items</th><th>Errors</th><th>Действия</th></tr></thead>
-              <tbody id="mediaSourcesBody"><tr><td colspan="8">Загрузка...</td></tr></tbody>
+              <thead><tr><th></th><th>Enabled</th><th>Source Name</th><th>Provider</th><th>Category</th><th>Priority</th><th>Videos Imported</th><th>Last Successful Import</th><th>Last Review</th><th>Status</th><th>Actions</th></tr></thead>
+              <tbody id="mediaSourcesBody"><tr><td colspan="11">Загрузка...</td></tr></tbody>
             </table>
           </div>
         </section>
@@ -83,7 +83,7 @@
         </section>
 
         <section class="panel tv-source-panel" aria-labelledby="mediaNewestTitle">
-          <div class="section-heading"><p class="section-kicker">Catalog</p><h2 id="mediaNewestTitle">Newest media</h2></div>
+          <div class="section-heading"><p class="section-kicker">Catalog</p><h2 id="mediaNewestTitle">Последний материал</h2></div>
           <div class="tv-source-table-wrap">
             <table class="tv-source-table">
               <thead><tr><th>Видео</th><th>Symbol</th><th>Category</th><th>Published</th><th>Status</th></tr></thead>
@@ -93,6 +93,7 @@
         </section>
       </main>
     </div>
+    <script src="/static/nav.js"></script>
     <script src="/static/media-admin.js"></script>
   </body>
 </html>

--- a/app/static/media-admin.js
+++ b/app/static/media-admin.js
@@ -20,22 +20,29 @@
   const sourceDuration = (source) => source.last_run?.execution_time ? `${source.last_run.execution_time}s` : (source.import_duration ? `${source.import_duration}s` : '—');
   const sourceErrors = (source) => source.last_error || (source.last_run?.errors || []).filter(Boolean).join('; ') || '—';
 
+  let allSources = [];
+  const matchesSearch = (source) => { const q = (document.getElementById('sourceSearch')?.value || '').toLowerCase(); if (!q) return true; return [source.name, source.provider, source.source_type, (source.categories || []).join(' '), source.url, source.channel_url].join(' ').toLowerCase().includes(q); };
   function renderSources(sources) {
+    allSources = sources;
+    const visible = sources.filter(matchesSearch);
     setText('mediaStatSources', String(sources.length));
-    if (!sources.length) { sourcesBody.innerHTML = '<tr><td colspan="8">Источники не настроены.</td></tr>'; return; }
-    sourcesBody.innerHTML = sources.map((source) => {
+    if (!visible.length) { sourcesBody.innerHTML = '<tr><td colspan="11">Источники не найдены.</td></tr>'; return; }
+    sourcesBody.innerHTML = visible.map((source) => {
       const label = statusLabel(source);
       const statusClass = source.enabled && !source.last_error && label !== 'Manual source — API not connected' ? 'is-enabled' : 'is-disabled';
       return `
       <tr>
-        <td><strong>${escapeHtml(source.name)}</strong><span>${escapeHtml(source.url || source.channel_url || '')}</span></td>
-        <td>${escapeHtml(source.source_type || 'youtube')}</td>
-        <td><span class="tv-provider-pill">${escapeHtml(providerLabel(source.provider))}</span><span>used: ${escapeHtml(providerLabel(source.provider_used || source.last_run?.provider_used || source.provider))}${source.provider_fallback || source.last_run?.provider_fallback ? ' · fallback yt-dlp' : ''}</span></td>
+        <td><input type="checkbox" data-select-source="${escapeHtml(source.id)}" /></td>
         <td><span class="tv-status-pill ${statusClass}">${escapeHtml(source.enabled ? 'Enabled' : 'Disabled')}</span></td>
-        <td>${formatValue(source.last_success || source.last_import)}</td>
+        <td><strong>${escapeHtml(source.name)}</strong><span>${escapeHtml(source.url || source.channel_url || '')}</span></td>
+        <td><span class="tv-provider-pill">${escapeHtml(providerLabel(source.provider))}</span></td>
+        <td>${escapeHtml((source.categories || []).join(', ') || '—')}</td>
+        <td>${escapeHtml(source.priority ?? 1)}</td>
         <td>${escapeHtml(source.items_count ?? source.videos_count ?? 0)}</td>
+        <td>${formatValue(source.last_success || source.last_import)}</td>
+        <td>${formatValue(source.last_review || source.review_updated_at)}</td>
         <td>${escapeHtml(sourceErrors(source))}</td>
-        <td><div class="tv-source-actions"><button data-action="Test" data-id="${escapeHtml(source.id)}">Health</button><button data-action="Disable" data-id="${escapeHtml(source.id)}">Disable</button><button data-action="Enable" data-id="${escapeHtml(source.id)}">Enable</button><button data-action="Delete" data-id="${escapeHtml(source.id)}">Delete</button></div></td>
+        <td><div class="tv-source-actions"><button data-action="Import Source" data-id="${escapeHtml(source.id)}">Import Now</button><button data-action="Test" data-id="${escapeHtml(source.id)}">Test</button><button data-action="Disable" data-id="${escapeHtml(source.id)}">Disable</button><button data-action="Enable" data-id="${escapeHtml(source.id)}">Enable</button><button data-action="Delete" data-id="${escapeHtml(source.id)}">Delete</button></div></td>
       </tr>`;
     }).join('');
   }
@@ -64,7 +71,7 @@
 
   function refresh() {
     Promise.all([
-      fetch('/api/media/sources', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((r) => r.ok ? r.json() : []),
+      fetch('/api/sources', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((r) => r.ok ? r.json() : []),
       fetch('/api/media', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((r) => r.ok ? r.json() : []),
       fetch('/api/media/stats', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((r) => r.ok ? r.json() : {}),
       fetch('/api/media/scheduler', { headers: { Accept: 'application/json' }, cache: 'no-store' }).then((r) => r.ok ? r.json() : {}),
@@ -76,10 +83,10 @@
     const button = event.target.closest('button[data-action]');
     if (!button) return;
     const id = button.dataset.id;
-    if (button.dataset.action === 'Import Source') { fetch(`/api/media/sources/${id}/import`, { method: 'POST', headers: { Accept: 'application/json' } }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); }); return; }
-    if (button.dataset.action === 'Test') { fetch(`/api/media/sources/${id}/test`, { method: 'POST', headers: { Accept: 'application/json' } }).then((r) => r.json()).then(showImportResult); return; }
-    if (button.dataset.action === 'Delete') { fetch(`/api/media/sources/${id}`, { method: 'DELETE', headers: { Accept: 'application/json' } }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); }); return; }
-    if (button.dataset.action === 'Disable' || button.dataset.action === 'Enable') { fetch(`/api/media/sources/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: JSON.stringify({ enabled: button.dataset.action === 'Enable' }) }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); }); return; }
+    if (button.dataset.action === 'Import Source') { fetch(`/api/sources/${id}/import`, { method: 'POST', headers: { Accept: 'application/json' } }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); }); return; }
+    if (button.dataset.action === 'Test') { fetch(`/api/sources/${id}/test`, { method: 'POST', headers: { Accept: 'application/json' } }).then((r) => r.json()).then(showImportResult); return; }
+    if (button.dataset.action === 'Delete') { fetch(`/api/sources/${id}`, { method: 'DELETE', headers: { Accept: 'application/json' } }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); }); return; }
+    if (button.dataset.action === 'Disable' || button.dataset.action === 'Enable') { fetch(`/api/sources/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: JSON.stringify({ enabled: button.dataset.action === 'Enable' }) }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); }); return; }
   });
 
   function runImport() {
@@ -102,6 +109,16 @@
   }
 
   importButton?.addEventListener('click', runImport);
+  document.getElementById('sourceSearch')?.addEventListener('input', () => renderSources(allSources));
+  const selectedIds = () => Array.from(document.querySelectorAll('[data-select-source]:checked')).map((el) => el.getAttribute('data-select-source')).filter(Boolean);
+  const bulk = (action) => fetch('/api/sources/import', { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: JSON.stringify({ action, ids: selectedIds() }) }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); });
+  document.getElementById('bulkEnable')?.addEventListener('click', () => bulk('enable'));
+  document.getElementById('bulkDisable')?.addEventListener('click', () => bulk('disable'));
+  document.getElementById('bulkDelete')?.addEventListener('click', () => { if (window.confirm('Удалить выбранные источники?')) bulk('delete'); });
+  document.getElementById('bulkImport')?.addEventListener('click', () => bulk('import_selected'));
+  document.getElementById('bulkTest')?.addEventListener('click', () => bulk('test'));
+  document.getElementById('exportSources')?.addEventListener('click', () => { window.location.href = '/api/sources/export?format=json'; });
+  document.getElementById('importSources')?.addEventListener('click', () => { const text = window.prompt('Вставьте JSON export с полем sources'); if (text) fetch('/api/sources/import', { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: text }).then((r) => r.json()).then((p) => { showImportResult(p); refresh(); }); });
   document.getElementById('mediaResolveSource')?.addEventListener('click', () => {
     const payload = formPayload();
     showResolve('Resolving...');
@@ -112,7 +129,7 @@
   sourceForm?.addEventListener('submit', (event) => {
     event.preventDefault();
     showResolve('Saving...');
-    fetch('/api/media/sources', { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: JSON.stringify(formPayload()) })
+    fetch('/api/sources', { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, body: JSON.stringify(formPayload()) })
       .then((r) => r.json().then((data) => { if (!r.ok) throw data; return data; }))
       .then((payload) => { showResolve(payload); sourceForm.reset(); return refresh(); }).catch(showResolve);
   });

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -64,6 +64,13 @@
     nav.appendChild(tvLink);
   }
 
+  if (!nav.querySelector('a[href="/ops/sources"]')) {
+    const sourcesLink = document.createElement('a');
+    sourcesLink.href = '/ops/sources';
+    sourcesLink.textContent = '📡 Источники';
+    nav.appendChild(sourcesLink);
+  }
+
 
   if (!nav.querySelector('a[href="/ops"]')) {
     const opsLink = document.createElement('a');


### PR DESCRIPTION
### Motivation
- Упростить управление runtime‑источниками медиа (YouTube, Telegram, RSS) из браузера без правки JSON, перезапуска сервиса или redeploy.
- Обеспечить мгновенную интеграцию изменений в Scheduler и Media Import через единый канонический `DATA_DIR/media_sources.json`.
- Добавить удобные операции (bulk, тестирование, импорт/экспорт) и аудит операций для production‑операций.

### Description
- Добавлена страница Source Manager `/ops/sources` (использует существующий dark UI) и пункт навигации `📡 Источники` в `app/static/nav.js` и `app/static/media-admin.html`/`.js` для поиска, bulk‑действий и per‑source кнопок. (файлы: `app/static/media-admin.html`, `app/static/media-admin.js`, `app/static/nav.js`).
- Реализованы новые API‑маршруты в `app/main.py`: `GET /api/sources`, `GET /api/sources/debug`, `GET /api/sources/{id}`, `POST /api/sources`, `PUT /api/sources/{id}`, `DELETE /api/sources/{id}`, `POST /api/sources/{id}/test`, `POST /api/sources/{id}/import`, `POST /api/sources/import`, `GET /api/sources/export` и связки к существующему движку (алиасы к `/api/media/*` где уместно). (файл: `app/main.py`).
- Расширен движок `MediaImportEngine` для валидации URL, поддержки `telegram_rss`/`youtube_playlist`, OPML экспорт/импорт и безопасной записи в канонический runtime файл; добавлена валидация URL для YouTube/Telegram/RSS и проверка при создании/обновлении источников. (файл: `app/services/media_import_engine.py`).
- При изменениях источников формируется запись в OPS audit log с actor, operation, before/after payload через существующий `OPS_AUDIT_PATH` для аудита изменений; документация Stage 22 добавлена в `README.md`.

### Testing
- Выполнена статическая проверка компиляции Python: `python -m py_compile app/main.py app/services/media_import_engine.py` — успешно.
- Проверка JavaScript: `node --check app/static/media-admin.js` — успешно.
- Быстрые API‑проверки через `TestClient` для `GET /api/sources`, `GET /api/sources/debug`, `GET /api/sources/export?format=opml` и загрузки страницы `/ops/sources` — успешны.
- Запущены регрессионные тесты `python -m pytest tests/test_media_import_engine.py tests/test_media_source_bootstrap.py -q`, в которых большинство тестов прошли, но один тест упал из‑за внешней сетевой/прокси‑ошибки (YouTube transcript запрос получил `403 Tunnel connection failed`), что является средо‑зависимой проблемой и не связано с логикой Source Manager; остальные тесты успешно прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d0653aa8c833189ef3a1024006dc7)